### PR TITLE
fix(navbar): remove unnecessary scroll on portal

### DIFF
--- a/app-modules/portal/resources/views/components/navbar.blade.php
+++ b/app-modules/portal/resources/views/components/navbar.blade.php
@@ -17,9 +17,9 @@
     @scroll.window.passive="onScroll()"
     @keydown.escape.window="open = false"
     x-effect="document.documentElement.style.overflow = open ? 'hidden' : ''"
-    class="hp-navbar sticky top-0 z-50 w-full px-4"
+    class="hp-navbar sticky top-0 z-50 w-full px-4 flex"
 >
-    <div class="relative mx-auto max-w-5xl">
+    <div class="relative mx-auto max-w-5xl flex-1">
         {{-- glow roxo radial atrás da pill --}}
         <div
             aria-hidden="true"


### PR DESCRIPTION
Only remove an unnecessary scrollbar on portal, css fix.

Before:
<img width="1919" height="945" alt="image" src="https://github.com/user-attachments/assets/27cc644f-9e45-4f94-a8ef-ebbfbbf1f8e2" />

After:
<img width="1919" height="944" alt="image" src="https://github.com/user-attachments/assets/80a3bb57-4b7e-4dfa-828a-5a96fcbdfd9b" />
