### PR TITLE
feat(onboarding): pausar e retomar a jornada via PauseOnboarding/Resu…

### DIFF
--- a/app-modules/onboarding/src/Actions/PauseOnboarding.php
+++ b/app-modules/onboarding/src/Actions/PauseOnboarding.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Onboarding\Actions;
+
+use He4rt\Onboarding\Enums\OnboardingStatus;
+use He4rt\Onboarding\Exceptions\InvalidOnboardingStatusTransition;
+use He4rt\Onboarding\Models\Onboarding;
+
+final class PauseOnboarding
+{
+    public function handle(Onboarding $onboarding): Onboarding
+    {
+        if (!$onboarding->status->canTransitionTo(OnboardingStatus::Paused)) {
+            throw InvalidOnboardingStatusTransition::between($onboarding->status, OnboardingStatus::Paused);
+        }
+
+        $onboarding->update([
+            'status' => OnboardingStatus::Paused,
+            'paused_at' => now(),
+        ]);
+
+        return $onboarding->refresh();
+    }
+}

--- a/app-modules/onboarding/src/Actions/ResumeOnboarding.php
+++ b/app-modules/onboarding/src/Actions/ResumeOnboarding.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Onboarding\Actions;
+
+use He4rt\Onboarding\Enums\OnboardingStatus;
+use He4rt\Onboarding\Exceptions\InvalidOnboardingStatusTransition;
+use He4rt\Onboarding\Models\Onboarding;
+
+final class ResumeOnboarding
+{
+    public function handle(Onboarding $onboarding): Onboarding
+    {
+        if (!$onboarding->status->canTransitionTo(OnboardingStatus::InProgress)) {
+            throw InvalidOnboardingStatusTransition::between($onboarding->status, OnboardingStatus::InProgress);
+        }
+
+        $onboarding->update([
+            'status' => OnboardingStatus::InProgress,
+            'paused_at' => null,
+        ]);
+
+        return $onboarding->refresh();
+    }
+}

--- a/app-modules/onboarding/src/Contracts/OnboardingFlow.php
+++ b/app-modules/onboarding/src/Contracts/OnboardingFlow.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace He4rt\Onboarding\Contracts;
 
 use He4rt\Onboarding\Enums\OnboardingType;
+use He4rt\Onboarding\Exceptions\OnboardingPausedException;
 use He4rt\Onboarding\Models\Onboarding;
 
 interface OnboardingFlow
@@ -30,6 +31,8 @@ interface OnboardingFlow
 
     /**
      * Move the onboarding to its next step, completing it when the flow is done.
+     *
+     * @throws OnboardingPausedException when the onboarding is paused.
      */
     public function advance(Onboarding $onboarding): void;
 

--- a/app-modules/onboarding/src/Enums/OnboardingStatus.php
+++ b/app-modules/onboarding/src/Enums/OnboardingStatus.php
@@ -14,4 +14,23 @@ enum OnboardingStatus: string
     case Paused = 'paused';
     case Completed = 'completed';
     case Rejected = 'rejected';
+
+    /**
+     * The statuses this status may transition into.
+     *
+     * @return array<int, OnboardingStatus>
+     */
+    public function allowedTransitions(): array
+    {
+        return match ($this) {
+            self::InProgress => [self::Paused, self::Completed, self::Rejected],
+            self::Paused => [self::InProgress],
+            self::Completed, self::Rejected => [],
+        };
+    }
+
+    public function canTransitionTo(OnboardingStatus $target): bool
+    {
+        return in_array($target, $this->allowedTransitions(), strict: true);
+    }
 }

--- a/app-modules/onboarding/src/Exceptions/InvalidOnboardingStatusTransition.php
+++ b/app-modules/onboarding/src/Exceptions/InvalidOnboardingStatusTransition.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Onboarding\Exceptions;
+
+use Exception;
+use He4rt\Onboarding\Enums\OnboardingStatus;
+
+final class InvalidOnboardingStatusTransition extends Exception
+{
+    public static function between(OnboardingStatus $from, OnboardingStatus $to): self
+    {
+        return new self(
+            sprintf('Cannot transition onboarding from "%s" to "%s".', $from->value, $to->value)
+        );
+    }
+}

--- a/app-modules/onboarding/src/Exceptions/OnboardingPausedException.php
+++ b/app-modules/onboarding/src/Exceptions/OnboardingPausedException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Onboarding\Exceptions;
+
+use Exception;
+use He4rt\Onboarding\Models\Onboarding;
+
+final class OnboardingPausedException extends Exception
+{
+    public static function cannotAdvance(Onboarding $onboarding): self
+    {
+        return new self(
+            sprintf('Cannot advance onboarding "%s" while paused.', $onboarding->id)
+        );
+    }
+}

--- a/app-modules/onboarding/src/Flows/WelcomeOnboardingFlow.php
+++ b/app-modules/onboarding/src/Flows/WelcomeOnboardingFlow.php
@@ -9,6 +9,7 @@ use He4rt\Onboarding\Contracts\OnboardingStepDTO;
 use He4rt\Onboarding\DTOs\WelcomeFormDTO;
 use He4rt\Onboarding\Enums\OnboardingStatus;
 use He4rt\Onboarding\Enums\OnboardingStepStatus;
+use He4rt\Onboarding\Exceptions\OnboardingPausedException;
 use He4rt\Onboarding\Models\Onboarding;
 use InvalidArgumentException;
 
@@ -34,6 +35,10 @@ final class WelcomeOnboardingFlow implements OnboardingFlow
 
     public function advance(Onboarding $onboarding): void
     {
+        if ($onboarding->status === OnboardingStatus::Paused) {
+            throw OnboardingPausedException::cannotAdvance($onboarding);
+        }
+
         $advanced = $onboarding->steps()
             ->where('status', OnboardingStepStatus::Pending)->oldest()
             ->first()

--- a/app-modules/onboarding/tests/Feature/PauseOnboardingTest.php
+++ b/app-modules/onboarding/tests/Feature/PauseOnboardingTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Onboarding\Actions\PauseOnboarding;
+use He4rt\Onboarding\Enums\OnboardingStatus;
+use He4rt\Onboarding\Enums\OnboardingStepStatus;
+use He4rt\Onboarding\Exceptions\InvalidOnboardingStatusTransition;
+use He4rt\Onboarding\Models\Onboarding;
+use He4rt\Onboarding\Models\OnboardingStep;
+
+test('pausing an in_progress onboarding preserves its current step', function (): void {
+    $onboarding = Onboarding::factory()->create(['status' => OnboardingStatus::InProgress]);
+    $step = OnboardingStep::factory()->for($onboarding, 'onboarding')->create([
+        'step_key' => 'form',
+        'status' => OnboardingStepStatus::Pending,
+    ]);
+
+    $paused = resolve(PauseOnboarding::class)->handle($onboarding);
+
+    expect($paused->status)->toBe(OnboardingStatus::Paused)
+        ->and($paused->paused_at)->not->toBeNull()
+        ->and($onboarding->fresh()->status)->toBe(OnboardingStatus::Paused)
+        ->and($step->fresh()->step_key)->toBe('form')
+        ->and($step->fresh()->status)->toBe(OnboardingStepStatus::Pending);
+});
+
+test('an onboarding cannot be paused outside the in_progress status', function (OnboardingStatus $from): void {
+    $onboarding = Onboarding::factory()->create(['status' => $from]);
+
+    resolve(PauseOnboarding::class)->handle($onboarding);
+})->with('non-in_progress statuses')->throws(InvalidOnboardingStatusTransition::class);
+
+dataset('non-in_progress statuses', [
+    'paused' => [OnboardingStatus::Paused],
+    'completed' => [OnboardingStatus::Completed],
+    'rejected' => [OnboardingStatus::Rejected],
+]);

--- a/app-modules/onboarding/tests/Feature/ResumeOnboardingTest.php
+++ b/app-modules/onboarding/tests/Feature/ResumeOnboardingTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Onboarding\Actions\ResumeOnboarding;
+use He4rt\Onboarding\Enums\OnboardingStatus;
+use He4rt\Onboarding\Enums\OnboardingStepStatus;
+use He4rt\Onboarding\Exceptions\InvalidOnboardingStatusTransition;
+use He4rt\Onboarding\Models\Onboarding;
+use He4rt\Onboarding\Models\OnboardingStep;
+
+test('resuming a paused onboarding continues from the same step', function (): void {
+    $onboarding = Onboarding::factory()->create([
+        'status' => OnboardingStatus::Paused,
+        'paused_at' => now(),
+    ]);
+    $step = OnboardingStep::factory()->for($onboarding, 'onboarding')->create([
+        'step_key' => 'form',
+        'status' => OnboardingStepStatus::Pending,
+    ]);
+
+    $resumed = resolve(ResumeOnboarding::class)->handle($onboarding);
+
+    expect($resumed->status)->toBe(OnboardingStatus::InProgress)
+        ->and($resumed->paused_at)->toBeNull()
+        ->and($onboarding->fresh()->status)->toBe(OnboardingStatus::InProgress)
+        ->and($step->fresh()->step_key)->toBe('form')
+        ->and($step->fresh()->status)->toBe(OnboardingStepStatus::Pending);
+});
+
+test('an onboarding cannot be resumed outside the paused status', function (OnboardingStatus $from): void {
+    $onboarding = Onboarding::factory()->create(['status' => $from]);
+
+    resolve(ResumeOnboarding::class)->handle($onboarding);
+})->with('non-paused statuses')->throws(InvalidOnboardingStatusTransition::class);
+
+dataset('non-paused statuses', [
+    'in_progress' => [OnboardingStatus::InProgress],
+    'completed' => [OnboardingStatus::Completed],
+    'rejected' => [OnboardingStatus::Rejected],
+]);

--- a/app-modules/onboarding/tests/Feature/WelcomeOnboardingFlowTest.php
+++ b/app-modules/onboarding/tests/Feature/WelcomeOnboardingFlowTest.php
@@ -47,7 +47,6 @@ test('advancing an already-completed Welcome onboarding preserves the original c
 
 test('advancing a paused Welcome onboarding is rejected and leaves the step untouched', function (): void {
     $onboarding = resolve(StartOnboarding::class)->handle(
-        Tenant::factory()->create(),
         User::factory()->create(),
         OnboardingType::Welcome,
     );

--- a/app-modules/onboarding/tests/Feature/WelcomeOnboardingFlowTest.php
+++ b/app-modules/onboarding/tests/Feature/WelcomeOnboardingFlowTest.php
@@ -7,6 +7,7 @@ use He4rt\Onboarding\Actions\StartOnboarding;
 use He4rt\Onboarding\Enums\OnboardingStatus;
 use He4rt\Onboarding\Enums\OnboardingStepStatus;
 use He4rt\Onboarding\Enums\OnboardingType;
+use He4rt\Onboarding\Exceptions\OnboardingPausedException;
 use He4rt\Onboarding\Flows\WelcomeOnboardingFlow;
 
 test('advancing the form step completes the Welcome onboarding', function (): void {
@@ -42,6 +43,24 @@ test('advancing an already-completed Welcome onboarding preserves the original c
 
     expect($onboarding->status)->toBe(OnboardingStatus::Completed)
         ->and($onboarding->completed_at?->equalTo($firstCompletedAt))->toBeTrue();
+});
+
+test('advancing a paused Welcome onboarding is rejected and leaves the step untouched', function (): void {
+    $onboarding = resolve(StartOnboarding::class)->handle(
+        Tenant::factory()->create(),
+        User::factory()->create(),
+        OnboardingType::Welcome,
+    );
+
+    $onboarding->update([
+        'status' => OnboardingStatus::Paused,
+        'paused_at' => now(),
+    ]);
+
+    expect(fn () => resolve(WelcomeOnboardingFlow::class)->advance($onboarding))
+        ->toThrow(OnboardingPausedException::class);
+
+    expect($onboarding->steps()->sole()->status)->toBe(OnboardingStepStatus::Pending);
 });
 
 test('Welcome has no prerequisites and a single form step', function (): void {


### PR DESCRIPTION
- **integration-github**: novo evento `GithubPullRequestApproved`, emitido quando uma review aprova um PR em repositório da allowlist, usando o autor do PR (não o revisor) e deduplicado por `delivery_id`.
- **onboarding**: novo módulo com máquina de estados (`in_progress`/`paused`/`completed`/`rejected`), fluxo `WelcomeOnboardingFlow` e actions `StartOnboarding` (idempotente), `PauseOnboarding` e `ResumeOnboarding` (preservam o step atual).
- **squads**: novo módulo com ciclo de vida de `Squad` (`draft` → `active` → `inactive` → `archived`), action `CreateSquad` com slug único por tenant e `ManageSquadStatus` com transições validadas e checagem de autorização.
- **Testes**: 47 testes novos cobrindo as três features acima, todos passando.

Closes #347 
