### PR TITLE
feat(skills): adicionar seed de skills para QA

### DIFF
--- a/app-modules/profile/database/migrations/2026_07_18_095900_add_qa_skills_to_catalog.php
+++ b/app-modules/profile/database/migrations/2026_07_18_095900_add_qa_skills_to_catalog.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+return new class extends Migration
+{
+    /**
+     * Backfill das skills de QA para bancos que ja executaram a migration
+     * inicial. Instancias novas recebem esse catalogo pela migration base.
+     *
+     * @var array<string, array<string, string>>
+     */
+    private const array CATALOG = [
+        'framework' => [
+            'selenium' => 'Selenium',
+            'cypress' => 'Cypress',
+            'playwright' => 'Playwright',
+            'webdriverio' => 'WebdriverIO',
+            'testcafe' => 'TestCafe',
+            'puppeteer' => 'Puppeteer',
+            'appium' => 'Appium',
+            'espresso' => 'Espresso',
+            'xcuitest' => 'XCUITest',
+            'detox' => 'Detox',
+            'rest-assured' => 'RestAssured',
+            'karate' => 'Karate',
+            'supertest' => 'Supertest',
+            'cucumber' => 'Cucumber',
+            'specflow' => 'SpecFlow',
+            'behave' => 'Behave',
+            'robot-framework' => 'Robot Framework',
+            'junit' => 'JUnit',
+            'testng' => 'TestNG',
+            'pytest' => 'PyTest',
+            'jest' => 'Jest',
+            'mocha-chai' => 'Mocha / Chai',
+            'nunit' => 'NUnit',
+            'xunit' => 'xUnit',
+        ],
+        'tool' => [
+            'postman-newman' => 'Postman / Newman',
+            'jmeter' => 'JMeter',
+            'k6' => 'K6',
+            'gatling' => 'Gatling',
+            'locust' => 'Locust',
+        ],
+    ];
+
+    public function up(): void
+    {
+        $now = now();
+        $rows = [];
+
+        foreach (self::CATALOG as $category => $skills) {
+            foreach ($skills as $slug => $name) {
+                $rows[] = [
+                    'id' => Str::uuid7()->toString(),
+                    'slug' => $slug,
+                    'name' => $name,
+                    'category' => $category,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ];
+            }
+        }
+
+        DB::table('skills')->upsert(
+            $rows,
+            ['slug'],
+            ['name', 'category', 'updated_at'],
+        );
+    }
+
+    public function down(): void
+    {
+        DB::table('skills')
+            ->whereIn('slug', array_keys(self::CATALOG['framework']))
+            ->orWhereIn('slug', array_keys(self::CATALOG['tool']))
+            ->delete();
+    }
+};


### PR DESCRIPTION
## Contexto

Este PR implementa a solução da issue #430.

Atualmente, a seção **Skills** da página de Perfil (`/profile`) não disponibiliza frameworks e ferramentas de automação de testes entre as opções cadastráveis. Isso dificulta que profissionais de Quality Assurance (QA) representem corretamente suas competências técnicas na plataforma.

Para resolver esse problema, este PR adiciona ao seed de skills as principais ferramentas utilizadas pelo mercado de QA, permitindo que elas passem a ser selecionáveis no perfil dos usuários.

## Alterações

Adiciona novas skills relacionadas à área de Quality Assurance, incluindo ferramentas de:

- **Testes Web (E2E/UI)**
  - Selenium
  - Cypress
  - Playwright
  - WebdriverIO
  - TestCafe
  - Puppeteer

- **Testes Mobile**
  - Appium
  - Espresso
  - XCUITest
  - Detox

- **Testes de API**
  - Rest Assured
  - Postman
  - Newman
  - Karate
  - Supertest

- **BDD**
  - Cucumber
  - SpecFlow
  - Behave
  - Robot Framework

- **Testes Unitários e de Integração**
  - JUnit
  - TestNG
  - PyTest
  - Jest
  - Mocha
  - Chai
  - NUnit
  - xUnit

- **Testes de Performance**
  - JMeter
  - K6
  - Gatling
  - Locust

## Motivação

- Permite que profissionais de QA representem melhor seu stack técnico.
- Amplia o catálogo de skills disponíveis na plataforma.
- Facilita a busca por profissionais com conhecimentos específicos em ferramentas de testes.
- Mantém o catálogo de skills centralizado e versionado por meio dos seeds, facilitando futuras atualizações.

## Test Plan

- Executar os seeders da aplicação.
- Verificar que as novas skills foram inseridas corretamente no banco de dados.
- Confirmar que as ferramentas aparecem como opções na seção **Skills** da página de Perfil (`/profile`).
- Validar que o seeder pode ser executado novamente sem criar registros duplicados (quando aplicável).