### PR TITLE
feat(portal): Adicionando botão de redirecionamento do para loja da h…

### DIFF
--- a/app-modules/portal/resources/views/components/navbar.blade.php
+++ b/app-modules/portal/resources/views/components/navbar.blade.php
@@ -84,7 +84,7 @@
                         iconOnly
                         aria-label="Loja"
                         target="_blank"
-                        rel="noopener noreferrer"
+                        rel="noopener"
                     />
                     <x-he4rt::button href="/app" size="sm" variant="outline"> Área do Usuário </x-he4rt::button>
                     <x-he4rt::button
@@ -191,7 +191,7 @@
                 icon="heroicon-s-shopping-bag"
                 iconPosition="leading"
                 target="_blank"
-                rel="noopener noreferrer"
+                rel="noopener"
             >
                 Compre na Loja
             </x-he4rt::button>

--- a/app-modules/portal/resources/views/components/navbar.blade.php
+++ b/app-modules/portal/resources/views/components/navbar.blade.php
@@ -75,6 +75,15 @@
                         iconOnly
                         aria-label="Redes sociais"
                     />
+                    <x-he4rt::button
+                        href="https://loja.heartdevs.com/he4rt/"
+                        size="sm"
+                        variant="outline"
+                        icon="heroicon-s-shopping-bag"
+                        iconPosition="leading"
+                        iconOnly
+                        aria-label="Loja"
+                    />
                     <x-he4rt::button href="/app" size="sm" variant="outline"> Área do Usuário </x-he4rt::button>
                     <x-he4rt::button
                         href="https://discord.gg/he4rt"
@@ -172,6 +181,15 @@
                 iconPosition="leading"
             >
                 Redes sociais
+            </x-he4rt::button>
+            <x-he4rt::button
+                href="https://loja.heartdevs.com/he4rt/"
+                variant="outline"
+                block
+                icon="heroicon-s-shopping-bag"
+                iconPosition="leading"
+            >
+                Compre na Loja
             </x-he4rt::button>
             <x-he4rt::button href="/app" variant="outline" block> Área do Usuário </x-he4rt::button>
             <x-he4rt::button

--- a/app-modules/portal/resources/views/components/navbar.blade.php
+++ b/app-modules/portal/resources/views/components/navbar.blade.php
@@ -83,6 +83,8 @@
                         iconPosition="leading"
                         iconOnly
                         aria-label="Loja"
+                        target="_blank"
+                        rel="noopener noreferrer"
                     />
                     <x-he4rt::button href="/app" size="sm" variant="outline"> Área do Usuário </x-he4rt::button>
                     <x-he4rt::button
@@ -188,6 +190,8 @@
                 block
                 icon="heroicon-s-shopping-bag"
                 iconPosition="leading"
+                target="_blank"
+                rel="noopener noreferrer"
             >
                 Compre na Loja
             </x-he4rt::button>

--- a/app-modules/portal/tests/Feature/SocialLinksPageTest.php
+++ b/app-modules/portal/tests/Feature/SocialLinksPageTest.php
@@ -32,8 +32,8 @@ it('renderiza os seis links com rótulos e URLs corretas', function (): void {
 it('abre cada link externo em nova aba com rel seguro', function (): void {
     $html = get('/redes')->getContent();
 
-    expect(mb_substr_count($html, 'target="_blank"'))->toBe(6);
-    expect(mb_substr_count($html, 'rel="noopener noreferrer"'))->toBe(6);
+    expect(mb_substr_count($html, 'target="_blank"'))->toBe(8);
+    expect(mb_substr_count($html, 'rel="noopener noreferrer"'))->toBe(8);
 });
 
 it('exibe o logo He4rt animado', function (): void {

--- a/app-modules/portal/tests/Feature/SocialLinksPageTest.php
+++ b/app-modules/portal/tests/Feature/SocialLinksPageTest.php
@@ -18,7 +18,7 @@ it('resolve a rota nomeada social-links para /redes', function (): void {
     expect(route('social-links', absolute: false))->toBe('/redes');
 });
 
-it('renderiza os seis links com rótulos e URLs corretas', function (): void {
+it('renderiza todos os links com rótulos e URLs corretas', function (): void {
     $assertion = get('/redes')
         ->assertOk();
 
@@ -32,8 +32,8 @@ it('renderiza os seis links com rótulos e URLs corretas', function (): void {
 it('abre cada link externo em nova aba com rel seguro', function (): void {
     $html = get('/redes')->getContent();
 
-    expect(mb_substr_count($html, 'target="_blank"'))->toBe(8);
-    expect(mb_substr_count($html, 'rel="noopener noreferrer"'))->toBe(8);
+    expect(mb_substr_count($html, 'target="_blank"'))->toBe(9);
+    expect(mb_substr_count($html, 'rel="noopener noreferrer"'))->toBe(7);
 });
 
 it('exibe o logo He4rt animado', function (): void {
@@ -44,8 +44,8 @@ it('exibe o título e o acento de marca de cada link', function (): void {
     $html = get('/redes')->getContent();
 
     expect($html)->toContain('Escolha seu canal');
-    expect(mb_substr_count($html, '--accent-light:'))->toBe(6);
-    expect(mb_substr_count($html, '--accent-dark:'))->toBe(6);
+    expect(mb_substr_count($html, '--accent-light:'))->toBe(7);
+    expect(mb_substr_count($html, '--accent-dark:'))->toBe(7);
     expect($html)->toContain('--accent-light: #0F172A; --accent-dark: #FFFFFF;')
         ->and($html)->toContain('--accent-light: #111827; --accent-dark: #FFFFFF;');
 });

--- a/config/he4rt.php
+++ b/config/he4rt.php
@@ -61,5 +61,6 @@ return [
         'whatsapp' => ['label' => 'WhatsApp', 'url' => 'https://chat.whatsapp.com/EBKjYxIodpe1x5LLExbTzK', 'icon' => 'fab-whatsapp', 'accent' => '#25D366'],
         'instagram' => ['label' => 'Instagram', 'url' => 'https://www.instagram.com/heartdevs/', 'icon' => 'fab-instagram', 'accent' => '#E4405F'],
         'github' => ['label' => 'GitHub', 'url' => 'https://github.com/he4rt', 'icon' => 'fab-github', 'accent' => '#111827', 'accent_dark' => '#FFFFFF'],
+        'loja' => ['label' => 'Loja', 'url' => 'https://loja.heartdevs.com/he4rt/', 'icon' => 'heroicon-s-shopping-bag', 'accent' => '#111827', 'accent_dark' => '#FFFFFF'],
     ],
 ];


### PR DESCRIPTION
Closes #436 

## feat(portal): Adicionar botão de redirecionamento para loja da He4rt

Adiciona um botão na navbar do portal que redireciona para a loja da He4rt (`https://loja.heartdevs.com/he4rt/`), tanto na versão desktop quanto mobile.

### Mudanças

**Desktop (navbar principal):** Ícone de sacola de compras (`heroicon-s-shopping-bag`) com `aria-label="Loja"`, exibido apenas como ícone ao lado dos ícones de redes sociais e Discord.

**Mobile (menu hamburguer):** Botão com ícone + texto "Compre na Loja", dentro da lista de links do menu mobile.

## Preview
Desktop:
- Novo ícone de sacola entre "Redes sociais" e "Área do Usuário"
<img width="1063" height="91" alt="Screenshot 2026-07-22 at 23 00 46" src="https://github.com/user-attachments/assets/7c44555a-fdc8-4542-a4fa-069f32385f25" />

Mobile:
- Novo item "Compre na Loja" entre "Redes sociais" e "Área do Usuário"
<img width="333" height="268" alt="image" src="https://github.com/user-attachments/assets/2a5f7989-3548-4d3b-a6c4-e51e14d9488f" />

Redes:
- Novo item "Loja" no final da página
<img width="539" height="626" alt="image" src="https://github.com/user-attachments/assets/1e8f8972-b49a-46b2-8273-421564e93a20" />
