### PR TITLE
feat(onboarding): adiciona gate de GitHub vinculado antes do step git…

### DIFF
--- a/app-modules/onboarding/src/Actions/AdvanceStep.php
+++ b/app-modules/onboarding/src/Actions/AdvanceStep.php
@@ -30,5 +30,9 @@ final class AdvanceStep
         ]);
 
         $flow->advance($onboarding);
+
+        if (!$flow->isComplete($onboarding)) {
+            $flow->createNextStep($onboarding);
+        }
     }
 }

--- a/app-modules/onboarding/src/Contracts/OnboardingFlow.php
+++ b/app-modules/onboarding/src/Contracts/OnboardingFlow.php
@@ -37,6 +37,12 @@ interface OnboardingFlow
     public function advance(Onboarding $onboarding): void;
 
     /**
+     * Create the next step defined by the flow, if any.
+     * Implementations may gate the creation (e.g. require a linked GitHub account).
+     */
+    public function createNextStep(Onboarding $onboarding): void;
+
+    /**
      * Whether every step of the flow has been completed.
      */
     public function isComplete(Onboarding $onboarding): bool;

--- a/app-modules/onboarding/src/Exceptions/GateBlockedException.php
+++ b/app-modules/onboarding/src/Exceptions/GateBlockedException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Onboarding\Exceptions;
+
+use RuntimeException;
+
+final class GateBlockedException extends RuntimeException
+{
+    public function __construct(
+        public readonly string $step,
+        public readonly string $reason,
+    ) {
+        parent::__construct(sprintf('Gate bloqueado para step [%s]: %s', $step, $reason));
+    }
+}

--- a/app-modules/onboarding/src/Flows/SquadsOnboardingFlow.php
+++ b/app-modules/onboarding/src/Flows/SquadsOnboardingFlow.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace He4rt\Onboarding\Flows;
 
+use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
 use He4rt\Onboarding\Contracts\OnboardingFlow;
 use He4rt\Onboarding\Contracts\OnboardingStepDTO;
 use He4rt\Onboarding\DTOs\WelcomeFormDTO;
 use He4rt\Onboarding\Enums\OnboardingStatus;
 use He4rt\Onboarding\Enums\OnboardingStepStatus;
+use He4rt\Onboarding\Exceptions\GateBlockedException;
 use He4rt\Onboarding\Models\Onboarding;
 use InvalidArgumentException;
 
@@ -55,6 +57,36 @@ final class SquadsOnboardingFlow implements OnboardingFlow
                 'completed_at' => now(),
             ]);
         }
+    }
+
+    public function createNextStep(Onboarding $onboarding): void
+    {
+        $doneKeys = $onboarding->steps()
+            ->where('status', OnboardingStepStatus::Done)
+            ->pluck('step_key')
+            ->toArray();
+
+        $remaining = array_values(array_diff($this->steps(), $doneKeys));
+
+        if ($remaining === []) {
+            return;
+        }
+
+        $nextKey = $remaining[0];
+
+        if ($nextKey === 'git_challenge') {
+            $linked = $onboarding->user->providers()
+                ->where('provider', IdentityProvider::GitHub)
+                ->whereNotNull('connected_at')
+                ->whereNull('disconnected_at')
+                ->exists();
+            throw_unless($linked, GateBlockedException::class, step: 'git_challenge', reason: 'github_not_linked');
+        }
+
+        $onboarding->steps()->firstOrCreate(
+            ['step_key' => $nextKey],
+            ['status' => OnboardingStepStatus::Pending],
+        );
     }
 
     public function isComplete(Onboarding $onboarding): bool

--- a/app-modules/onboarding/src/Flows/WelcomeOnboardingFlow.php
+++ b/app-modules/onboarding/src/Flows/WelcomeOnboardingFlow.php
@@ -55,6 +55,8 @@ final class WelcomeOnboardingFlow implements OnboardingFlow
         }
     }
 
+    public function createNextStep(Onboarding $onboarding): void {}
+
     public function isComplete(Onboarding $onboarding): bool
     {
         return $onboarding->steps()

--- a/app-modules/onboarding/tests/Feature/SquadsOnboardingFlowTest.php
+++ b/app-modules/onboarding/tests/Feature/SquadsOnboardingFlowTest.php
@@ -2,11 +2,14 @@
 
 declare(strict_types=1);
 
+use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
+use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
 use He4rt\Identity\User\Models\User;
 use He4rt\Onboarding\Actions\StartOnboarding;
 use He4rt\Onboarding\Enums\OnboardingStatus;
 use He4rt\Onboarding\Enums\OnboardingStepStatus;
 use He4rt\Onboarding\Enums\OnboardingType;
+use He4rt\Onboarding\Exceptions\GateBlockedException;
 use He4rt\Onboarding\Flows\SquadsOnboardingFlow;
 
 test('Squads resolves its flow and declares its steps', function (): void {
@@ -54,4 +57,46 @@ test('advancing the form step leaves the Squads onboarding in progress', functio
         ->and($step->completed_at)->not->toBeNull()
         ->and($onboarding->status)->toBe(OnboardingStatus::InProgress)
         ->and($onboarding->completed_at)->toBeNull();
+});
+
+test('gate blocks git_challenge when github is not linked', function (): void {
+    $user = User::factory()->create();
+    $onboarding = resolve(StartOnboarding::class)->handle(
+        $user,
+        OnboardingType::Squads,
+    );
+
+    $flow = OnboardingType::Squads->handler();
+    $flow->advance($onboarding);
+
+    expect(fn () => $flow->createNextStep($onboarding))
+        ->toThrow(GateBlockedException::class);
+
+    $onboarding->refresh();
+    expect($onboarding->steps()->where('step_key', 'git_challenge')->exists())
+        ->toBeFalse();
+});
+
+test('gate allows git_challenge when github is linked', function (): void {
+    $user = User::factory()->create();
+    $onboarding = resolve(StartOnboarding::class)->handle($user, OnboardingType::Squads);
+
+    // Vincula GitHub
+    ExternalIdentity::factory()->create([
+        'model_type' => $user->getMorphClass(),
+        'model_id' => $user->id,
+        'provider' => IdentityProvider::GitHub,
+        'connected_at' => now(),
+        'disconnected_at' => null,
+    ]);
+
+    $flow = OnboardingType::Squads->handler();
+    $flow->advance($onboarding);
+
+    $flow->createNextStep($onboarding);
+
+    $onboarding->refresh();
+    $step = $onboarding->steps()->where('step_key', 'git_challenge')->sole();
+
+    expect($step->status)->toBe(OnboardingStepStatus::Pending);
 });


### PR DESCRIPTION
Closes #350

## O que muda

Adiciona o gate de GitHub vinculado antes do step `git_challenge` no `SquadsOnboardingFlow`.

### Como funciona

- Ao concluir o step `form`, o `AdvanceStep` agora chama `createNextStep()` no flow
- `createNextStep()` verifica se o usuário tem um `ExternalIdentity` do GitHub conectado
- **Sem vínculo**: lança `GateBlockedException` e **nenhuma linha** é criada em `onboarding_steps`
- **Com vínculo**: cria o step `git_challenge` como `pending`

### Critérios de aceite

- [x] Sem GitHub vinculado → `GateBlockedException` é lançada, sem linha em `onboarding_steps`
- [x] Com GitHub vinculado → step `git_challenge` é criado como `pending`
- [x] Gate não produz linha em `onboarding_steps` quando falha