### PR TITLE
feat(squads): SquadPolicy — captain/sub-captain or super-admin authorization

### DIFF
--- a/app-modules/squads/src/Policies/SquadPolicy.php
+++ b/app-modules/squads/src/Policies/SquadPolicy.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Squads\Policies;
+
+use He4rt\Identity\User\Models\User;
+use He4rt\Squads\Enums\SquadRole;
+use He4rt\Squads\Models\Squad;
+use He4rt\Squads\Models\SquadMember;
+use Illuminate\Auth\Access\AuthorizationException;
+
+final class SquadPolicy
+{
+    public function canManage(User $actor, Squad $squad): bool
+    {
+        if ($actor->isAdmin()) {
+            return true;
+        }
+
+        return SquadMember::query()
+            ->where('squad_id', $squad->id)
+            ->where('user_id', $actor->id)
+            ->whereIn('role', [SquadRole::Captain, SquadRole::SubCaptain])
+            ->exists();
+    }
+
+    public function authorize(User $actor, Squad $squad): void
+    {
+        throw_unless($this->canManage($actor, $squad), AuthorizationException::class);
+    }
+}

--- a/app-modules/squads/tests/Feature/SquadPolicyTest.php
+++ b/app-modules/squads/tests/Feature/SquadPolicyTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Identity\User\Models\User;
+use He4rt\Squads\Enums\SquadRole;
+use He4rt\Squads\Models\Squad;
+use He4rt\Squads\Models\SquadMember;
+use He4rt\Squads\Policies\SquadPolicy;
+use Illuminate\Auth\Access\AuthorizationException;
+
+describe('SquadPolicy', static function (): void {
+    test('a captain is authorized to manage their own squad', function (): void {
+        $squad = Squad::factory()->create();
+        $captain = User::factory()->create();
+
+        SquadMember::factory()->create([
+            'squad_id' => $squad->id,
+            'user_id' => $captain->id,
+            'role' => SquadRole::Captain,
+        ]);
+
+        $policy = resolve(SquadPolicy::class);
+
+        expect($policy->canManage($captain, $squad))->toBeTrue();
+
+        $policy->authorize($captain, $squad);
+    });
+
+    test('a captain is denied managing a squad they do not belong to', function (): void {
+        $ownSquad = Squad::factory()->create();
+        $otherSquad = Squad::factory()->create();
+        $captain = User::factory()->create();
+
+        SquadMember::factory()->create([
+            'squad_id' => $ownSquad->id,
+            'user_id' => $captain->id,
+            'role' => SquadRole::Captain,
+        ]);
+
+        $policy = resolve(SquadPolicy::class);
+
+        expect($policy->canManage($captain, $otherSquad))->toBeFalse();
+
+        $policy->authorize($captain, $otherSquad);
+    })->throws(AuthorizationException::class);
+
+    test('a super-admin is authorized on any squad, even without membership', function (): void {
+        config(['he4rt.admins' => 'guisaliba']);
+
+        $squad = Squad::factory()->create();
+        $admin = User::factory()->create([
+            'username' => 'guisaliba',
+        ]);
+
+        $policy = resolve(SquadPolicy::class);
+
+        expect($policy->canManage($admin, $squad))->toBeTrue();
+
+        $policy->authorize($admin, $squad);
+    });
+
+    test('a sub-captain is authorized to manage their own squad', function (): void {
+        $squad = Squad::factory()->create();
+        $subCaptain = User::factory()->create();
+
+        SquadMember::factory()->create([
+            'squad_id' => $squad->id,
+            'user_id' => $subCaptain->id,
+            'role' => SquadRole::SubCaptain,
+        ]);
+
+        $policy = resolve(SquadPolicy::class);
+
+        expect($policy->canManage($subCaptain, $squad))->toBeTrue();
+
+        $policy->authorize($subCaptain, $squad);
+    });
+
+    test('a common member is denied managing their own squad', function (): void {
+        $squad = Squad::factory()->create();
+        $member = User::factory()->create();
+
+        SquadMember::factory()->create([
+            'squad_id' => $squad->id,
+            'user_id' => $member->id,
+            'role' => SquadRole::Member,
+        ]);
+
+        $policy = resolve(SquadPolicy::class);
+
+        expect($policy->canManage($member, $squad))->toBeFalse();
+
+        $policy->authorize($member, $squad);
+    })->throws(AuthorizationException::class);
+});


### PR DESCRIPTION
Materializa o design de `Policies/SquadPolicy` já descrito em CONTEXT.md.

- `canManage(User $actor, Squad $squad): bool` — verdadeiro para super-admins incondicionalmente; caso contrário, apenas para um Captain/SubCaptain ativo do squad alvo.
- `authorize(User $actor, Squad $squad): void` — lança `AuthorizationException`, seguindo o padrão `throw_unless` já utilizado em `CreateSquad`/`ManageSquadStatus`.

Fora do escopo (conforme o plano): ações concretas que irão consumir esta policy (PromoteToSubCaptain, DecideApplication, MarkExMember, AssignCaptain, ReallocateLeader) — ainda não implementadas neste módulo.

## Plano de testes
- [x] `SquadPolicyTest.php` — 5 cenários (captain do próprio/outro squad, super-admin, sub-captain, membro comum), 5/5 verdes
- [x] Suite completa de `app-modules/squads` — 27/27 verdes
- [x] Pint limpo nos arquivos modificados

Closes #357 