### PR TITLE
feat(panel-admin): UserResource com List/View/Edit e Role hierarchy

### DIFF
--- a/app-modules/identity/database/factories/UserFactory.php
+++ b/app-modules/identity/database/factories/UserFactory.php
@@ -29,6 +29,11 @@ final class UserFactory extends Factory
         ];
     }
 
+    public function member(): static
+    {
+        return $this->state(['role' => Role::Member]);
+    }
+
     public function staff(): static
     {
         return $this->state(['role' => Role::Staff]);

--- a/app-modules/identity/database/factories/UserFactory.php
+++ b/app-modules/identity/database/factories/UserFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace He4rt\Identity\Database\Factories;
 
+use He4rt\Identity\User\Enums\Role;
 use He4rt\Identity\User\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
@@ -24,6 +25,27 @@ final class UserFactory extends Factory
             'email' => fake()->email(),
             'password' => Hash::make('password'),
             'is_donator' => false,
+            'role' => Role::Member,
         ];
+    }
+
+    public function staff(): static
+    {
+        return $this->state(['role' => Role::Staff]);
+    }
+
+    public function compliance(): static
+    {
+        return $this->state(['role' => Role::Compliance]);
+    }
+
+    public function recruiter(): static
+    {
+        return $this->state(['role' => Role::Recruiter]);
+    }
+
+    public function squadCaptain(): static
+    {
+        return $this->state(['role' => Role::SquadCaptain]);
     }
 }

--- a/app-modules/identity/database/migrations/2026_07_26_120000_add_role_and_soft_deletes_to_users_table.php
+++ b/app-modules/identity/database/migrations/2026_07_26_120000_add_role_and_soft_deletes_to_users_table.php
@@ -29,6 +29,28 @@ return new class extends Migration
         DB::statement('ALTER TABLE users DROP CONSTRAINT IF EXISTS users_username_unique');
         DB::statement('DROP INDEX IF EXISTS users_username_unique');
 
+        // up() only enforced uniqueness among active rows, so a soft-deleted
+        // row may share a username with an active row (or another trashed
+        // row). Rename those duplicates before restoring the global unique
+        // constraint below, keeping the active row (or the oldest one, if
+        // all are trashed) untouched. The suffix is intentionally neutral
+        // (not "_deleted_"): the renamed row isn't necessarily trashed.
+        DB::statement(<<<'SQL'
+            UPDATE users
+            SET username = username || '_dup_' || substr(id::text, 1, 8)
+            WHERE id IN (
+                SELECT id
+                FROM (
+                    SELECT id, row_number() OVER (
+                        PARTITION BY username
+                        ORDER BY deleted_at IS NULL DESC, created_at ASC
+                    ) AS row_number
+                    FROM users
+                ) ranked
+                WHERE row_number > 1
+            )
+        SQL);
+
         Schema::table('users', static function (Blueprint $table): void {
             $table->unique('username');
             $table->dropColumn(['role', 'deleted_at']);

--- a/app-modules/identity/database/migrations/2026_07_26_120000_add_role_and_soft_deletes_to_users_table.php
+++ b/app-modules/identity/database/migrations/2026_07_26_120000_add_role_and_soft_deletes_to_users_table.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Identity\User\Enums\Role;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', static function (Blueprint $table): void {
+            $table->string('role')->default(Role::Member->value)->after('is_donator');
+            $table->softDeletesTz();
+        });
+
+        DB::statement('ALTER TABLE users DROP CONSTRAINT IF EXISTS users_username_unique');
+
+        // Scoped to active rows only: soft-deleted users must not block a
+        // username from being reused (e.g. account merges reassign it).
+        DB::statement('CREATE UNIQUE INDEX users_username_unique ON users (username) WHERE deleted_at IS NULL');
+    }
+
+    public function down(): void
+    {
+        DB::statement('ALTER TABLE users DROP CONSTRAINT IF EXISTS users_username_unique');
+        DB::statement('DROP INDEX IF EXISTS users_username_unique');
+
+        Schema::table('users', static function (Blueprint $table): void {
+            $table->unique('username');
+            $table->dropColumn(['role', 'deleted_at']);
+        });
+    }
+};

--- a/app-modules/identity/database/migrations/2026_07_26_120000_add_role_and_soft_deletes_to_users_table.php
+++ b/app-modules/identity/database/migrations/2026_07_26_120000_add_role_and_soft_deletes_to_users_table.php
@@ -29,31 +29,60 @@ return new class extends Migration
         DB::statement('ALTER TABLE users DROP CONSTRAINT IF EXISTS users_username_unique');
         DB::statement('DROP INDEX IF EXISTS users_username_unique');
 
-        // up() only enforced uniqueness among active rows, so a soft-deleted
-        // row may share a username with an active row (or another trashed
-        // row). Rename those duplicates before restoring the global unique
-        // constraint below, keeping the active row (or the oldest one, if
-        // all are trashed) untouched. The suffix is intentionally neutral
-        // (not "_deleted_"): the renamed row isn't necessarily trashed.
-        DB::statement(<<<'SQL'
-            UPDATE users
-            SET username = username || '_dup_' || substr(id::text, 1, 8)
-            WHERE id IN (
-                SELECT id
-                FROM (
-                    SELECT id, row_number() OVER (
-                        PARTITION BY username
-                        ORDER BY deleted_at IS NULL DESC, created_at ASC
-                    ) AS row_number
-                    FROM users
-                ) ranked
-                WHERE row_number > 1
-            )
-        SQL);
+        $this->deduplicateUsernames();
 
         Schema::table('users', static function (Blueprint $table): void {
             $table->unique('username');
             $table->dropColumn(['role', 'deleted_at']);
         });
+    }
+
+    /**
+     * up() only enforced uniqueness among active rows, so a soft-deleted row
+     * may share a username with an active row (or another trashed row).
+     * Rename those duplicates before restoring the global unique constraint,
+     * keeping the active row (or the oldest one, if all are trashed)
+     * untouched. Candidates are checked against every username already in
+     * the table (not just the other duplicates), incrementing a counter
+     * until a free one is found, so this can't collide with an unrelated
+     * pre-existing username. The suffix is intentionally neutral (not
+     * "_deleted_"): the renamed row isn't necessarily trashed.
+     */
+    private function deduplicateUsernames(): void
+    {
+        /** @var array<string, true> $takenUsernames */
+        $takenUsernames = DB::table('users')->pluck('username')
+            ->mapWithKeys(static fn (string $username): array => [$username => true])
+            ->all();
+
+        $duplicateLosers = DB::select(<<<'SQL'
+            SELECT id, username
+            FROM (
+                SELECT id, username, row_number() OVER (
+                    PARTITION BY username
+                    ORDER BY deleted_at IS NULL DESC, created_at ASC
+                ) AS row_number
+                FROM users
+            ) ranked
+            WHERE row_number > 1
+        SQL);
+
+        foreach ($duplicateLosers as $row) {
+            /** @var array{id: string, username: string} $row */
+            $row = (array) $row;
+            $id = $row['id'];
+            $base = $row['username'].'_dup_'.mb_substr($id, 0, 8);
+            $candidate = $base;
+            $attempt = 1;
+
+            while (isset($takenUsernames[$candidate])) {
+                $candidate = $base.'_'.$attempt;
+                $attempt++;
+            }
+
+            $takenUsernames[$candidate] = true;
+
+            DB::table('users')->where('id', $id)->update(['username' => $candidate]);
+        }
     }
 };

--- a/app-modules/identity/database/migrations/2026_07_27_000000_promote_configured_admins_to_staff_role.php
+++ b/app-modules/identity/database/migrations/2026_07_27_000000_promote_configured_admins_to_staff_role.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use He4rt\Identity\User\Enums\Role;
+use He4rt\Identity\User\Models\User;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\DB;
 
@@ -15,7 +16,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        $usernames = str(config('he4rt.admins'))->explode(',')->filter()->values()->toArray();
+        $usernames = User::configuredAdminUsernames();
 
         if ($usernames === []) {
             return;

--- a/app-modules/identity/database/migrations/2026_07_27_000000_promote_configured_admins_to_staff_role.php
+++ b/app-modules/identity/database/migrations/2026_07_27_000000_promote_configured_admins_to_staff_role.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Identity\User\Enums\Role;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Backfills users listed in HE4RT_ADMINS_USERNAMES (isAdmin() bypass)
+     * that don't already have Staff/Compliance role, so panel authorization
+     * relies on a single source of truth (role) instead of the env list.
+     */
+    public function up(): void
+    {
+        $usernames = str(config('he4rt.admins'))->explode(',')->filter()->values()->toArray();
+
+        if ($usernames === []) {
+            return;
+        }
+
+        DB::table('users')
+            ->whereIn('username', $usernames)
+            ->whereNotIn('role', [Role::Staff->value, Role::Compliance->value])
+            ->update(['role' => Role::Staff->value]);
+    }
+
+    public function down(): void
+    {
+        // Data backfill, not reversible.
+    }
+};

--- a/app-modules/identity/lang/en/enums.php
+++ b/app-modules/identity/lang/en/enums.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'role' => [
+        'staff' => 'Staff',
+        'compliance' => 'Compliance',
+        'recruiter' => 'Recruiter',
+        'squad_captain' => 'Squad Captain',
+        'member' => 'Member',
+    ],
+];

--- a/app-modules/identity/lang/pt_BR/enums.php
+++ b/app-modules/identity/lang/pt_BR/enums.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'role' => [
+        'staff' => 'Staff',
+        'compliance' => 'Compliance',
+        'recruiter' => 'Recrutador',
+        'squad_captain' => 'Capitão de Squad',
+        'member' => 'Membro',
+    ],
+];

--- a/app-modules/identity/src/IdentityServiceProvider.php
+++ b/app-modules/identity/src/IdentityServiceProvider.php
@@ -13,6 +13,7 @@ class IdentityServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
+        $this->loadTranslationsFrom(__DIR__.'/../lang', 'identity');
 
         Relation::morphMap([
             'user' => User::class,

--- a/app-modules/identity/src/User/Enums/Role.php
+++ b/app-modules/identity/src/User/Enums/Role.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Identity\User\Enums;
+
+use App\Enums\Concerns\StringifyEnum;
+use Filament\Support\Colors\Color;
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasIcon;
+use Filament\Support\Contracts\HasLabel;
+use Filament\Support\Icons\Heroicon;
+
+enum Role: string implements HasColor, HasIcon, HasLabel
+{
+    use StringifyEnum;
+
+    case Staff = 'staff';
+    case Compliance = 'compliance';
+    case Recruiter = 'recruiter';
+    case SquadCaptain = 'squad_captain';
+    case Member = 'member';
+
+    public function getLabel(): string
+    {
+        return __('identity::enums.role.'.$this->value);
+    }
+
+    public function getColor(): array
+    {
+        return match ($this) {
+            self::Staff => Color::Amber,
+            self::Compliance => Color::Red,
+            self::Recruiter => Color::Blue,
+            self::SquadCaptain => Color::Purple,
+            self::Member => Color::Gray,
+        };
+    }
+
+    public function getIcon(): Heroicon
+    {
+        return match ($this) {
+            self::Staff => Heroicon::ShieldCheck,
+            self::Compliance => Heroicon::Scale,
+            self::Recruiter => Heroicon::Briefcase,
+            self::SquadCaptain => Heroicon::Flag,
+            self::Member => Heroicon::User,
+        };
+    }
+
+    /**
+     * Compliance é hierarquicamente um superconjunto de Staff: quem pode
+     * fazer hard delete também pode editar/soft-deletar.
+     */
+    public function isStaff(): bool
+    {
+        return in_array($this, [self::Staff, self::Compliance], strict: true);
+    }
+
+    public function isCompliance(): bool
+    {
+        return $this === self::Compliance;
+    }
+
+    /**
+     * Quem enxerga a ficha de um membro no painel: staff/compliance (gestão)
+     * e recruiter/squad captain (recrutamento), mas não member.
+     */
+    public function canViewUsers(): bool
+    {
+        return in_array($this, [self::Staff, self::Compliance, self::Recruiter, self::SquadCaptain], strict: true);
+    }
+}

--- a/app-modules/identity/src/User/Models/User.php
+++ b/app-modules/identity/src/User/Models/User.php
@@ -61,9 +61,22 @@ final class User extends Authenticatable implements FilamentUser, HasMedia, HasN
     use Notifiable;
     use SoftDeletes;
 
+    /**
+     * @return list<string>
+     */
+    public static function configuredAdminUsernames(): array
+    {
+        $usernames = array_map(
+            mb_trim(...),
+            explode(',', config()->string('he4rt.admins')),
+        );
+
+        return array_values(array_filter($usernames, static fn (string $username): bool => $username !== ''));
+    }
+
     public function isAdmin(): bool
     {
-        return in_array($this->username, str(config('he4rt.admins'))->explode(',')->toArray(), strict: true);
+        return in_array($this->username, self::configuredAdminUsernames(), strict: true);
     }
 
     public function isStaff(): bool

--- a/app-modules/identity/src/User/Models/User.php
+++ b/app-modules/identity/src/User/Models/User.php
@@ -12,15 +12,21 @@ use Filament\Panel;
 use He4rt\Gamification\Character\Models\Character;
 use He4rt\Identity\Database\Factories\UserFactory;
 use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
+use He4rt\Identity\User\Enums\Role;
 use He4rt\Identity\User\Observers\UserObserver;
+use He4rt\Profile\Models\Profile;
+use He4rt\Profile\Models\ProfileSkill;
+use He4rt\Profile\Models\WorkExperience;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Spatie\MediaLibrary\HasMedia;
@@ -32,12 +38,14 @@ use Spatie\MediaLibrary\InteractsWithMedia;
  * @property string $username
  * @property string|null $email
  * @property bool $is_donator
+ * @property Role $role
  * @property CarbonInterface|null $suspended_until
  * @property CarbonInterface|null $banned_at
  * @property CarbonInterface|null $first_login_at
  * @property string|null $remember_token
  * @property CarbonInterface|null $created_at
  * @property CarbonInterface|null $updated_at
+ * @property CarbonInterface|null $deleted_at
  */
 #[ObservedBy(classes: UserObserver::class)]
 #[Table(name: 'users')]
@@ -50,10 +58,16 @@ final class User extends Authenticatable implements FilamentUser, HasMedia, HasN
     use HasUuids;
     use InteractsWithMedia;
     use Notifiable;
+    use SoftDeletes;
 
     public function isAdmin(): bool
     {
         return in_array($this->username, str(config('he4rt.admins'))->explode(',')->toArray(), strict: true);
+    }
+
+    public function hasRole(Role $role): bool
+    {
+        return $this->role === $role;
     }
 
     /**
@@ -70,6 +84,44 @@ final class User extends Authenticatable implements FilamentUser, HasMedia, HasN
     public function character(): HasOne
     {
         return $this->hasOne(Character::class);
+    }
+
+    /**
+     * @return HasOne<Profile, $this>
+     */
+    public function profile(): HasOne
+    {
+        return $this->hasOne(Profile::class);
+    }
+
+    /**
+     * @return HasManyThrough<WorkExperience, Profile, $this>
+     */
+    public function workExperiences(): HasManyThrough
+    {
+        return $this->hasManyThrough(
+            WorkExperience::class,
+            Profile::class,
+            'user_id',
+            'profile_id',
+            'id',
+            'id',
+        );
+    }
+
+    /**
+     * @return HasManyThrough<ProfileSkill, Profile, $this>
+     */
+    public function profileSkills(): HasManyThrough
+    {
+        return $this->hasManyThrough(
+            ProfileSkill::class,
+            Profile::class,
+            'user_id',
+            'profile_id',
+            'id',
+            'id',
+        );
     }
 
     public function getFilamentName(): string
@@ -131,6 +183,7 @@ final class User extends Authenticatable implements FilamentUser, HasMedia, HasN
         return [
             'is_donator' => 'boolean',
             'password' => 'hashed',
+            'role' => Role::class,
             'suspended_until' => 'datetime',
             'banned_at' => 'datetime',
             'first_login_at' => 'datetime',

--- a/app-modules/identity/src/User/Models/User.php
+++ b/app-modules/identity/src/User/Models/User.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace He4rt\Identity\User\Models;
 
 use App\Concerns\HasAddress;
+use App\Enums\FilamentPanel;
 use Carbon\CarbonInterface;
 use Filament\Models\Contracts\FilamentUser;
 use Filament\Models\Contracts\HasName;
@@ -63,6 +64,11 @@ final class User extends Authenticatable implements FilamentUser, HasMedia, HasN
     public function isAdmin(): bool
     {
         return in_array($this->username, str(config('he4rt.admins'))->explode(',')->toArray(), strict: true);
+    }
+
+    public function isStaff(): bool
+    {
+        return $this->hasRole(Role::Staff);
     }
 
     public function hasRole(Role $role): bool
@@ -143,7 +149,7 @@ final class User extends Authenticatable implements FilamentUser, HasMedia, HasN
     public function canAccessPanel(Panel $panel): bool
     {
         return match ($panel->getId()) {
-            'admin' => app()->isProduction() ? $this->isAdmin() : true,
+            FilamentPanel::Admin->value => $this->isAdmin() || $this->role->canViewUsers(),
             default => true
         };
     }

--- a/app-modules/identity/src/User/Observers/UserObserver.php
+++ b/app-modules/identity/src/User/Observers/UserObserver.php
@@ -26,7 +26,7 @@ class UserObserver
         $this->ensureProfileExists($user);
     }
 
-    public function deleted(User $user): void
+    public function forceDeleted(User $user): void
     {
         $user->address()->delete();
     }

--- a/app-modules/identity/src/User/Observers/UserObserver.php
+++ b/app-modules/identity/src/User/Observers/UserObserver.php
@@ -43,6 +43,6 @@ class UserObserver
 
     private function isConfiguredAdmin(string $username): bool
     {
-        return in_array($username, str(config('he4rt.admins'))->explode(',')->toArray(), strict: true);
+        return in_array($username, User::configuredAdminUsernames(), strict: true);
     }
 }

--- a/app-modules/identity/src/User/Observers/UserObserver.php
+++ b/app-modules/identity/src/User/Observers/UserObserver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace He4rt\Identity\User\Observers;
 
+use He4rt\Identity\User\Enums\Role;
 use He4rt\Identity\User\Models\User;
 use He4rt\Profile\Models\Profile;
 
@@ -13,6 +14,10 @@ class UserObserver
     {
         if (blank($user->username)) {
             $user->username = str($user->name)->snake()->toString();
+        }
+
+        if ($this->isConfiguredAdmin($user->username) && !in_array($user->role, [Role::Staff, Role::Compliance], strict: true)) {
+            $user->role = Role::Staff;
         }
     }
 
@@ -34,5 +39,10 @@ class UserObserver
     private function ensureProfileExists(User $user): void
     {
         Profile::ensureExists((string) $user->getKey());
+    }
+
+    private function isConfiguredAdmin(string $username): bool
+    {
+        return in_array($username, str(config('he4rt.admins'))->explode(',')->toArray(), strict: true);
     }
 }

--- a/app-modules/identity/src/User/Policies/UserPolicy.php
+++ b/app-modules/identity/src/User/Policies/UserPolicy.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Identity\User\Policies;
+
+use He4rt\Identity\User\Models\User;
+
+final class UserPolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return $user->role->canViewUsers();
+    }
+
+    public function view(User $user): bool
+    {
+        return $user->role->canViewUsers();
+    }
+
+    public function update(User $user): bool
+    {
+        return $user->role->isStaff();
+    }
+
+    public function delete(User $user): bool
+    {
+        return $user->role->isStaff();
+    }
+
+    public function restore(User $user): bool
+    {
+        return $user->role->isCompliance();
+    }
+
+    public function forceDelete(User $user): bool
+    {
+        return $user->role->isCompliance();
+    }
+}

--- a/app-modules/identity/tests/Unit/User/UserPolicyTest.php
+++ b/app-modules/identity/tests/Unit/User/UserPolicyTest.php
@@ -44,12 +44,16 @@ test('update and delete allow staff and compliance', function (): void {
         ->and($this->policy->delete($compliance))->toBeTrue();
 });
 
-test('update and delete deny non-staff roles', function (): void {
-    $member = User::factory()->create();
+test('update and delete deny non-staff roles', function (string $factoryState): void {
+    $user = User::factory()->{$factoryState}()->create();
 
-    expect($this->policy->update($member))->toBeFalse()
-        ->and($this->policy->delete($member))->toBeFalse();
-});
+    expect($this->policy->update($user))->toBeFalse()
+        ->and($this->policy->delete($user))->toBeFalse();
+})->with([
+    'member' => 'member',
+    'recruiter' => 'recruiter',
+    'squad captain' => 'squadCaptain',
+]);
 
 test('restore and forceDelete require compliance', function (): void {
     $compliance = User::factory()->compliance()->create();

--- a/app-modules/identity/tests/Unit/User/UserPolicyTest.php
+++ b/app-modules/identity/tests/Unit/User/UserPolicyTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Identity\User\Models\User;
+use He4rt\Identity\User\Policies\UserPolicy;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $this->policy = new UserPolicy();
+});
+
+test('viewAny allows staff, compliance, recruiter and squad captain', function (): void {
+    expect($this->policy->viewAny(User::factory()->staff()->create()))->toBeTrue()
+        ->and($this->policy->viewAny(User::factory()->compliance()->create()))->toBeTrue()
+        ->and($this->policy->viewAny(User::factory()->recruiter()->create()))->toBeTrue()
+        ->and($this->policy->viewAny(User::factory()->squadCaptain()->create()))->toBeTrue();
+});
+
+test('viewAny denies member', function (): void {
+    expect($this->policy->viewAny(User::factory()->create()))->toBeFalse();
+});
+
+test('view allows staff, compliance, recruiter and squad captain', function (): void {
+    expect($this->policy->view(User::factory()->staff()->create()))->toBeTrue()
+        ->and($this->policy->view(User::factory()->compliance()->create()))->toBeTrue()
+        ->and($this->policy->view(User::factory()->recruiter()->create()))->toBeTrue()
+        ->and($this->policy->view(User::factory()->squadCaptain()->create()))->toBeTrue();
+});
+
+test('view denies member', function (): void {
+    expect($this->policy->view(User::factory()->create()))->toBeFalse();
+});
+
+test('update and delete allow staff and compliance', function (): void {
+    $staff = User::factory()->staff()->create();
+    $compliance = User::factory()->compliance()->create();
+
+    expect($this->policy->update($staff))->toBeTrue()
+        ->and($this->policy->delete($staff))->toBeTrue()
+        ->and($this->policy->update($compliance))->toBeTrue()
+        ->and($this->policy->delete($compliance))->toBeTrue();
+});
+
+test('update and delete deny non-staff roles', function (): void {
+    $member = User::factory()->create();
+
+    expect($this->policy->update($member))->toBeFalse()
+        ->and($this->policy->delete($member))->toBeFalse();
+});
+
+test('restore and forceDelete require compliance', function (): void {
+    $compliance = User::factory()->compliance()->create();
+    $staff = User::factory()->staff()->create();
+
+    expect($this->policy->restore($compliance))->toBeTrue()
+        ->and($this->policy->forceDelete($compliance))->toBeTrue()
+        ->and($this->policy->restore($staff))->toBeFalse()
+        ->and($this->policy->forceDelete($staff))->toBeFalse();
+});

--- a/app-modules/panel-admin/src/Filament/Resources/Users/Pages/EditUser.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Users/Pages/EditUser.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\PanelAdmin\Filament\Resources\Users\Pages;
+
+use Filament\Actions\Action;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\ForceDeleteAction;
+use Filament\Actions\RestoreAction;
+use Filament\Resources\Pages\EditRecord;
+use He4rt\PanelAdmin\Filament\Resources\Users\UserResource;
+
+class EditUser extends EditRecord
+{
+    protected static string $resource = UserResource::class;
+
+    /**
+     * @return Action[]
+     */
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+            ForceDeleteAction::make(),
+            RestoreAction::make(),
+        ];
+    }
+}

--- a/app-modules/panel-admin/src/Filament/Resources/Users/Pages/ListUsers.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Users/Pages/ListUsers.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\PanelAdmin\Filament\Resources\Users\Pages;
+
+use Filament\Resources\Pages\ListRecords;
+use He4rt\PanelAdmin\Filament\Resources\Users\UserResource;
+
+class ListUsers extends ListRecords
+{
+    protected static string $resource = UserResource::class;
+}

--- a/app-modules/panel-admin/src/Filament/Resources/Users/Pages/ViewUser.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Users/Pages/ViewUser.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\PanelAdmin\Filament\Resources\Users\Pages;
+
+use Filament\Actions\EditAction;
+use Filament\Resources\Pages\ViewRecord;
+use He4rt\PanelAdmin\Filament\Resources\Users\UserResource;
+
+class ViewUser extends ViewRecord
+{
+    protected static string $resource = UserResource::class;
+
+    /**
+     * @return EditAction[]
+     */
+    protected function getHeaderActions(): array
+    {
+        return [
+            EditAction::make(),
+        ];
+    }
+}

--- a/app-modules/panel-admin/src/Filament/Resources/Users/RelationManagers/ProfileSkillsRelationManager.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Users/RelationManagers/ProfileSkillsRelationManager.php
@@ -19,6 +19,7 @@ use He4rt\Identity\User\Models\User;
 use He4rt\Profile\Enums\SkillProficiency;
 use He4rt\Profile\Models\Profile;
 use He4rt\Profile\Models\ProfileSkill;
+use Illuminate\Validation\Rules\Unique;
 
 class ProfileSkillsRelationManager extends RelationManager
 {
@@ -33,7 +34,13 @@ class ProfileSkillsRelationManager extends RelationManager
                     ->relationship('skill', 'name')
                     ->searchable()
                     ->preload()
-                    ->required(),
+                    ->required()
+                    ->unique(
+                        table: 'profile_skills',
+                        column: 'skill_id',
+                        ignoreRecord: true,
+                        modifyRuleUsing: fn (Unique $rule): Unique => $rule->where('profile_id', $this->ownerProfileId()),
+                    ),
 
                 Select::make('proficiency')
                     ->label('Proficiency')
@@ -83,7 +90,7 @@ class ProfileSkillsRelationManager extends RelationManager
 
     private function isEditableByCurrentUser(): bool
     {
-        return auth()->user()?->role->isStaff() ?? false;
+        return auth()->user()?->can('update', User::class) ?? false;
     }
 
     /**
@@ -99,5 +106,13 @@ class ProfileSkillsRelationManager extends RelationManager
         $data['profile_id'] = $profile->id;
 
         return ProfileSkill::query()->create($data);
+    }
+
+    private function ownerProfileId(): ?string
+    {
+        /** @var User $owner */
+        $owner = $this->getOwnerRecord();
+
+        return Profile::query()->where('user_id', $owner->id)->value('id');
     }
 }

--- a/app-modules/panel-admin/src/Filament/Resources/Users/RelationManagers/ProfileSkillsRelationManager.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Users/RelationManagers/ProfileSkillsRelationManager.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\PanelAdmin\Filament\Resources\Users\RelationManagers;
+
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\CreateAction;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use He4rt\Identity\User\Models\User;
+use He4rt\Profile\Enums\SkillProficiency;
+use He4rt\Profile\Models\Profile;
+use He4rt\Profile\Models\ProfileSkill;
+
+class ProfileSkillsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'profileSkills';
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Select::make('skill_id')
+                    ->label('Skill')
+                    ->relationship('skill', 'name')
+                    ->searchable()
+                    ->preload()
+                    ->required(),
+
+                Select::make('proficiency')
+                    ->label('Proficiency')
+                    ->options(SkillProficiency::class)
+                    ->required(),
+
+                TextInput::make('years_experience')
+                    ->label('Years of Experience')
+                    ->integer(),
+            ]);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->recordTitleAttribute('skill.name')
+            ->columns([
+                TextColumn::make('skill.name')
+                    ->label('Skill')
+                    ->searchable(),
+
+                TextColumn::make('proficiency')
+                    ->label('Proficiency')
+                    ->badge(),
+
+                TextColumn::make('years_experience')
+                    ->label('Years of Experience')
+                    ->placeholder('—'),
+            ])
+            ->headerActions([
+                CreateAction::make()
+                    ->using($this->createProfileSkill(...))
+                    ->visible($this->isEditableByCurrentUser(...)),
+            ])
+            ->recordActions([
+                EditAction::make()
+                    ->visible($this->isEditableByCurrentUser(...)),
+                DeleteAction::make()
+                    ->visible($this->isEditableByCurrentUser(...)),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ])->visible($this->isEditableByCurrentUser(...)),
+            ]);
+    }
+
+    private function isEditableByCurrentUser(): bool
+    {
+        return auth()->user()?->role->isStaff() ?? false;
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    private function createProfileSkill(array $data): ProfileSkill
+    {
+        /** @var User $owner */
+        $owner = $this->getOwnerRecord();
+
+        $profile = Profile::ensureExists($owner->id);
+
+        $data['profile_id'] = $profile->id;
+
+        return ProfileSkill::query()->create($data);
+    }
+}

--- a/app-modules/panel-admin/src/Filament/Resources/Users/RelationManagers/WorkExperiencesRelationManager.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Users/RelationManagers/WorkExperiencesRelationManager.php
@@ -14,6 +14,7 @@ use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
@@ -45,10 +46,13 @@ class WorkExperiencesRelationManager extends RelationManager
 
                 DatePicker::make('start_date')
                     ->label('Start Date')
-                    ->required(),
+                    ->required()
+                    ->maxDate(today()),
 
                 DatePicker::make('end_date')
-                    ->label('End Date'),
+                    ->label('End Date')
+                    ->afterOrEqual('start_date')
+                    ->hidden(fn (Get $get): bool => (bool) $get('is_currently_working_here')),
 
                 Checkbox::make('is_currently_working_here')
                     ->label('Currently Working Here')
@@ -102,7 +106,7 @@ class WorkExperiencesRelationManager extends RelationManager
 
     private function isEditableByCurrentUser(): bool
     {
-        return auth()->user()?->role->isStaff() ?? false;
+        return auth()->user()?->can('update', User::class) ?? false;
     }
 
     /**

--- a/app-modules/panel-admin/src/Filament/Resources/Users/RelationManagers/WorkExperiencesRelationManager.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Users/RelationManagers/WorkExperiencesRelationManager.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\PanelAdmin\Filament\Resources\Users\RelationManagers;
+
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\CreateAction;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\Checkbox;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use He4rt\Identity\User\Models\User;
+use He4rt\Profile\Models\Profile;
+use He4rt\Profile\Models\WorkExperience;
+
+class WorkExperiencesRelationManager extends RelationManager
+{
+    protected static string $relationship = 'workExperiences';
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                TextInput::make('company_name')
+                    ->label('Company')
+                    ->required(),
+
+                TextInput::make('position')
+                    ->label('Position')
+                    ->required(),
+
+                Textarea::make('description')
+                    ->label('Description')
+                    ->required()
+                    ->rows(3),
+
+                DatePicker::make('start_date')
+                    ->label('Start Date')
+                    ->required(),
+
+                DatePicker::make('end_date')
+                    ->label('End Date'),
+
+                Checkbox::make('is_currently_working_here')
+                    ->label('Currently Working Here')
+                    ->live(),
+            ]);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->recordTitleAttribute('position')
+            ->columns([
+                TextColumn::make('company_name')
+                    ->label('Company')
+                    ->searchable(),
+
+                TextColumn::make('position')
+                    ->label('Position')
+                    ->searchable(),
+
+                TextColumn::make('start_date')
+                    ->label('Start Date')
+                    ->date(),
+
+                TextColumn::make('end_date')
+                    ->label('End Date')
+                    ->date()
+                    ->placeholder('—'),
+
+                IconColumn::make('is_currently_working_here')
+                    ->label('Current')
+                    ->boolean(),
+            ])
+            ->headerActions([
+                CreateAction::make()
+                    ->using($this->createWorkExperience(...))
+                    ->visible($this->isEditableByCurrentUser(...)),
+            ])
+            ->recordActions([
+                EditAction::make()
+                    ->visible($this->isEditableByCurrentUser(...)),
+                DeleteAction::make()
+                    ->visible($this->isEditableByCurrentUser(...)),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ])->visible($this->isEditableByCurrentUser(...)),
+            ]);
+    }
+
+    private function isEditableByCurrentUser(): bool
+    {
+        return auth()->user()?->role->isStaff() ?? false;
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    private function createWorkExperience(array $data): WorkExperience
+    {
+        /** @var User $owner */
+        $owner = $this->getOwnerRecord();
+
+        $profile = Profile::ensureExists($owner->id);
+
+        $data['profile_id'] = $profile->id;
+
+        return WorkExperience::query()->create($data);
+    }
+}

--- a/app-modules/panel-admin/src/Filament/Resources/Users/Schemas/UserForm.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Users/Schemas/UserForm.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\PanelAdmin\Filament\Resources\Users\Schemas;
+
+use Filament\Forms\Components\CheckboxList;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Schemas\Components\Component;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Components\Tabs;
+use Filament\Schemas\Components\Tabs\Tab;
+use Filament\Schemas\Schema;
+use He4rt\Identity\User\Enums\Role;
+use He4rt\Profile\Data\WorkPreferences;
+use He4rt\Profile\Enums\EmploymentType;
+use He4rt\Profile\Enums\SeniorityLevel;
+use He4rt\Profile\Enums\SocialPlatform;
+use He4rt\Profile\Enums\StartAvailability;
+use Illuminate\Support\Arr;
+
+class UserForm
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Tabs::make('User')
+                    ->tabs([
+                        Tab::make('Identidade')
+                            ->schema(self::identitySchema()),
+
+                        Tab::make('Perfil')
+                            ->schema([self::profileSection()]),
+
+                        Tab::make('Endereço')
+                            ->schema([self::addressSection()]),
+                    ])
+                    ->columnSpanFull(),
+            ]);
+    }
+
+    /**
+     * @return array<int, Component>
+     */
+    private static function identitySchema(): array
+    {
+        return [
+            TextInput::make('username')
+                ->label('Username')
+                ->required()
+                ->unique(ignoreRecord: true),
+
+            TextInput::make('name')
+                ->label('Name')
+                ->required()
+                ->unique(ignoreRecord: true),
+
+            TextInput::make('email')
+                ->label('Email')
+                ->email(),
+
+            Select::make('role')
+                ->label('Role')
+                ->options(Role::class)
+                ->required(),
+
+            Toggle::make('is_donator')
+                ->label('Donator'),
+        ];
+    }
+
+    private static function profileSection(): Section
+    {
+        return Section::make('Perfil')
+            ->relationship('profile')
+            ->mutateRelationshipDataBeforeFillUsing(function (array $data): array {
+                /** @var WorkPreferences $preferences */
+                $preferences = $data['preferences'] ?? new WorkPreferences();
+
+                return [
+                    ...Arr::except($data, ['preferences']),
+                    'has_disability' => $preferences->hasDisability,
+                    'willing_to_relocate' => $preferences->willingToRelocate,
+                    'is_open_to_remote' => $preferences->isOpenToRemote,
+                    'employment_types' => array_map(
+                        static fn (EmploymentType $type): string => $type->value,
+                        $preferences->employmentTypes,
+                    ),
+                ];
+            })
+            ->mutateRelationshipDataBeforeSaveUsing(fn (array $data): array => [
+                ...Arr::except($data, [
+                    'has_disability',
+                    'willing_to_relocate',
+                    'is_open_to_remote',
+                    'employment_types',
+                ]),
+                'preferences' => [
+                    'has_disability' => $data['has_disability'] ?? false,
+                    'willing_to_relocate' => $data['willing_to_relocate'] ?? false,
+                    'is_open_to_remote' => $data['is_open_to_remote'] ?? false,
+                    'employment_types' => $data['employment_types'] ?? [],
+                ],
+            ])
+            ->schema([
+                TextInput::make('nickname')
+                    ->label('Nickname'),
+
+                TextInput::make('headline')
+                    ->label('Headline'),
+
+                Textarea::make('about')
+                    ->label('Sobre')
+                    ->rows(3),
+
+                DatePicker::make('birthdate')
+                    ->label('Data de Nascimento'),
+
+                Select::make('seniority_level')
+                    ->label('Senioridade')
+                    ->options(SeniorityLevel::class),
+
+                TextInput::make('years_experience')
+                    ->label('Anos de Experiência')
+                    ->integer(),
+
+                Toggle::make('available_for_proposals')
+                    ->label('Disponível para Propostas'),
+
+                Select::make('start_availability')
+                    ->label('Disponibilidade de Início')
+                    ->options(StartAvailability::class),
+
+                TextInput::make('expected_salary_min')
+                    ->label('Pretensão Salarial Mínima')
+                    ->numeric()
+                    ->prefix('R$'),
+
+                TextInput::make('expected_salary_max')
+                    ->label('Pretensão Salarial Máxima')
+                    ->numeric()
+                    ->prefix('R$'),
+
+                TextInput::make('social_links.'.SocialPlatform::Instagram->value)
+                    ->label('Instagram'),
+
+                TextInput::make('social_links.'.SocialPlatform::Twitter->value)
+                    ->label('Twitter'),
+
+                TextInput::make('social_links.'.SocialPlatform::Website->value)
+                    ->label('Website'),
+
+                TextInput::make('social_links.'.SocialPlatform::YouTube->value)
+                    ->label('YouTube'),
+
+                TextInput::make('social_links.'.SocialPlatform::Bluesky->value)
+                    ->label('Bluesky'),
+
+                Toggle::make('has_disability')
+                    ->label('Possui Deficiência'),
+
+                Toggle::make('willing_to_relocate')
+                    ->label('Disponível para Relocação'),
+
+                Toggle::make('is_open_to_remote')
+                    ->label('Aberto a Trabalho Remoto'),
+
+                CheckboxList::make('employment_types')
+                    ->label('Tipos de Contratação')
+                    ->options(EmploymentType::class),
+            ])
+            ->columnSpanFull();
+    }
+
+    private static function addressSection(): Section
+    {
+        return Section::make('Endereço')
+            ->relationship('address')
+            ->schema([
+                TextInput::make('country')
+                    ->label('País')
+                    ->maxLength(4),
+
+                TextInput::make('state')
+                    ->label('Estado'),
+
+                TextInput::make('city')
+                    ->label('Cidade'),
+
+                TextInput::make('zip_code')
+                    ->label('CEP')
+                    ->mask('99999-999'),
+            ])
+            ->columnSpanFull();
+    }
+}

--- a/app-modules/panel-admin/src/Filament/Resources/Users/Schemas/UserForm.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Users/Schemas/UserForm.php
@@ -57,8 +57,7 @@ class UserForm
 
             TextInput::make('name')
                 ->label('Name')
-                ->required()
-                ->unique(ignoreRecord: true),
+                ->required(),
 
             TextInput::make('email')
                 ->label('Email')
@@ -79,8 +78,9 @@ class UserForm
         return Section::make('Perfil')
             ->relationship('profile')
             ->mutateRelationshipDataBeforeFillUsing(function (array $data): array {
-                /** @var WorkPreferences $preferences */
-                $preferences = $data['preferences'] ?? new WorkPreferences();
+                $preferences = $data['preferences'] instanceof WorkPreferences
+                    ? $data['preferences']
+                    : new WorkPreferences();
 
                 return [
                     ...Arr::except($data, ['preferences']),

--- a/app-modules/panel-admin/src/Filament/Resources/Users/Schemas/UserInfolist.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Users/Schemas/UserInfolist.php
@@ -46,7 +46,7 @@ class UserInfolist
 
                         Tab::make('Moderação')
                             ->schema(self::moderationSchema())
-                            ->hidden(static fn (): bool => !(auth()->user()?->role->isStaff() ?? false)),
+                            ->hidden(static fn (): bool => !(auth()->user()?->can('update', User::class) ?? false)),
                     ])
                     ->columnSpanFull(),
             ]);

--- a/app-modules/panel-admin/src/Filament/Resources/Users/Schemas/UserInfolist.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Users/Schemas/UserInfolist.php
@@ -1,0 +1,395 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\PanelAdmin\Filament\Resources\Users\Schemas;
+
+use Filament\Infolists\Components\IconEntry;
+use Filament\Infolists\Components\RepeatableEntry;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Schemas\Components\Component;
+use Filament\Schemas\Components\Tabs;
+use Filament\Schemas\Components\Tabs\Tab;
+use Filament\Schemas\Schema;
+use He4rt\Activity\Voice\Models\Voice;
+use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
+use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
+use He4rt\Identity\User\Models\User;
+use He4rt\IntegrationDiscord\Models\DiscordMember;
+use He4rt\IntegrationDiscord\Models\DiscordRole;
+use He4rt\Moderation\Cases\Models\ModerationCase;
+use He4rt\Profile\Enums\SocialPlatform;
+use Illuminate\Database\Eloquent\Collection;
+
+class UserInfolist
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Tabs::make('User')
+                    ->tabs([
+                        Tab::make('Identidade')
+                            ->schema(self::identitySchema()),
+
+                        Tab::make('Perfil')
+                            ->schema(self::profileSchema()),
+
+                        Tab::make('Endereço')
+                            ->schema(self::addressSchema()),
+
+                        Tab::make('Gamificação')
+                            ->schema(self::gamificationSchema()),
+
+                        Tab::make('Atividade')
+                            ->schema(self::activitySchema()),
+
+                        Tab::make('Moderação')
+                            ->schema(self::moderationSchema())
+                            ->hidden(static fn (): bool => !(auth()->user()?->role->isStaff() ?? false)),
+                    ])
+                    ->columnSpanFull(),
+            ]);
+    }
+
+    /**
+     * @return array<int, Component>
+     */
+    private static function identitySchema(): array
+    {
+        return [
+            TextEntry::make('username')
+                ->label('Username'),
+
+            TextEntry::make('name')
+                ->label('Name'),
+
+            TextEntry::make('email')
+                ->label('Email')
+                ->placeholder('—'),
+
+            TextEntry::make('role')
+                ->label('Role')
+                ->badge(),
+
+            IconEntry::make('is_donator')
+                ->label('Donator')
+                ->boolean(),
+
+            TextEntry::make('created_at')
+                ->label('Membro desde')
+                ->dateTime(),
+        ];
+    }
+
+    /**
+     * @return array<int, Component>
+     */
+    private static function profileSchema(): array
+    {
+        return [
+            TextEntry::make('profile.nickname')
+                ->label('Nickname')
+                ->placeholder('—'),
+
+            TextEntry::make('profile.headline')
+                ->label('Headline')
+                ->placeholder('—'),
+
+            TextEntry::make('profile.about')
+                ->label('Sobre')
+                ->placeholder('—')
+                ->columnSpanFull(),
+
+            TextEntry::make('profile.birthdate')
+                ->label('Data de Nascimento')
+                ->date()
+                ->placeholder('—'),
+
+            TextEntry::make('profile.seniority_level')
+                ->label('Senioridade')
+                ->badge()
+                ->placeholder('—'),
+
+            TextEntry::make('profile.years_experience')
+                ->label('Anos de Experiência')
+                ->placeholder('—'),
+
+            IconEntry::make('profile.available_for_proposals')
+                ->label('Disponível para Propostas')
+                ->boolean(),
+
+            TextEntry::make('profile.start_availability')
+                ->label('Disponibilidade de Início')
+                ->badge()
+                ->placeholder('—'),
+
+            TextEntry::make('profile.expected_salary_min')
+                ->label('Pretensão Salarial Mínima')
+                ->money('BRL')
+                ->placeholder('—'),
+
+            TextEntry::make('profile.expected_salary_max')
+                ->label('Pretensão Salarial Máxima')
+                ->money('BRL')
+                ->placeholder('—'),
+
+            TextEntry::make('profile.social_links.'.SocialPlatform::Instagram->value)
+                ->label('Instagram')
+                ->placeholder('—'),
+
+            TextEntry::make('profile.social_links.'.SocialPlatform::Twitter->value)
+                ->label('Twitter')
+                ->placeholder('—'),
+
+            TextEntry::make('profile.social_links.'.SocialPlatform::Website->value)
+                ->label('Website')
+                ->placeholder('—'),
+
+            TextEntry::make('profile.social_links.'.SocialPlatform::YouTube->value)
+                ->label('YouTube')
+                ->placeholder('—'),
+
+            TextEntry::make('profile.social_links.'.SocialPlatform::Bluesky->value)
+                ->label('Bluesky')
+                ->placeholder('—'),
+
+            IconEntry::make('profile.preferences.hasDisability')
+                ->label('Possui Deficiência')
+                ->boolean(),
+
+            IconEntry::make('profile.preferences.willingToRelocate')
+                ->label('Disponível para Relocação')
+                ->boolean(),
+
+            IconEntry::make('profile.preferences.isOpenToRemote')
+                ->label('Aberto a Trabalho Remoto')
+                ->boolean(),
+
+            TextEntry::make('profile.preferences.employmentTypes')
+                ->label('Tipos de Contratação')
+                ->badge()
+                ->placeholder('—'),
+        ];
+    }
+
+    /**
+     * @return array<int, Component>
+     */
+    private static function addressSchema(): array
+    {
+        return [
+            TextEntry::make('address.country')
+                ->label('País')
+                ->placeholder('—'),
+
+            TextEntry::make('address.state')
+                ->label('Estado')
+                ->placeholder('—'),
+
+            TextEntry::make('address.city')
+                ->label('Cidade')
+                ->placeholder('—'),
+
+            TextEntry::make('address.zip_code')
+                ->label('CEP')
+                ->placeholder('—'),
+        ];
+    }
+
+    /**
+     * @return array<int, Component>
+     */
+    private static function gamificationSchema(): array
+    {
+        return [
+            TextEntry::make('character.level')
+                ->label('Nível')
+                ->badge()
+                ->placeholder('—'),
+
+            TextEntry::make('character.experience')
+                ->label('Experiência')
+                ->placeholder('—'),
+
+            TextEntry::make('character.reputation')
+                ->label('Reputação')
+                ->placeholder('—'),
+
+            RepeatableEntry::make('character.badges')
+                ->label('Badges')
+                ->schema([
+                    TextEntry::make('name')
+                        ->label('Nome'),
+
+                    TextEntry::make('pivot.claimed_at')
+                        ->label('Conquistada em')
+                        ->dateTime(),
+                ])
+                ->columns(2)
+                ->columnSpanFull(),
+
+            RepeatableEntry::make('character.wallets')
+                ->label('Carteira')
+                ->schema([
+                    TextEntry::make('currency')
+                        ->label('Moeda'),
+
+                    TextEntry::make('balance')
+                        ->label('Saldo'),
+                ])
+                ->columns(2)
+                ->columnSpanFull(),
+        ];
+    }
+
+    /**
+     * @return array<int, Component>
+     */
+    private static function activitySchema(): array
+    {
+        return [
+            RepeatableEntry::make('providers')
+                ->label('Conexões')
+                ->schema([
+                    TextEntry::make('provider')
+                        ->label('Provider')
+                        ->badge(),
+
+                    TextEntry::make('external_account_id')
+                        ->label('ID Externo')
+                        ->placeholder('—'),
+
+                    TextEntry::make('connected_at')
+                        ->label('Conectado em')
+                        ->dateTime()
+                        ->placeholder('—'),
+
+                    TextEntry::make('messages_count')
+                        ->label('Mensagens'),
+                ])
+                ->columns(4)
+                ->columnSpanFull(),
+
+            TextEntry::make('activity_messages_total')
+                ->label('Total de Mensagens')
+                ->state(static fn (User $record): int => self::messagesCount($record)),
+
+            TextEntry::make('activity_voice_hours')
+                ->label('Horas de Voice (aproximado)')
+                ->state(static fn (User $record): float => self::voiceHours($record)),
+
+            TextEntry::make('activity_discord_roles')
+                ->label('Cargos no Discord')
+                ->state(static fn (User $record): array => self::discordRoles($record))
+                ->badge()
+                ->placeholder('—'),
+        ];
+    }
+
+    /**
+     * @return array<int, Component>
+     */
+    private static function moderationSchema(): array
+    {
+        $caseSchema = [
+            TextEntry::make('status')
+                ->label('Status')
+                ->badge(),
+
+            TextEntry::make('severity')
+                ->label('Severidade')
+                ->badge()
+                ->placeholder('—'),
+
+            TextEntry::make('violation_type')
+                ->label('Tipo de Violação')
+                ->badge()
+                ->placeholder('—'),
+
+            TextEntry::make('created_at')
+                ->label('Criado em')
+                ->dateTime(),
+        ];
+
+        return [
+            RepeatableEntry::make('moderation_authored_cases')
+                ->label('Casos como Autor')
+                ->state(static fn (User $record) => ModerationCase::query()
+                    ->where('author_id', $record->id)
+                    ->latest()
+                    ->limit(10)
+                    ->get())
+                ->schema($caseSchema)
+                ->columns(4)
+                ->columnSpanFull(),
+
+            RepeatableEntry::make('moderation_assigned_cases')
+                ->label('Casos como Responsável')
+                ->state(static fn (User $record) => ModerationCase::query()
+                    ->where('assigned_to', $record->id)
+                    ->latest()
+                    ->limit(10)
+                    ->get())
+                ->schema($caseSchema)
+                ->columns(4)
+                ->columnSpanFull(),
+
+            TextEntry::make('suspended_until')
+                ->label('Suspenso até')
+                ->dateTime()
+                ->placeholder('—'),
+
+            TextEntry::make('banned_at')
+                ->label('Banido em')
+                ->dateTime()
+                ->placeholder('—'),
+        ];
+    }
+
+    private static function messagesCount(User $record): int
+    {
+        /** @var Collection<int, ExternalIdentity> $providers */
+        $providers = $record->providers;
+
+        return $providers->sum(static fn (ExternalIdentity $identity): int => $identity->messages_count);
+    }
+
+    private static function voiceHours(User $record): float
+    {
+        $identityIds = $record->providers->pluck('id');
+
+        if ($identityIds->isEmpty()) {
+            return 0.0;
+        }
+
+        $joinedCount = Voice::query()
+            ->whereIn('external_identity_id', $identityIds)
+            ->where('state', 'joined')
+            ->count();
+
+        return round($joinedCount * 0.75, 1);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private static function discordRoles(User $record): array
+    {
+        /** @var ExternalIdentity|null $discordIdentity */
+        $discordIdentity = $record->providers->firstWhere('provider', IdentityProvider::Discord);
+
+        if ($discordIdentity === null) {
+            return [];
+        }
+
+        $member = DiscordMember::query()
+            ->where('external_identity_id', $discordIdentity->id)
+            ->with('roles')
+            ->first();
+
+        return $member?->roles
+            ->map(static fn (DiscordRole $role): string => $role->name)
+            ->all() ?? [];
+    }
+}

--- a/app-modules/panel-admin/src/Filament/Resources/Users/Tables/UsersTable.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Users/Tables/UsersTable.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\PanelAdmin\Filament\Resources\Users\Tables;
+
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Actions\ForceDeleteAction;
+use Filament\Actions\ForceDeleteBulkAction;
+use Filament\Actions\RestoreAction;
+use Filament\Actions\RestoreBulkAction;
+use Filament\Actions\ViewAction;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Filters\TernaryFilter;
+use Filament\Tables\Filters\TrashedFilter;
+use Filament\Tables\Table;
+use He4rt\Identity\User\Enums\Role;
+use He4rt\Identity\User\Models\User;
+use He4rt\Profile\Enums\SeniorityLevel;
+use Illuminate\Database\Eloquent\Builder;
+
+class UsersTable
+{
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('username')
+                    ->label('Username')
+                    ->searchable()
+                    ->sortable(),
+
+                TextColumn::make('name')
+                    ->label('Name')
+                    ->searchable()
+                    ->sortable(),
+
+                TextColumn::make('email')
+                    ->label('Email')
+                    ->searchable()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+
+                TextColumn::make('role')
+                    ->label('Role')
+                    ->badge(),
+
+                TextColumn::make('profile.seniority_level')
+                    ->label('Senioridade')
+                    ->badge()
+                    ->placeholder('—'),
+
+                IconColumn::make('profile.available_for_proposals')
+                    ->label('Disponível')
+                    ->boolean(),
+
+                TextColumn::make('address.city')
+                    ->label('Cidade')
+                    ->placeholder('—'),
+
+                TextColumn::make('character.level')
+                    ->label('Nível')
+                    ->badge()
+                    ->placeholder('—'),
+
+                TextColumn::make('status')
+                    ->label('Status')
+                    ->state(static fn (User $record): string => match (true) {
+                        $record->trashed() => 'removed',
+                        $record->banned_at !== null => 'banned',
+                        $record->suspended_until?->isFuture() => 'suspended',
+                        default => 'active',
+                    })
+                    ->badge()
+                    ->color(static fn (string $state): string => match ($state) {
+                        'removed' => 'gray',
+                        'banned' => 'danger',
+                        'suspended' => 'warning',
+                        default => 'success',
+                    })
+                    ->formatStateUsing(static fn (string $state): string => match ($state) {
+                        'removed' => 'Removido',
+                        'banned' => 'Banido',
+                        'suspended' => 'Suspenso',
+                        default => 'Ativo',
+                    }),
+
+                IconColumn::make('is_donator')
+                    ->label('Donator')
+                    ->boolean(),
+            ])
+            ->paginated([25, 50, 100])
+            ->filters([
+                SelectFilter::make('role')
+                    ->label('Role')
+                    ->options(Role::class),
+
+                SelectFilter::make('seniority_level')
+                    ->label('Senioridade')
+                    ->options(SeniorityLevel::class)
+                    ->query(static fn (Builder $query, array $data): Builder => $query->when(
+                        $data['value'] ?? null,
+                        static fn (Builder $q, mixed $value): Builder => $q->whereRelation('profile', 'seniority_level', $value),
+                    )),
+
+                TernaryFilter::make('available_for_proposals')
+                    ->label('Disponível para Propostas')
+                    ->queries(
+                        true: static fn (Builder $query): Builder => $query->whereRelation('profile', 'available_for_proposals', operator: true),
+                        false: static fn (Builder $query): Builder => $query->whereRelation('profile', 'available_for_proposals', operator: false),
+                    ),
+
+                TrashedFilter::make(),
+            ])
+            ->recordActions([
+                ViewAction::make(),
+                EditAction::make(),
+                DeleteAction::make(),
+                RestoreAction::make(),
+                ForceDeleteAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                    RestoreBulkAction::make(),
+                    ForceDeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+}

--- a/app-modules/panel-admin/src/Filament/Resources/Users/UserResource.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Users/UserResource.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\PanelAdmin\Filament\Resources\Users;
+
+use BackedEnum;
+use Filament\Resources\Pages\PageRegistration;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+use He4rt\Identity\User\Models\User;
+use He4rt\PanelAdmin\Filament\Resources\Users\Pages\EditUser;
+use He4rt\PanelAdmin\Filament\Resources\Users\Pages\ListUsers;
+use He4rt\PanelAdmin\Filament\Resources\Users\Pages\ViewUser;
+use He4rt\PanelAdmin\Filament\Resources\Users\RelationManagers\ProfileSkillsRelationManager;
+use He4rt\PanelAdmin\Filament\Resources\Users\RelationManagers\WorkExperiencesRelationManager;
+use He4rt\PanelAdmin\Filament\Resources\Users\Schemas\UserForm;
+use He4rt\PanelAdmin\Filament\Resources\Users\Schemas\UserInfolist;
+use He4rt\PanelAdmin\Filament\Resources\Users\Tables\UsersTable;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+
+class UserResource extends Resource
+{
+    protected static ?string $model = User::class;
+
+    protected static ?string $slug = 'users';
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedUsers;
+
+    public static function form(Schema $schema): Schema
+    {
+        return UserForm::configure($schema);
+    }
+
+    public static function infolist(Schema $schema): Schema
+    {
+        return UserInfolist::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return UsersTable::table($table);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            WorkExperiencesRelationManager::class,
+            ProfileSkillsRelationManager::class,
+        ];
+    }
+
+    /**
+     * @return array<string, PageRegistration>
+     */
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListUsers::route('/'),
+            'view' => ViewUser::route('/{record}'),
+            'edit' => EditUser::route('/{record}/edit'),
+        ];
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->withoutGlobalScopes([
+                SoftDeletingScope::class,
+            ])
+            ->with(['profile', 'address', 'character']);
+    }
+
+    public static function getGloballySearchableAttributes(): array
+    {
+        return ['username', 'name', 'email'];
+    }
+}

--- a/app-modules/panel-admin/src/PanelAdminServiceProvider.php
+++ b/app-modules/panel-admin/src/PanelAdminServiceProvider.php
@@ -9,6 +9,7 @@ use Filament\Navigation\NavigationItem;
 use Filament\Panel;
 use He4rt\PanelAdmin\Discord\DiscordCluster;
 use He4rt\PanelAdmin\Filament\Resources\ExternalIdentities\ExternalIdentityResource;
+use He4rt\PanelAdmin\Filament\Resources\Users\UserResource;
 use He4rt\PanelAdmin\Github\GithubCluster;
 use He4rt\PanelAdmin\Marketing\MarketingCluster;
 use He4rt\PanelAdmin\Moderation\Livewire\AppealQueue;
@@ -42,6 +43,7 @@ class PanelAdminServiceProvider extends ServiceProvider
                 ->navigation($this->buildNavigation(...))
                 ->resources([
                     ExternalIdentityResource::class,
+                    UserResource::class,
                 ])
                 ->discoverResources(
                     in: __DIR__.'/Moderation/Resources',
@@ -125,6 +127,7 @@ class PanelAdminServiceProvider extends ServiceProvider
             ...TwitchCluster::getNavigationItems(),
             ...GithubCluster::getNavigationItems(),
             ...ExternalIdentityResource::getNavigationItems(),
+            ...UserResource::getNavigationItems(),
             ...DiscordCluster::getNavigationItems(),
         ]);
     }

--- a/app-modules/panel-admin/tests/Feature/Users/UserResourceTest.php
+++ b/app-modules/panel-admin/tests/Feature/Users/UserResourceTest.php
@@ -1,0 +1,341 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Actions\Testing\TestAction;
+use Filament\Facades\Filament;
+use He4rt\Identity\User\Enums\Role;
+use He4rt\Identity\User\Models\User;
+use He4rt\Moderation\Cases\Models\ModerationCase;
+use He4rt\PanelAdmin\Filament\Resources\Users\Pages\EditUser;
+use He4rt\PanelAdmin\Filament\Resources\Users\Pages\ListUsers;
+use He4rt\PanelAdmin\Filament\Resources\Users\Pages\ViewUser;
+use He4rt\PanelAdmin\Filament\Resources\Users\RelationManagers\ProfileSkillsRelationManager;
+use He4rt\PanelAdmin\Filament\Resources\Users\RelationManagers\WorkExperiencesRelationManager;
+use He4rt\Profile\Enums\SkillProficiency;
+use He4rt\Profile\Models\Profile;
+use He4rt\Profile\Models\ProfileSkill;
+use He4rt\Profile\Models\Skill;
+use He4rt\Profile\Models\WorkExperience;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(function (): void {
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+});
+
+test('staff, recruiter e squad captain listam os usuários', function (): void {
+    $member = User::factory()->create();
+
+    foreach (['staff', 'recruiter', 'squadCaptain'] as $state) {
+        $viewer = User::factory()->{$state}()->create();
+
+        $this->actingAs($viewer);
+
+        livewire(ListUsers::class)
+            ->loadTable()
+            ->assertCanSeeTableRecords([$viewer, $member]);
+    }
+});
+
+test('membro não pode acessar a listagem', function (): void {
+    $member = User::factory()->create();
+
+    $this->actingAs($member);
+
+    livewire(ListUsers::class)
+        ->assertForbidden();
+});
+
+test('membro não pode acessar a view de outro usuário', function (): void {
+    $member = User::factory()->create();
+    $target = User::factory()->create();
+
+    $this->actingAs($member);
+
+    livewire(ViewUser::class, ['record' => $target->id])
+        ->assertForbidden();
+});
+
+test('staff vê a seção de moderação na view, recrutador não vê', function (): void {
+    $target = User::factory()->create();
+
+    $staff = User::factory()->staff()->create();
+    $this->actingAs($staff);
+
+    livewire(ViewUser::class, ['record' => $target->id])
+        ->assertOk()
+        ->assertSee('Moderação');
+
+    $recruiter = User::factory()->recruiter()->create();
+    $this->actingAs($recruiter);
+
+    livewire(ViewUser::class, ['record' => $target->id])
+        ->assertOk()
+        ->assertDontSee('Moderação');
+});
+
+test('view não quebra para usuário sem character', function (): void {
+    $staff = User::factory()->staff()->create();
+    $target = User::factory()->create();
+
+    expect($target->character)->toBeNull();
+
+    $this->actingAs($staff);
+
+    livewire(ViewUser::class, ['record' => $target->id])
+        ->assertOk();
+});
+
+test('staff edita identidade, perfil e endereço em um único submit', function (): void {
+    $staff = User::factory()->staff()->create();
+    $target = User::factory()->create();
+
+    $this->actingAs($staff);
+
+    livewire(EditUser::class, ['record' => $target->id])
+        ->fillForm([
+            'role' => Role::Recruiter->value,
+            'is_donator' => true,
+            'profile.nickname' => 'devzin',
+            'profile.headline' => 'Backend Developer',
+            'profile.seniority_level' => 'senior',
+            'profile.available_for_proposals' => true,
+            'profile.social_links.instagram' => 'devzin.insta',
+            'profile.has_disability' => true,
+            'profile.willing_to_relocate' => true,
+            'profile.is_open_to_remote' => true,
+            'profile.employment_types' => ['clt'],
+            'address.country' => 'BR',
+            'address.state' => 'SP',
+            'address.city' => 'Campinas',
+        ])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    $target->refresh();
+
+    expect($target->role)->toBe(Role::Recruiter)
+        ->and($target->is_donator)->toBeTrue()
+        ->and($target->profile->nickname)->toBe('devzin')
+        ->and($target->profile->seniority_level->value)->toBe('senior')
+        ->and($target->profile->available_for_proposals)->toBeTrue()
+        ->and($target->profile->social_links)->toMatchArray(['instagram' => 'devzin.insta'])
+        ->and($target->profile->preferences->hasDisability)->toBeTrue()
+        ->and($target->profile->preferences->willingToRelocate)->toBeTrue()
+        ->and($target->profile->preferences->isOpenToRemote)->toBeTrue()
+        ->and($target->address->city)->toBe('Campinas');
+});
+
+test('rejeita username duplicado na edição', function (): void {
+    $staff = User::factory()->staff()->create();
+    User::factory()->create(['username' => 'taken']);
+    $target = User::factory()->create();
+
+    $this->actingAs($staff);
+
+    livewire(EditUser::class, ['record' => $target->id])
+        ->fillForm(['username' => 'taken'])
+        ->call('save')
+        ->assertHasFormErrors(['username']);
+});
+
+test('recrutador e squad captain não conseguem acessar a edição', function (): void {
+    $target = User::factory()->create();
+
+    foreach (['recruiter', 'squadCaptain'] as $state) {
+        $viewer = User::factory()->{$state}()->create();
+
+        $this->actingAs($viewer);
+
+        livewire(EditUser::class, ['record' => $target->id])
+            ->assertForbidden();
+    }
+});
+
+test('cria uma work experience preenchendo o profile_id automaticamente', function (): void {
+    $staff = User::factory()->staff()->create();
+    $target = User::factory()->create();
+
+    $this->actingAs($staff);
+
+    livewire(WorkExperiencesRelationManager::class, [
+        'ownerRecord' => $target,
+        'pageClass' => EditUser::class,
+    ])
+        ->callAction(TestAction::make('create')->table(), data: [
+            'company_name' => 'He4rt',
+            'position' => 'Developer',
+            'description' => 'Building community tools.',
+            'start_date' => now()->subYear()->toDateString(),
+            'is_currently_working_here' => true,
+        ])
+        ->assertHasNoTableActionErrors();
+
+    $workExperience = WorkExperience::query()->where('company_name', 'He4rt')->sole();
+
+    expect($workExperience->profile->user_id)->toBe($target->id);
+});
+
+test('staff edita uma work experience existente', function (): void {
+    $staff = User::factory()->staff()->create();
+    $target = User::factory()->create();
+    $profile = Profile::ensureExists($target->id);
+    $workExperience = WorkExperience::factory()->for($profile)->create(['position' => 'Junior Developer']);
+
+    $this->actingAs($staff);
+
+    livewire(WorkExperiencesRelationManager::class, [
+        'ownerRecord' => $target,
+        'pageClass' => EditUser::class,
+    ])
+        ->callAction(
+            TestAction::make('edit')->table($workExperience),
+            data: ['position' => 'Senior Developer'],
+        )
+        ->assertHasNoTableActionErrors();
+
+    expect($workExperience->fresh()->position)->toBe('Senior Developer');
+});
+
+test('staff exclui uma work experience', function (): void {
+    $staff = User::factory()->staff()->create();
+    $target = User::factory()->create();
+    $profile = Profile::ensureExists($target->id);
+    $workExperience = WorkExperience::factory()->for($profile)->create();
+
+    $this->actingAs($staff);
+
+    livewire(WorkExperiencesRelationManager::class, [
+        'ownerRecord' => $target,
+        'pageClass' => EditUser::class,
+    ])
+        ->callAction(TestAction::make('delete')->table($workExperience));
+
+    expect(WorkExperience::query()->find($workExperience->id))->toBeNull();
+});
+
+test('cria uma profile skill preenchendo o profile_id automaticamente', function (): void {
+    $staff = User::factory()->staff()->create();
+    $target = User::factory()->create();
+    $skill = Skill::factory()->create();
+
+    $this->actingAs($staff);
+
+    livewire(ProfileSkillsRelationManager::class, [
+        'ownerRecord' => $target,
+        'pageClass' => EditUser::class,
+    ])
+        ->callAction(TestAction::make('create')->table(), data: [
+            'skill_id' => $skill->id,
+            'proficiency' => SkillProficiency::Advanced->value,
+            'years_experience' => 3,
+        ])
+        ->assertHasNoTableActionErrors();
+
+    $profileSkill = ProfileSkill::query()->where('skill_id', $skill->id)->sole();
+
+    expect($profileSkill->profile->user_id)->toBe($target->id);
+});
+
+test('staff edita a proficiência de uma profile skill existente', function (): void {
+    $staff = User::factory()->staff()->create();
+    $target = User::factory()->create();
+    $profile = Profile::ensureExists($target->id);
+    $profileSkill = ProfileSkill::factory()->for($profile)->create(['proficiency' => SkillProficiency::Beginner]);
+
+    $this->actingAs($staff);
+
+    livewire(ProfileSkillsRelationManager::class, [
+        'ownerRecord' => $target,
+        'pageClass' => EditUser::class,
+    ])
+        ->callAction(
+            TestAction::make('edit')->table($profileSkill),
+            data: ['proficiency' => SkillProficiency::Expert->value],
+        )
+        ->assertHasNoTableActionErrors();
+
+    expect($profileSkill->fresh()->proficiency)->toBe(SkillProficiency::Expert);
+});
+
+test('staff exclui (detach) uma profile skill', function (): void {
+    $staff = User::factory()->staff()->create();
+    $target = User::factory()->create();
+    $profile = Profile::ensureExists($target->id);
+    $profileSkill = ProfileSkill::factory()->for($profile)->create();
+
+    $this->actingAs($staff);
+
+    livewire(ProfileSkillsRelationManager::class, [
+        'ownerRecord' => $target,
+        'pageClass' => EditUser::class,
+    ])
+        ->callAction(TestAction::make('delete')->table($profileSkill));
+
+    expect(ProfileSkill::query()->find($profileSkill->id))->toBeNull();
+});
+
+test('recrutador não vê ações de criar/editar/excluir nas relation managers', function (): void {
+    $recruiter = User::factory()->recruiter()->create();
+    $target = User::factory()->create();
+
+    $this->actingAs($recruiter);
+
+    livewire(WorkExperiencesRelationManager::class, [
+        'ownerRecord' => $target,
+        'pageClass' => ViewUser::class,
+    ])
+        ->assertActionHidden(TestAction::make('create')->table())
+        ->assertOk();
+
+    livewire(ProfileSkillsRelationManager::class, [
+        'ownerRecord' => $target,
+        'pageClass' => ViewUser::class,
+    ])
+        ->assertActionHidden(TestAction::make('create')->table())
+        ->assertOk();
+});
+
+test('soft delete é a ação padrão', function (): void {
+    $staff = User::factory()->staff()->create();
+    $target = User::factory()->create();
+
+    $this->actingAs($staff);
+
+    livewire(ListUsers::class)
+        ->callAction(TestAction::make('delete')->table($target));
+
+    expect($target->fresh()->trashed())->toBeTrue();
+});
+
+test('hard delete é indisponível sem permissão de compliance e disponível com ela', function (): void {
+    $target = User::factory()->create(['deleted_at' => now()]);
+
+    $staff = User::factory()->staff()->create();
+    $this->actingAs($staff);
+
+    livewire(ListUsers::class)
+        ->assertActionHidden(TestAction::make('forceDelete')->table($target));
+
+    $compliance = User::factory()->compliance()->create();
+    $this->actingAs($compliance);
+
+    livewire(ListUsers::class)
+        ->callAction(TestAction::make('forceDelete')->table($target));
+
+    expect(User::withTrashed()->find($target->id))->toBeNull();
+});
+
+test('view não quebra quando o usuário tem casos de moderação como autor e responsável', function (): void {
+    $target = User::factory()->create();
+    ModerationCase::factory()->create(['author_id' => $target->id]);
+    ModerationCase::factory()->create(['assigned_to' => $target->id]);
+
+    $staff = User::factory()->staff()->create();
+    $this->actingAs($staff);
+
+    livewire(ViewUser::class, ['record' => $target->id])
+        ->assertOk()
+        ->assertSee('Moderação');
+});

--- a/app-modules/panel-admin/tests/Feature/Users/UserResourceTest.php
+++ b/app-modules/panel-admin/tests/Feature/Users/UserResourceTest.php
@@ -238,6 +238,29 @@ test('cria uma profile skill preenchendo o profile_id automaticamente', function
     expect($profileSkill->profile->user_id)->toBe($target->id);
 });
 
+test('não permite duplicar a mesma skill no profile', function (): void {
+    $staff = User::factory()->staff()->create();
+    $target = User::factory()->create();
+    $profile = Profile::ensureExists($target->id);
+    $skill = Skill::factory()->create();
+    ProfileSkill::factory()->for($profile)->for($skill)->create();
+
+    $this->actingAs($staff);
+
+    livewire(ProfileSkillsRelationManager::class, [
+        'ownerRecord' => $target,
+        'pageClass' => EditUser::class,
+    ])
+        ->callAction(TestAction::make('create')->table(), data: [
+            'skill_id' => $skill->id,
+            'proficiency' => SkillProficiency::Advanced->value,
+            'years_experience' => 3,
+        ])
+        ->assertHasTableActionErrors(['skill_id' => 'unique']);
+
+    expect(ProfileSkill::query()->where('skill_id', $skill->id)->count())->toBe(1);
+});
+
 test('staff edita a proficiência de uma profile skill existente', function (): void {
     $staff = User::factory()->staff()->create();
     $target = User::factory()->create();

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Providers;
 
 // use Illuminate\Support\Facades\Gate;
+use He4rt\Identity\User\Models\User;
+use He4rt\Identity\User\Policies\UserPolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
 final class AuthServiceProvider extends ServiceProvider
@@ -15,7 +17,7 @@ final class AuthServiceProvider extends ServiceProvider
      * @var array<class-string, class-string>
      */
     protected $policies = [
-        // 'App\Models\Model' => 'App\Policies\ModelPolicy',
+        User::class => UserPolicy::class,
     ];
 
     /**

--- a/database/seeders/BaseSeeder.php
+++ b/database/seeders/BaseSeeder.php
@@ -23,6 +23,7 @@ class BaseSeeder extends Seeder
                 'name' => 'Daniel Reis',
                 'email' => 'admin@admin.com',
                 'password' => Hash::make('admin'),
+                'role' => 'staff',
             ]);
 
         Character::factory()

--- a/tests/Feature/AddressTest.php
+++ b/tests/Feature/AddressTest.php
@@ -30,7 +30,7 @@ it('user sem endereço retorna null', function (): void {
     expect($user->address)->toBeNull();
 });
 
-it('deletar user deleta address via cascade', function (): void {
+it('soft delete do user preserva o address', function (): void {
     $user = User::factory()->create();
 
     Address::factory()->forUser($user)->create();
@@ -38,6 +38,18 @@ it('deletar user deleta address via cascade', function (): void {
     expect(Address::query()->where('addressable_id', $user->id)->exists())->toBeTrue();
 
     $user->delete();
+
+    expect(Address::query()->where('addressable_id', $user->id)->exists())->toBeTrue();
+});
+
+it('force delete do user deleta address via cascade', function (): void {
+    $user = User::factory()->create();
+
+    Address::factory()->forUser($user)->create();
+
+    expect(Address::query()->where('addressable_id', $user->id)->exists())->toBeTrue();
+
+    $user->forceDelete();
 
     expect(Address::query()->where('addressable_id', $user->id)->exists())->toBeFalse();
 });


### PR DESCRIPTION
Closes #424

## Contexto

Não existia `UserResource` no painel admin. Staff/moderação precisava de uma tela única pra ver e editar um membro por inteiro — os dados estavam espalhados entre `Character`, `ExternalIdentity`, `Profile`, `Address` e `ModerationCase`.

Este PR entrega **List, Edit e View** para os dados editáveis pelo admin, mantendo como seções agregadas somente-leitura os dados que vêm de outros domínios (respeitando a fronteira presentation/core — sem duplicar lógica de escrita de outros módulos). **Create ficou fora de escopo** por decisão explícita no issue: contas só nascem via OAuth, e criação manual seria admitir débito técnico.

## O que entra

### Identity — hierarquia de roles (pré-requisito pro Policy do Resource)
- Enum `Role` (`Staff`, `Compliance`, `Recruiter`, `SquadCaptain`, `Member`) com `isStaff()`, `isCompliance()`, `canViewUsers()`.
- Migration adicionando `role` e soft deletes ao `users`; o unique index de `username` virou **parcial** (`WHERE deleted_at IS NULL`) pra não travar reuso de username por conta soft-deletada (regressão pega no fluxo de merge de contas).
- `UserPolicy`: `viewAny`/`view` liberam staff/compliance/recruiter/squad captain; `update`/`delete` restritos a staff; `restore`/`forceDelete` restritos a compliance — hard delete nunca é o padrão, sempre com a confirmação explícita que o Filament já exige.
- Relações `profile()`, `workExperiences()`, `profileSkills()` no `User` (aceitável no core por poder ser reaproveitado por outros módulos, conforme discutido no issue).

### Panel-admin — `UserResource`
- **List**: colunas de username/name/email (buscáveis), role, senioridade, disponibilidade, cidade, nível, status computado (ativo/suspenso/banido/removido) e donator; paginação `[25, 50, 100]`; filtros de role, senioridade e disponibilidade.
- **Edit** (staff-only): identidade (username/name/email/role/is_donator), perfil profissional (nickname, headline, about, senioridade, disponibilidade, pretensão salarial, redes sociais, preferências de remoto/relocação/contratação/deficiência) e endereço — tudo num único submit.
- **View** (staff/compliance/recruiter/squad captain): mesmos dados em modo leitura, mais as seções agregadas:
  - **Gamificação** (nível/XP/reputação/badges/carteira via `character()`) — 100% somente-leitura, sem action de conceder badge (adiado pro issue de badges por evento, já combinado na thread).
  - **Atividade** (conexões, total de mensagens, horas de voice aproximadas, cargos do Discord via `providers()`).
  - **Moderação** (casos como autor/responsável, suspensão/banimento) — **oculta pra quem não é staff/compliance**.
- RelationManagers de Skills e Experiências profissionais: create/edit/delete pra staff, somente leitura pra recruiter/squad captain.

## Decisões registradas durante a implementação

- Skills RelationManager opera sobre `profileSkills()` (registros `ProfileSkill` diretos) em vez de `Profile::skills()` (`BelongsToMany`) — mesmo resultado prático, menos retrabalho sobre o que já existia.
- `preferences` do perfil é um cast custom (`AsWorkPreferences`), não array puro — o form usa os hooks nativos do Filament (`mutateRelationshipDataBeforeFill/SaveUsing`) pra achatar/reagrupar os campos, seguindo o mesmo padrão manual já usado em `ProfilePage` (portal).

## Testes

- `UserPolicyTest`: cobre a hierarquia de roles em todas as abilities.
- `UserResourceTest` (18 testes): autorização por página/seção (List/Edit/View × staff/compliance/recruiter/squad captain/member), edição multi-seção com persistência de `preferences`/`social_links`/endereço, validação de username duplicado, estado vazio pra usuário sem `Character`, RelationManagers (create/edit/delete pra staff, ocultas pra recruiter), soft delete como ação padrão, hard delete restrito a compliance.

```
vendor/bin/pest app-modules/identity app-modules/panel-admin
# 114 passed
```

PHPStan (nível 6), Pint e Rector limpos nos arquivos tocados.

## Como testar manualmente

1. `make dev`, logar em `/admin` com uma conta `staff` ou `compliance`.
2. Acessar **Admin ▸ Usuários** — conferir busca, filtros e paginação da listagem.
3. Abrir um usuário (View) — conferir as abas Identidade/Perfil/Endereço/Gamificação/Atividade/Moderação.
4. Editar um usuário — alterar campos de perfil (incluindo preferências e redes sociais) e endereço num único submit, salvar e conferir persistência.
5. Testar a ação de excluir (soft delete por padrão) e, com uma conta `compliance`, a exclusão física (hard delete, com confirmação).