### PR TITLE
fix(timeline): Exibir imagem de perfil do usuário nas threads (igual …

### DIFF
--- a/app-modules/panel-app/resources/views/livewire/timeline/reply-composer.blade.php
+++ b/app-modules/panel-app/resources/views/livewire/timeline/reply-composer.blade.php
@@ -4,15 +4,23 @@
 >
     <form wire:submit="reply">
         <div class="flex gap-2 px-3 pt-3 pb-2 sm:gap-3 sm:px-4 sm:pt-4 sm:pb-3">
-            <div
-                class="hidden h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-purple-500 to-amber-500 text-xs font-semibold text-white sm:flex"
-            >
-                {{
-                    str(auth()->user()->name)
-                        ->substr(0, 2)
-                        ->upper()
-                }}
-            </div>
+            @if ($this->avatarUrl)
+                <img
+                    src="{{ $this->avatarUrl }}"
+                    alt="{{ auth()->user()->name }}"
+                    class="hidden h-8 w-8 shrink-0 rounded-full object-cover sm:block"
+                />
+            @else
+                <div
+                    class="hidden h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-purple-500 to-amber-500 text-xs font-semibold text-white sm:flex"
+                >
+                    {{
+                        str(auth()->user()->name)
+                            ->substr(0, 2)
+                            ->upper()
+                    }}
+                </div>
+            @endif
             <div class="[&_.fi-fo-field-wrp]:gap-0 [&_.fi-fo-field-wrp-label]:hidden min-w-0 flex-1">
                 {{ $this->form }}
             </div>

--- a/app-modules/panel-app/resources/views/livewire/timeline/thread-replies.blade.php
+++ b/app-modules/panel-app/resources/views/livewire/timeline/thread-replies.blade.php
@@ -12,11 +12,20 @@
                     @continue (!$reply->postable)
                     <div wire:key="reply-{{ $reply->id }}" class="px-3 py-3 sm:px-4">
                         <div class="flex gap-2 sm:gap-3">
-                            <div
-                                class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-purple-500 to-amber-500 text-[10px] font-semibold text-white sm:h-8 sm:w-8 sm:text-xs"
-                            >
-                                {{ str($reply->user->name)->substr(0, 2)->upper() }}
-                            </div>
+                            @php($replyAvatarUrl = $reply->user->getFirstMediaUrl('avatar') ?: null)
+                            @if ($replyAvatarUrl)
+                                <img
+                                    src="{{ $replyAvatarUrl }}"
+                                    alt="{{ $reply->user->name }}"
+                                    class="h-7 w-7 shrink-0 rounded-full object-cover sm:h-8 sm:w-8"
+                                />
+                            @else
+                                <div
+                                    class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-purple-500 to-amber-500 text-[10px] font-semibold text-white sm:h-8 sm:w-8 sm:text-xs"
+                                >
+                                    {{ str($reply->user->name)->substr(0, 2)->upper() }}
+                                </div>
+                            @endif
                             <div class="min-w-0 flex-1">
                                 <div class="flex items-center justify-between gap-2">
                                     <div class="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-0.5 text-sm">

--- a/app-modules/panel-app/src/Livewire/Timeline/ReplyComposer.php
+++ b/app-modules/panel-app/src/Livewire/Timeline/ReplyComposer.php
@@ -13,6 +13,7 @@ use He4rt\Activity\Timeline\Actions\CreateReply;
 use He4rt\Activity\Timeline\DTOs\CreateReplyDTO;
 use He4rt\Identity\User\Models\User;
 use Illuminate\View\View;
+use Livewire\Attributes\Computed;
 use Livewire\Attributes\Locked;
 use Livewire\Component;
 
@@ -79,6 +80,15 @@ final class ReplyComposer extends Component implements HasSchemas
 
         $this->form->fill();
         $this->dispatch('timeline.reply-created');
+    }
+
+    #[Computed]
+    public function avatarUrl(): ?string
+    {
+        /** @var User $user */
+        $user = auth()->user();
+
+        return $user->getFirstMediaUrl('avatar') ?: null;
     }
 
     public function render(): View

--- a/app-modules/panel-app/src/Livewire/Timeline/ThreadReplies.php
+++ b/app-modules/panel-app/src/Livewire/Timeline/ThreadReplies.php
@@ -43,7 +43,7 @@ final class ThreadReplies extends Component
     {
         $replies = Timeline::query()
             ->where('root_id', $this->timelineId)->whereNotNull('parent_id')
-            ->with(['user', 'postable'])
+            ->with(['user.media', 'postable'])
             ->oldest()
             ->simplePaginate($this->perPage);
 

--- a/app-modules/panel-app/tests/Feature/Timeline/ThreadPageTest.php
+++ b/app-modules/panel-app/tests/Feature/Timeline/ThreadPageTest.php
@@ -10,6 +10,8 @@ use He4rt\PanelApp\Livewire\Timeline\PostShow;
 use He4rt\PanelApp\Livewire\Timeline\ReplyComposer;
 use He4rt\PanelApp\Livewire\Timeline\ThreadReplies;
 use He4rt\PanelApp\Pages\ThreadPage;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
 
 use function Pest\Livewire\livewire;
 
@@ -75,6 +77,24 @@ test('thread replies shows all replies in chronological order', function (): voi
         ->assertSee('First reply')
         ->assertSee('Second reply')
         ->assertSeeInOrder(['First reply', 'Second reply']);
+});
+
+test('thread replies shows the author avatar when one exists', function (): void {
+    Storage::fake(config()->string('filesystems.default'));
+
+    $replier = User::factory()->create(['name' => 'Replier With Avatar']);
+    $replier->addMedia(UploadedFile::fake()->image('avatar.jpg'))->toMediaCollection('avatar');
+
+    $entry = PostEntry::factory()->create(['content' => 'Reply with avatar']);
+    Timeline::factory()->for($replier)->create([
+        'postable_type' => (new PostEntry)->getMorphClass(),
+        'postable_id' => $entry->id,
+        'root_id' => $this->rootPost->id,
+        'parent_id' => $this->rootPost->id,
+    ]);
+
+    livewire(ThreadReplies::class, ['timelineId' => $this->rootPost->id])
+        ->assertSee($replier->getFirstMediaUrl('avatar'), escape: false);
 });
 
 test('post renders without crashing when its author was deleted', function (): void {


### PR DESCRIPTION
## Descrição

Corrige a exibição do avatar nas threads. Antes, as respostas exibiam apenas as iniciais do usuário, mesmo quando ele possuía uma imagem de perfil cadastrada. Agora, o comportamento é o mesmo do feed, exibindo o avatar quando disponível e utilizando as iniciais apenas como fallback.

## Mudanças

* Exibe o avatar do autor nas respostas da thread, seguindo o mesmo padrão do feed.
* Exibe o avatar do usuário logado no composer de respostas.
* Adiciona eager loading de `user.media` nas replies para evitar consultas N+1.
* Adiciona testes para garantir a renderização correta do avatar nas replies.

## Como testar

1. Faça login com um usuário que tenha um avatar cadastrado.
2. Acesse uma thread que contenha respostas desse usuário.
3. Verifique que o avatar é exibido tanto nas respostas quanto ao lado do campo de resposta.

> **Nota (teste local):**
> O Spatie Media Library gera URLs absolutas a partir do `APP_URL`. Como o `php artisan serve` roda em `localhost:8000`, é necessário configurar:
>
> ```env
> APP_URL=http://localhost:8000
> ```
>
> Em seguida, limpe o cache de configuração:
>
> ```bash
> php artisan config:clear
> ```
>
> Sem isso, as URLs dos avatares apontam para a porta `80`, fazendo com que as imagens apareçam quebradas. Esse comportamento também afeta o feed e não é específico deste PR.
Closes #459 
