### PR TITLE
fix: remover opção de fixar post da timeline

### DIFF
--- a/app-modules/panel-app/resources/views/components/timeline/engagement.blade.php
+++ b/app-modules/panel-app/resources/views/components/timeline/engagement.blade.php
@@ -31,7 +31,7 @@
         </span>
     </div>
 
-    @if ($isOwner)
+    @if ($isOwner && config('he4rt.features.timeline_pin'))
         <button
             type="button"
             wire:click="togglePin"

--- a/app-modules/panel-app/resources/views/components/timeline/header.blade.php
+++ b/app-modules/panel-app/resources/views/components/timeline/header.blade.php
@@ -32,7 +32,7 @@
         </div>
     </div>
 
-    @if ($pinned)
+    @if ($pinned && config('he4rt.features.timeline_pin'))
         <div class="flex shrink-0 items-center gap-1 text-xs text-amber-500">
             <x-heroicon-s-map-pin class="h-3.5 w-3.5" />
             <span class="hidden sm:inline">Fixado</span>

--- a/app-modules/panel-app/src/Livewire/Timeline/PostShow.php
+++ b/app-modules/panel-app/src/Livewire/Timeline/PostShow.php
@@ -26,7 +26,7 @@ final class PostShow extends Component
 
     public function togglePin(#[CurrentUser] ?User $user): void
     {
-        if (!$user instanceof User) {
+        if (!config('he4rt.features.timeline_pin') || !$user instanceof User) {
             return;
         }
 

--- a/config/he4rt.php
+++ b/config/he4rt.php
@@ -11,6 +11,11 @@ return [
         'minimum_level_for_retro' => env('HE4RT_SEASON_MIN_LEVEL', 3),
     ],
     'server_key' => env('HE4RT_BOT_SECRET', 'he4rt'),
+
+    'features' => [
+        'timeline_pin' => env('HE4RT_FEATURE_TIMELINE_PIN', default: false),
+    ],
+
     'discord' => [
         'token' => env('DISCORD_TOKEN'),
         'voice_xp_interval' => (int) env('HE4RT_DISCORD_VOICE_XP_INTERVAL', 1_200),


### PR DESCRIPTION
## Contexto
Este PR implementa a solução da issue [461](https://github.com/he4rt/heartdevs.com/issues/461) e remove a opção de fixar post do feed da aplicação

## Descrição do problema
Atualmente existe a função de fixar disponível na timeline, porém ela pode ser utilizada por qualquer usuário e não possui um propósito concreto definido. Como não há uma funcionalidade real por trás dessa ação, ela acaba disponível sem trazer valor claro e pode gerar confusão no uso. A sugestão é desativar essa função até que exista uma proposta concreta e bem definida para ela.

Alterações
- Adicionado feature flag com o valor **false** como default para desabilitar a função de fixar
- Desabilita do engament.blade.php a opção de fixar/desfixar

## ANTES
<img width="1206" height="191" alt="image" src="https://github.com/user-attachments/assets/b93b0da4-de84-4109-9e44-57ec33606c97" />


## DEPOIS
<img width="1158" height="614" alt="image" src="https://github.com/user-attachments/assets/26515963-b63e-4aeb-91cc-157a27d9eadc" />


## Issue relacionada
Closes https://github.com/he4rt/heartdevs.com/issues/461