### PR TITLE
fix: ajustar opções da navbar em dispositivos mobile

### DIFF
--- a/app-modules/portal/resources/views/components/navbar.blade.php
+++ b/app-modules/portal/resources/views/components/navbar.blade.php
@@ -174,7 +174,7 @@
         </nav>
 
         {{-- CTAs full-width --}}
-        <div class="flex flex-col gap-3 border-zinc-950/10 pt-6 dark:border-white/10">
+        <div class="flex flex-col gap-3 border-t border-zinc-950/10 pt-6 dark:border-white/10">
             <x-he4rt::button
                 :href="route('social-links', absolute: false)"
                 variant="outline"

--- a/app-modules/portal/resources/views/components/navbar.blade.php
+++ b/app-modules/portal/resources/views/components/navbar.blade.php
@@ -174,7 +174,7 @@
         </nav>
 
         {{-- CTAs full-width --}}
-        <div class="mt-auto flex flex-col gap-3 border-t border-zinc-950/10 pt-6 dark:border-white/10">
+        <div class="flex flex-col gap-3 border-zinc-950/10 pt-6 dark:border-white/10">
             <x-he4rt::button
                 :href="route('social-links', absolute: false)"
                 variant="outline"


### PR DESCRIPTION
## Summary

No layout mobile, o menu de navegação está posicionado na parte inferior da tela, o que reduz sua visibilidade e dificulta o acesso aos principais recursos da plataforma.

Esta alteração reposiciona o menu para uma área mais visível e reorganiza seus itens para destacar as funcionalidades de maior importância. A nova ordem de exibição passa a ser:

1. Loja
2. Entrar no Discord
3. Área do Usuário
4. Redes Sociais

O objetivo é melhorar a usabilidade da navegação em dispositivos móveis, tornando o acesso às principais ações mais intuitivo.

### Alterações

- Alterado o arquivo navbar.blade.php removendo margin-auto para os links exibirem no topo.

## Plano de Testes

- [x] Acessar a aplicação em um dispositivo mobile ou utilizando o modo responsivo do navegador.
- [x] Verificar se o menu de navegação é exibido na parte superior da tela.
- [x] Confirmar o menu inicia na superior e não mais na inferior na seguinte ordem:
  - Loja
  - Entrar no Discord
  - Área do Usuário
  - Redes Sociais
- [x] Validar que todos os links permanecem funcionando corretamente após a reorganização.
---

## Evidências (Adicione o comportamento anterior, como prints de tela ou GIFs.)

### Antes
<img width="450" height="768" alt="image" src="https://github.com/user-attachments/assets/679e47f0-54d9-4068-a463-cfd820032462" />

### Depois (Opcional)
<img width="451" height="766" alt="image" src="https://github.com/user-attachments/assets/601ffe43-2268-4870-a1c1-ab0f21912588" />


## Issues Relacionadas

Closes [#464](https://github.com/he4rt/heartdevs.com/issues/464)