### PR TITLE
chore(makefile): conserta os targets de qualidade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,15 +10,11 @@ route-list: ## List all registered routes
 
 .PHONY: pint
 pint: ## Run Pint code style fixer
-	@export XDEBUG_MODE=off
-	@$(CURDIR)/vendor/bin/pint --parallel
-	@unset XDEBUG_MODE
+	@XDEBUG_MODE=off $(CURDIR)/vendor/bin/pint --parallel
 
 .PHONY: test-pint
 test-pint: ## Run Pint code style fixer in test mode
-	@export XDEBUG_MODE=off
-	@$(CURDIR)/vendor/bin/pint --test --parallel
-	@unset XDEBUG_MODE=off
+	@XDEBUG_MODE=off $(CURDIR)/vendor/bin/pint --test --parallel
 
 .PHONY: rector
 rector: ## Run Rector
@@ -37,7 +33,7 @@ p: phpstan ## Alias for phpstan
 
 .PHONY: test-phpstan
 test-phpstan: ## Run PHPStan in test mode
-	@$(CURDIR)/vendor/bin/phpstan analyse --ansi
+	@$(CURDIR)/vendor/bin/phpstan analyse --ansi --memory-limit=2G
 
 .PHONY: format
 format: rector pint ## Run Pint and Rector and try to fixes the source code
@@ -76,7 +72,7 @@ env-up: ## Start the development environment
 	@docker compose --file docker-compose.yml up --detach
 
 .PHONY: env-down
-env-down: ## Start the development environment
+env-down: ## Stop the development environment (removes images and volumes)
 	@docker compose --file docker-compose.yml down --rmi all --volumes
 
 .PHONY: dev


### PR DESCRIPTION
Closes #471

`make check`, `make pint` e `make format` estavam quebrados. O `CLAUDE.md` manda rodar `make check` antes de commitar — quem segue a doc bate num erro que não é dele.

## O bug

```make
pint:
	@export XDEBUG_MODE=off      # morre aqui: não alcança a linha de baixo
	@$(CURDIR)/vendor/bin/pint --parallel
	@unset XDEBUG_MODE           # ← e esta linha mata o target
```

Cada linha de receita do make roda no **próprio shell**, então o `export` nunca teve efeito nenhum sobre o Pint. E o `unset` derruba o target: o make executa a linha direto, sem shell, e `unset` é builtin, não binário — `make: unset: No such file or directory` → `Error 1`.

Reproduzi isolado: acontece **mesmo com a sintaxe correta** (`unset XDEBUG_MODE`). O `=off` sobrando no `test-pint` era só o segundo erro na mesma linha, não a causa. Por isso `make pint` e `make format` caíam junto, não só o `test-pint`.

A variável agora vai inline no comando, que é onde ela precisa valer:

```make
test-pint:
	@XDEBUG_MODE=off $(CURDIR)/vendor/bin/pint --test --parallel
```

## Também neste PR

- **`test-phpstan` ganha `--memory-limit=2G`**, que o target `phpstan` já tinha. Sem ele o `make check` estoura os 128M padrão do PHP CLI e morre com fatal de memória — ou seja, `make check` tinha *dois* motivos independentes pra falhar.
- **Help do `env-down`** dizia "Start the development environment" (cópia do `env-up`).

## Por que o CI não pegou

Os workflows chamam `vendor/bin/pint`, `vendor/bin/phpstan` e `vendor/bin/pest` direto — nenhum passa pelo Makefile. O pipeline seguia verde com o gate local quebrado. Vale considerar se o CI deveria consumir os mesmos targets, pra não haver duas definições de "checar o projeto" que podem divergir de novo.

## Verificação

Todos exit 0, e nenhum arquivo tocado além do Makefile:

| | |
|---|---|
| `make check` | ✅ 0 |
| `make test-pint` | ✅ 0 |
| `make test-phpstan` | ✅ 0 |
| `make pint` | ✅ 0 |
| `make format` | ✅ 0 |

## Pergunta — `env-down` é destrutivo de propósito?

```make
@docker compose --file docker-compose.yml down --rmi all --volumes
```

`--volumes` apaga o banco de desenvolvimento e `--rmi all` remove as imagens. Quem digita `make env-down` esperando só parar os containers perde o Postgres local e paga o download/build de novo no próximo `env-up`.

Se for intencional, o help novo já avisa e tá resolvido. Se não for, eu proporia `env-down` = `down` puro e um `env-destroy` separado pro comportamento atual — mas não mudei nada aqui porque é decisão de vocês.
