### PR TITLE
Add scroll-to-top dispatch after profile update

### DIFF
--- a/app-modules/panel-app/src/Pages/ProfilePage.php
+++ b/app-modules/panel-app/src/Pages/ProfilePage.php
@@ -425,6 +425,8 @@ class ProfilePage extends Page
 
         resolve(SyncProfileSkills::class)->handle($profile, $this->repeaterToSkills($formData['skills'] ?? []));
 
+        $this->dispatch('scroll-to-top');
+
         $this->form->saveRelationships();
 
         Notification::make()


### PR DESCRIPTION
This pull request introduces a small user experience improvement to the profile save process. After saving the profile, the page will now automatically scroll to the top, ensuring users see any relevant notifications or messages.

* Added a call to dispatch the `scroll-to-top` event after saving profile skills in the `save` method of `ProfilePage.php`.