### PR TITLE
feat(onboarding): cadeia de pré-requisito Welcome => Squads (#351)

### DIFF
--- a/app-modules/onboarding/database/factories/OnboardingFactory.php
+++ b/app-modules/onboarding/database/factories/OnboardingFactory.php
@@ -25,4 +25,12 @@ final class OnboardingFactory extends Factory
             'paused_at' => null,
         ];
     }
+
+    public function completed(): static
+    {
+        return $this->state([
+            'status' => OnboardingStatus::Completed,
+            'completed_at' => now(),
+        ]);
+    }
 }

--- a/app-modules/onboarding/src/Actions/StartOnboarding.php
+++ b/app-modules/onboarding/src/Actions/StartOnboarding.php
@@ -5,19 +5,36 @@ declare(strict_types=1);
 namespace He4rt\Onboarding\Actions;
 
 use He4rt\Identity\User\Models\User;
+use He4rt\Onboarding\Contracts\OnboardingCompletionGate;
 use He4rt\Onboarding\Enums\OnboardingStatus;
 use He4rt\Onboarding\Enums\OnboardingStepStatus;
 use He4rt\Onboarding\Enums\OnboardingType;
+use He4rt\Onboarding\Exceptions\PrerequisiteNotMetException;
 use He4rt\Onboarding\Models\Onboarding;
 use Illuminate\Support\Facades\DB;
 
-final class StartOnboarding
+final readonly class StartOnboarding
 {
+    public function __construct(
+        private OnboardingCompletionGate $gate,
+    ) {}
+
     public function handle(User $user, OnboardingType $type): Onboarding
     {
         // Resolve o flow antes de qualquer escrita: tipo sem handler falha alto,
         // sem deixar um onboarding órfão (em vez de persistir um estado travado).
         $flow = $type->handler();
+
+        // Pré-requisitos inter-tipo (ex.: Squads exige Welcome concluído) são
+        // validados via gate antes de qualquer escrita.
+        foreach ($flow->prerequisites() as $prerequisite) {
+            throw_unless(
+                $this->gate->isCompleted($user, $prerequisite),
+                PrerequisiteNotMetException::class,
+                type: $type,
+                prerequisite: $prerequisite,
+            );
+        }
 
         return DB::transaction(static function () use ($user, $type, $flow): Onboarding {
             $onboarding = Onboarding::query()->firstOrCreate(

--- a/app-modules/onboarding/src/Exceptions/PrerequisiteNotMetException.php
+++ b/app-modules/onboarding/src/Exceptions/PrerequisiteNotMetException.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Onboarding\Exceptions;
+
+use He4rt\Onboarding\Enums\OnboardingType;
+use RuntimeException;
+
+final class PrerequisiteNotMetException extends RuntimeException
+{
+    public function __construct(
+        public readonly OnboardingType $type,
+        public readonly OnboardingType $prerequisite,
+    ) {
+        parent::__construct(sprintf(
+            'Onboarding [%s] bloqueado: pré-requisito [%s] não concluído.',
+            $type->value,
+            $prerequisite->value,
+        ));
+    }
+}

--- a/app-modules/onboarding/src/Flows/SquadsOnboardingFlow.php
+++ b/app-modules/onboarding/src/Flows/SquadsOnboardingFlow.php
@@ -10,6 +10,7 @@ use He4rt\Onboarding\Contracts\OnboardingStepDTO;
 use He4rt\Onboarding\DTOs\WelcomeFormDTO;
 use He4rt\Onboarding\Enums\OnboardingStatus;
 use He4rt\Onboarding\Enums\OnboardingStepStatus;
+use He4rt\Onboarding\Enums\OnboardingType;
 use He4rt\Onboarding\Exceptions\GateBlockedException;
 use He4rt\Onboarding\Models\Onboarding;
 use InvalidArgumentException;
@@ -29,10 +30,12 @@ final class SquadsOnboardingFlow implements OnboardingFlow
         };
     }
 
+    /**
+     * @return list<OnboardingType>
+     */
     public function prerequisites(): array
     {
-        // TO-DO: #351
-        return [];
+        return [OnboardingType::Welcome];
     }
 
     public function advance(Onboarding $onboarding): void

--- a/app-modules/onboarding/tests/Feature/OnboardingPrerequisiteChainTest.php
+++ b/app-modules/onboarding/tests/Feature/OnboardingPrerequisiteChainTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Identity\User\Models\User;
+use He4rt\Onboarding\Actions\StartOnboarding;
+use He4rt\Onboarding\Enums\OnboardingStatus;
+use He4rt\Onboarding\Enums\OnboardingType;
+use He4rt\Onboarding\Exceptions\PrerequisiteNotMetException;
+use He4rt\Onboarding\Models\Onboarding;
+
+test('starting Squads without a completed Welcome is blocked with the prerequisite as reason', function (): void {
+    $user = User::factory()->create();
+
+    expect(fn () => resolve(StartOnboarding::class)->handle($user, OnboardingType::Squads))
+        ->toThrow(function (PrerequisiteNotMetException $exception): void {
+            expect($exception->type)->toBe(OnboardingType::Squads)
+                ->and($exception->prerequisite)->toBe(OnboardingType::Welcome);
+        });
+
+    expect(Onboarding::query()->count())->toBe(0);
+});
+
+test('starting Squads with a Welcome still in progress is blocked', function (): void {
+    $user = User::factory()->create();
+    Onboarding::factory()->for($user)->create(['status' => OnboardingStatus::InProgress]);
+
+    expect(fn () => resolve(StartOnboarding::class)->handle($user, OnboardingType::Squads))
+        ->toThrow(PrerequisiteNotMetException::class);
+
+    expect(Onboarding::query()->where('type', OnboardingType::Squads)->exists())->toBeFalse();
+});
+
+test('a completed Welcome unlocks the Squads onboarding', function (): void {
+    $user = User::factory()->create();
+    Onboarding::factory()->for($user)->completed()->create();
+
+    $onboarding = resolve(StartOnboarding::class)->handle($user, OnboardingType::Squads);
+
+    expect($onboarding->exists)->toBeTrue()
+        ->and($onboarding->type)->toBe(OnboardingType::Squads)
+        ->and($onboarding->status)->toBe(OnboardingStatus::InProgress);
+});
+
+test('Welcome has no prerequisites and starts without any prior onboarding', function (): void {
+    $user = User::factory()->create();
+
+    expect(OnboardingType::Welcome->handler()->prerequisites())->toBeEmpty();
+
+    $onboarding = resolve(StartOnboarding::class)->handle($user, OnboardingType::Welcome);
+
+    expect($onboarding->status)->toBe(OnboardingStatus::InProgress);
+});

--- a/app-modules/onboarding/tests/Feature/SquadsOnboardingFlowTest.php
+++ b/app-modules/onboarding/tests/Feature/SquadsOnboardingFlowTest.php
@@ -11,17 +11,19 @@ use He4rt\Onboarding\Enums\OnboardingStepStatus;
 use He4rt\Onboarding\Enums\OnboardingType;
 use He4rt\Onboarding\Exceptions\GateBlockedException;
 use He4rt\Onboarding\Flows\SquadsOnboardingFlow;
+use He4rt\Onboarding\Models\Onboarding;
 
 test('Squads resolves its flow and declares its steps', function (): void {
     $flow = OnboardingType::Squads->handler();
 
     expect($flow)->toBeInstanceOf(SquadsOnboardingFlow::class)
         ->and($flow->steps())->toBe(['form', 'git_challenge'])
-        ->and($flow->prerequisites())->toBeEmpty();
+        ->and($flow->prerequisites())->toBe([OnboardingType::Welcome]);
 });
 
 test('starting Squads creates an in-progress onboarding with a pending form step', function (): void {
     $user = User::factory()->create();
+    Onboarding::factory()->for($user)->completed()->create();
 
     $onboarding = resolve(StartOnboarding::class)->handle(
         $user,
@@ -41,8 +43,11 @@ test('starting Squads creates an in-progress onboarding with a pending form step
 });
 
 test('advancing the form step leaves the Squads onboarding in progress', function (): void {
+    $user = User::factory()->create();
+    Onboarding::factory()->for($user)->completed()->create();
+
     $onboarding = resolve(StartOnboarding::class)->handle(
-        User::factory()->create(),
+        $user,
         OnboardingType::Squads,
     );
 
@@ -61,6 +66,8 @@ test('advancing the form step leaves the Squads onboarding in progress', functio
 
 test('gate blocks git_challenge when github is not linked', function (): void {
     $user = User::factory()->create();
+    Onboarding::factory()->for($user)->completed()->create();
+
     $onboarding = resolve(StartOnboarding::class)->handle(
         $user,
         OnboardingType::Squads,
@@ -79,6 +86,8 @@ test('gate blocks git_challenge when github is not linked', function (): void {
 
 test('gate allows git_challenge when github is linked', function (): void {
     $user = User::factory()->create();
+    Onboarding::factory()->for($user)->completed()->create();
+
     $onboarding = resolve(StartOnboarding::class)->handle($user, OnboardingType::Squads);
 
     // Vincula GitHub


### PR DESCRIPTION
## Contexto

O onboarding `Squads` (APTO) não pode ser iniciado por quem ainda não concluiu o onboarding `Welcome` — essa é a cadeia de pré-requisito inter-tipo prevista no PRD (#341). Até então, `SquadsOnboardingFlow::prerequisites()` retornava `[]` (com um `TO-DO: #351`) e o `StartOnboarding` não validava nada, permitindo iniciar o Squads sem o Welcome concluído.

Este PR implementa a cadeia: o flow do Squads declara `[Welcome]` como pré-requisito e o `StartOnboarding` valida cada pré-requisito através do gate público `OnboardingCompletionGate::isCompleted()` (#349) **antes de qualquer escrita**. Quando o pré-requisito não está `completed`, o início é bloqueado com uma `PrerequisiteNotMetException` que carrega o tipo bloqueado e o pré-requisito faltante como motivo — nenhum onboarding órfão é persistido.

### Alterações

- `src/Flows/SquadsOnboardingFlow.php` — `prerequisites()` passa a retornar `[OnboardingType::Welcome]`.
- `src/Actions/StartOnboarding.php` — recebe o `OnboardingCompletionGate` por injeção e valida os pré-requisitos do flow antes da transação; classe agora é `final readonly`.
- `src/Exceptions/PrerequisiteNotMetException.php` — **nova** exception com `type` e `prerequisite` públicos (o motivo do bloqueio), no mesmo estilo da `GateBlockedException`.
- `database/factories/OnboardingFactory.php` — novo state `completed()` para os testes.
- `tests/Feature/OnboardingPrerequisiteChainTest.php` — **novo** teste cobrindo os cenários BDD da issue: Squads sem Welcome é bloqueado com o motivo (inclusive com Welcome apenas `in_progress`), Welcome concluído destrava o Squads, e Welcome segue sem pré-requisitos.
- `tests/Feature/SquadsOnboardingFlowTest.php` — atualizado: `prerequisites()` agora esperado como `[Welcome]` e os testes que iniciam Squads concluem o Welcome antes.

### Critérios de aceite

- [x] `prerequisites()` do Squads = `[Welcome]`
- [x] Iniciar Squads sem Welcome concluído é bloqueado com motivo
- [x] Iniciar Squads com Welcome concluído funciona
- [x] Teste da cadeia

---

## Plano de Testes

- [x] Executar `make check` (Rector, Pint e PHPStan passando)
- [x] Executar `make test` — módulo onboarding: 35/35 testes passando
- [x] Suíte completa: 949/951 — as 2 falhas são em `MergeDuplicateDiscordProfilesTest` (módulo `integration-discord`) e **pré-existentes**: reproduzem de forma idêntica na base `feat/squads` (`8ab4cce0`) sem este commit. Este PR toca apenas `app-modules/onboarding`, sem código compartilhado com esse teste
- [ ] Revisor: conferir que os cenários BDD da issue #351 correspondem aos testes de OnboardingPrerequisiteChainTest"

---

## Issues Relacionadas

Closes #351
Related to #341
