### PR TITLE
fix(panel): corrigir contraste da logo no login em dark mode

### DIFF
--- a/app-modules/panel-app/resources/views/auth/login.blade.php
+++ b/app-modules/panel-app/resources/views/auth/login.blade.php
@@ -72,7 +72,7 @@
                     <img
                         src="{{ asset('images/logo.svg') }}"
                         alt="He4rt Developers"
-                        class="h-12 w-auto text-purple-500"
+                        class="h-12 w-auto dark:brightness-0 dark:invert"
                     />
                 </div>
 


### PR DESCRIPTION
## Contexto

No login do painel (`/app/login`), a logo mobile da He4rt ficava preta sobre fundo escuro no dark mode, com contraste baixo e quase invisível. Isso acontecia porque o SVG é carregado via `<img>` com `fill="currentColor"`, e classes como `text-purple-500` não alteram a cor nesse caso.

A alteração aplica filtro CSS apenas no dark mode (`dark:brightness-0 dark:invert`), tornando a logo branca no dark e mantendo a preta no light. O impacto esperado é melhorar a legibilidade da marca na tela de login sem mudar o comportamento no tema claro.

### Alterações

- Ajuste da classe CSS da logo mobile em `app-modules/panel-app/resources/views/auth/login.blade.php`
- Troca de `text-purple-500` por `dark:brightness-0 dark:invert`
- Light mode preservado; dark mode passa a exibir a logo com contraste adequado

---

## Plano de Testes

- [ ] Executar `make check`
- [ ] Executar `make test`
- [ ] Abrir `/app/login` em viewport mobile (< `lg`) no **dark mode** e confirmar que a logo fica visível (branca)
- [ ] Abrir `/app/login` em viewport mobile (< `lg`) no **light mode** e confirmar que a logo preta original permanece
- [ ] Confirmar no desktop (`lg+`) que o painel esquerdo com a logo branca não foi alterado

---

## Evidências

### Antes

<img width="940" height="946" alt="image" src="https://github.com/user-attachments/assets/05fe5557-3eb3-466c-ac98-cde54594aa8e" />

### Depois

<img width="667" height="837" alt="image" src="https://github.com/user-attachments/assets/adc125f3-c971-457a-8885-57c854745d4c" />

---

## Issues Relacionadas

Fixes #468