### PR TITLE
fix(marketing): corrige participantes ausentes no Meeting Showcase

### DIFF
--- a/app-modules/panel-admin/src/Marketing/Pages/MeetingShowcasePage.php
+++ b/app-modules/panel-admin/src/Marketing/Pages/MeetingShowcasePage.php
@@ -58,7 +58,7 @@ class MeetingShowcasePage extends Page
 
         $tz = config('app.display_timezone');
         $start = Date::parse($this->startDate, $tz)->utc();
-        $end = Date::parse($this->endDate, $tz)->utc();
+        $end = Date::parse($this->endDate, $tz)->endOfMinute()->utc();
 
         /** @var Collection<int, Message> $messageStats */
         $messageStats = Message::query()
@@ -73,6 +73,8 @@ class MeetingShowcasePage extends Page
         $identityIds = $messageStats->pluck('external_identity_id');
 
         $identities = ExternalIdentity::query()
+            ->withTrashed()
+            ->with('user')
             ->whereIn('id', $identityIds)
             ->get()
             ->keyBy('id');
@@ -102,24 +104,17 @@ class MeetingShowcasePage extends Page
         }
 
         $metadata = $identity->metadata ?? [];
+        $discordUser = $metadata['user'] ?? $metadata['author'] ?? [];
 
-        $username = $metadata['username'] ?? null;
-        $avatar = $metadata['avatar'] ?? null;
-        $globalName = $metadata['global_name'] ?? null;
-
-        if (isset($metadata['user'])) {
-            $discordUser = $metadata['user'];
-            $username ??= $discordUser['username'] ?? null;
-            $globalName ??= $discordUser['global_name'] ?? null;
-
-            if (!$avatar && isset($discordUser['avatar'])) {
-                $avatar = sprintf(
-                    'https://cdn.discordapp.com/avatars/%s/%s.png?size=128',
-                    $identity->external_account_id,
-                    $discordUser['avatar'],
-                );
-            }
+        if (!is_array($discordUser)) {
+            $discordUser = [];
         }
+
+        $linkedUser = $identity->user;
+
+        $username = $metadata['username'] ?? $discordUser['username'] ?? $linkedUser?->username;
+        $avatar = $metadata['avatar'] ?? $discordUser['avatar'] ?? null;
+        $globalName = $metadata['global_name'] ?? $discordUser['global_name'] ?? $linkedUser?->name;
 
         if ($avatar && !str_starts_with((string) $avatar, 'http')) {
             $avatar = sprintf(

--- a/app-modules/panel-admin/tests/Feature/Marketing/MeetingShowcasePageTest.php
+++ b/app-modules/panel-admin/tests/Feature/Marketing/MeetingShowcasePageTest.php
@@ -56,6 +56,14 @@ test('it loads Discord participant data from every supported metadata shape', fu
             'channel_id' => 'meeting-channel',
             'sent_at' => Date::parse('2026-08-03 22:30:00', 'America/Sao_Paulo')->utc(),
         ]);
+
+        if ((string) $accountId === '111') {
+            Message::factory()->create([
+                'external_identity_id' => $identity->id,
+                'channel_id' => 'meeting-channel',
+                'sent_at' => Date::parse('2026-08-03 22:31:00', 'America/Sao_Paulo')->utc(),
+            ]);
+        }
     }
 
     $linkedUser = User::factory()->create([
@@ -111,6 +119,7 @@ test('it loads Discord participant data from every supported metadata shape', fu
             'username' => 'root-user',
             'global_name' => 'Root User',
             'avatar_url' => 'https://cdn.example.com/root.png',
+            'total_messages' => 2,
         ])
         ->and($participantsByAccount->get('222'))->toMatchArray([
             'username' => 'profile-user',

--- a/app-modules/panel-admin/tests/Feature/Marketing/MeetingShowcasePageTest.php
+++ b/app-modules/panel-admin/tests/Feature/Marketing/MeetingShowcasePageTest.php
@@ -153,3 +153,25 @@ test('it includes messages sent during the selected end minute', function (): vo
         ->assertSet('loaded', value: true)
         ->assertSet('participants.0.username', 'last-minute-user');
 });
+
+test('it excludes messages sent after the selected end minute', function (): void {
+    $identity = ExternalIdentity::factory()->create([
+        'provider' => IdentityProvider::Discord,
+        'external_account_id' => '445',
+        'metadata' => ['username' => 'too-late-user'],
+    ]);
+
+    Message::factory()->create([
+        'external_identity_id' => $identity->id,
+        'channel_id' => 'meeting-channel',
+        'sent_at' => Date::parse('2026-08-03 23:41:00', 'America/Sao_Paulo')->utc(),
+    ]);
+
+    livewire(MeetingShowcasePage::class)
+        ->set('channelId', 'meeting-channel')
+        ->set('startDate', '2026-08-03T22:00')
+        ->set('endDate', '2026-08-03T23:40')
+        ->call('loadParticipants')
+        ->assertSet('loaded', value: true)
+        ->assertSet('participants', []);
+});

--- a/app-modules/panel-admin/tests/Feature/Marketing/MeetingShowcasePageTest.php
+++ b/app-modules/panel-admin/tests/Feature/Marketing/MeetingShowcasePageTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Facades\Filament;
+use He4rt\Activity\Message\Models\Message;
+use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
+use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
+use He4rt\Identity\User\Models\User;
+use He4rt\PanelAdmin\Marketing\Pages\MeetingShowcasePage;
+use Illuminate\Support\Facades\Date;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(function (): void {
+    config(['app.display_timezone' => 'America/Sao_Paulo']);
+
+    $admin = User::factory()->create();
+
+    $this->actingAs($admin);
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+});
+
+test('it loads Discord participant data from every supported metadata shape', function (): void {
+    $metadataByAccount = [
+        '111' => [
+            'username' => 'root-user',
+            'global_name' => 'Root User',
+            'avatar' => 'https://cdn.example.com/root.png',
+        ],
+        '222' => [
+            'user' => [
+                'username' => 'profile-user',
+                'global_name' => 'Profile User',
+                'avatar' => 'profile-avatar',
+            ],
+        ],
+        '333' => [
+            'author' => [
+                'username' => 'message-user',
+                'global_name' => 'Message User',
+                'avatar' => 'message-avatar',
+            ],
+        ],
+    ];
+
+    foreach ($metadataByAccount as $accountId => $metadata) {
+        $identity = ExternalIdentity::factory()->create([
+            'provider' => IdentityProvider::Discord,
+            'external_account_id' => $accountId,
+            'metadata' => $metadata,
+        ]);
+
+        Message::factory()->create([
+            'external_identity_id' => $identity->id,
+            'channel_id' => 'meeting-channel',
+            'sent_at' => Date::parse('2026-08-03 22:30:00', 'America/Sao_Paulo')->utc(),
+        ]);
+    }
+
+    $linkedUser = User::factory()->create([
+        'username' => 'linked-user',
+        'name' => 'Linked User',
+    ]);
+
+    $identityWithoutMetadata = ExternalIdentity::factory()->create([
+        'model_id' => $linkedUser->id,
+        'provider' => IdentityProvider::Discord,
+        'external_account_id' => '444',
+        'metadata' => [],
+    ]);
+
+    Message::factory()->create([
+        'external_identity_id' => $identityWithoutMetadata->id,
+        'channel_id' => 'meeting-channel',
+        'sent_at' => Date::parse('2026-08-03 22:45:00', 'America/Sao_Paulo')->utc(),
+    ]);
+
+    $disconnectedIdentity = ExternalIdentity::factory()->create([
+        'provider' => IdentityProvider::Discord,
+        'external_account_id' => '555',
+        'metadata' => [
+            'author' => [
+                'username' => 'disconnected-user',
+                'global_name' => 'Disconnected User',
+            ],
+        ],
+    ]);
+
+    Message::factory()->create([
+        'external_identity_id' => $disconnectedIdentity->id,
+        'channel_id' => 'meeting-channel',
+        'sent_at' => Date::parse('2026-08-03 23:00:00', 'America/Sao_Paulo')->utc(),
+    ]);
+
+    $disconnectedIdentity->delete();
+
+    $component = livewire(MeetingShowcasePage::class)
+        ->set('channelId', 'meeting-channel')
+        ->set('startDate', '2026-08-03T22:00')
+        ->set('endDate', '2026-08-03T23:40')
+        ->call('loadParticipants')
+        ->assertSet('loaded', value: true);
+
+    /** @var array<int, array{discord_id: string|null, username: string, global_name: string, avatar_url: string|null, total_messages: int}> $participants */
+    $participants = $component->get('participants');
+    $participantsByAccount = collect($participants)->keyBy('discord_id');
+
+    expect($participants)->toHaveCount(5)
+        ->and($participantsByAccount->get('111'))->toMatchArray([
+            'username' => 'root-user',
+            'global_name' => 'Root User',
+            'avatar_url' => 'https://cdn.example.com/root.png',
+        ])
+        ->and($participantsByAccount->get('222'))->toMatchArray([
+            'username' => 'profile-user',
+            'global_name' => 'Profile User',
+            'avatar_url' => 'https://cdn.discordapp.com/avatars/222/profile-avatar.png?size=128',
+        ])
+        ->and($participantsByAccount->get('333'))->toMatchArray([
+            'username' => 'message-user',
+            'global_name' => 'Message User',
+            'avatar_url' => 'https://cdn.discordapp.com/avatars/333/message-avatar.png?size=128',
+        ])
+        ->and($participantsByAccount->get('444'))->toMatchArray([
+            'username' => 'linked-user',
+            'global_name' => 'Linked User',
+        ])
+        ->and($participantsByAccount->get('555'))->toMatchArray([
+            'username' => 'disconnected-user',
+            'global_name' => 'Disconnected User',
+        ]);
+});
+
+test('it includes messages sent during the selected end minute', function (): void {
+    $identity = ExternalIdentity::factory()->create([
+        'provider' => IdentityProvider::Discord,
+        'external_account_id' => '444',
+        'metadata' => ['username' => 'last-minute-user'],
+    ]);
+
+    Message::factory()->create([
+        'external_identity_id' => $identity->id,
+        'channel_id' => 'meeting-channel',
+        'sent_at' => Date::parse('2026-08-03 23:40:59', 'America/Sao_Paulo')->utc(),
+    ]);
+
+    livewire(MeetingShowcasePage::class)
+        ->set('channelId', 'meeting-channel')
+        ->set('startDate', '2026-08-03T22:00')
+        ->set('endDate', '2026-08-03T23:40')
+        ->call('loadParticipants')
+        ->assertSet('loaded', value: true)
+        ->assertSet('participants.0.username', 'last-minute-user');
+});


### PR DESCRIPTION
## Contexto

O Meeting Showcase podia encontrar a mensagem no período informado e ainda assim não identificar corretamente o participante. Isso acontecia porque os dados do Discord chegam em formatos diferentes e a tela só tratava parte deles.

Também existia um corte no último minuto escolhido. Ao informar 23:40 como horário final, por exemplo, mensagens enviadas depois de 23:40:00 ficavam fora da consulta.

Este PR corrige a leitura e exibição dos participantes que já foram ingeridos. O fluxo de ingestão das mensagens não foi alterado.

### Alterações

- Suporte aos formatos de metadata na raiz, em `metadata.user` e em `metadata.author`
- Fallback para o usuário vinculado quando a identidade não possui metadata suficiente
- Inclusão de identidades desconectadas que ainda possuem mensagens históricas
- Inclusão de todo o último minuto selecionado no filtro de período
- Testes cobrindo os formatos de metadata, fallback de usuário, identidade desconectada e mensagens dentro e fora do limite final

---

## Plano de Testes

- [x] Rector nos arquivos alterados sem sugestões
- [x] Pint completo aprovado
- [x] PHPStan completo sem erros
- [x] Testes de Marketing com 8 testes e 69 assertions
- [x] Teste da importação de `metadata.author` com 1 teste e 4 assertions
- [x] Testes da persistência de mensagens com 3 testes e 9 assertions
- [x] Validação local da tela com participantes nos diferentes formatos de metadata

A suíte completa local executou 933 testes. Foram 931 aprovados e 2 falhas preexistentes em `MergeDuplicateDiscordProfilesTest`, causadas pelo tratamento de caminho absoluto do Windows no parâmetro `--pairs-file`. Esses testes ficam fora dos arquivos e do fluxo alterado neste PR. O CI em Linux fará a validação completa novamente.

---

## Issues Relacionadas

Closes #477