### PR TITLE
fix(login): ajustar background e texto para systemas com light theme

### DIFF
--- a/app-modules/panel-app/resources/views/auth/login.blade.php
+++ b/app-modules/panel-app/resources/views/auth/login.blade.php
@@ -76,7 +76,7 @@
                     />
                 </div>
 
-                <h2 class="mb-1 text-xl font-semibold text-white">Entrar</h2>
+                <h2 class="mb-1 text-xl font-semibold dark:text-white text-dark">Entrar</h2>
                 <p class="mb-6 text-sm text-zinc-400">Acesse sua conta He4rt Developers</p>
 
                 {{-- OAuth --}}
@@ -146,7 +146,7 @@
                         <div class="w-full border-t border-zinc-800"></div>
                     </div>
                     <div class="relative flex justify-center text-xs uppercase">
-                        <span class="bg-gray-950 px-3 text-zinc-500">ou</span>
+                        <span class="bg-white px-3 text-zinc-500 dark:bg-gray-950 dark:text-zinc-400">ou</span>
                     </div>
                 </div>
 


### PR DESCRIPTION
## Contexto
Esta alteração visa corrigir a omissão do texto "Entrar" na tela de login para usuários que usam light theme. Foi aplicado suporte para o texto ser visivél tanto em light/dark theme


### Alterações
- O login.blade.php foi alterado garantindo suporte para os dois temas.
- Ajustado background para o span "ou" que também não estava de acordo para usuários light theme


## Plano de Testes
- [x]  Executar `make check`
- [x] Executar `make test`
- [x] Abrir /app/login usando light theme e confirmar que o texto "Entrar" é exibido

## Evidências

### Antes
<img width="1919" height="964" alt="image" src="https://github.com/user-attachments/assets/e940a6f0-f24d-4176-a59f-28b4a0742055" />

### Depois
<img width="1919" height="959" alt="image" src="https://github.com/user-attachments/assets/3c94bef6-0825-4808-878f-d4e515549b15" />


## Issues Relacionadas
Fixes #480
