### PR TITLE
feat(onboarding): conclusão do git_challenge libera o gate APTO (#352)

### DIFF
--- a/app-modules/onboarding/src/DTOs/GitChallengeDTO.php
+++ b/app-modules/onboarding/src/DTOs/GitChallengeDTO.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Onboarding\DTOs;
+
+use He4rt\Onboarding\Contracts\OnboardingStepDTO;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
+
+/**
+ * Payload da conclusão do desafio do Git.
+ *
+ * TODO: #353 aperta o contrato com os campos do PR aprovado
+ * (repo, pr_number, approved_at) quando o evento GithubPullRequestApproved existir.
+ */
+final readonly class GitChallengeDTO implements OnboardingStepDTO
+{
+    /**
+     * @param  array<array-key, mixed>  $data
+     */
+    public function __construct(
+        public array $data = [],
+    ) {}
+
+    /**
+     * @throws ValidationException
+     */
+    public function validate(array $payload): static
+    {
+        $validated = Validator::make($payload, [
+            'data' => ['sometimes', 'array'],
+        ])->validate();
+
+        $data = $validated['data'] ?? [];
+
+        return new self(
+            data: is_array($data) ? $data : [],
+        );
+    }
+
+    /**
+     * @return array<array-key, mixed>
+     */
+    public function toArray(): array
+    {
+        return $this->data;
+    }
+}

--- a/app-modules/onboarding/src/Flows/SquadsOnboardingFlow.php
+++ b/app-modules/onboarding/src/Flows/SquadsOnboardingFlow.php
@@ -7,6 +7,7 @@ namespace He4rt\Onboarding\Flows;
 use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
 use He4rt\Onboarding\Contracts\OnboardingFlow;
 use He4rt\Onboarding\Contracts\OnboardingStepDTO;
+use He4rt\Onboarding\DTOs\GitChallengeDTO;
 use He4rt\Onboarding\DTOs\WelcomeFormDTO;
 use He4rt\Onboarding\Enums\OnboardingStatus;
 use He4rt\Onboarding\Enums\OnboardingStepStatus;
@@ -26,6 +27,7 @@ final class SquadsOnboardingFlow implements OnboardingFlow
     {
         return match ($stepKey) {
             'form' => new WelcomeFormDTO(),
+            'git_challenge' => new GitChallengeDTO(),
             default => throw new InvalidArgumentException('Step não suportado: '.$stepKey),
         };
     }

--- a/app-modules/onboarding/tests/Feature/SquadsOnboardingFlowTest.php
+++ b/app-modules/onboarding/tests/Feature/SquadsOnboardingFlowTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
 use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
 use He4rt\Identity\User\Models\User;
+use He4rt\Onboarding\Actions\AdvanceStep;
 use He4rt\Onboarding\Actions\StartOnboarding;
+use He4rt\Onboarding\Contracts\OnboardingCompletionGate;
 use He4rt\Onboarding\Enums\OnboardingStatus;
 use He4rt\Onboarding\Enums\OnboardingStepStatus;
 use He4rt\Onboarding\Enums\OnboardingType;
@@ -108,4 +110,57 @@ test('gate allows git_challenge when github is linked', function (): void {
     $step = $onboarding->steps()->where('step_key', 'git_challenge')->sole();
 
     expect($step->status)->toBe(OnboardingStepStatus::Pending);
+});
+
+test('concluding git_challenge completes the Squads onboarding and opens the APTO gate', function (): void {
+    $user = User::factory()->create();
+    Onboarding::factory()->for($user)->completed()->create();
+
+    ExternalIdentity::factory()->create([
+        'model_type' => $user->getMorphClass(),
+        'model_id' => $user->id,
+        'provider' => IdentityProvider::GitHub,
+        'connected_at' => now(),
+        'disconnected_at' => null,
+    ]);
+
+    $onboarding = resolve(StartOnboarding::class)->handle($user, OnboardingType::Squads);
+
+    resolve(AdvanceStep::class)->handle($onboarding, ['data' => ['terms' => true]]);
+
+    resolve(AdvanceStep::class)->handle($onboarding, []);
+
+    $onboarding->refresh();
+    $step = $onboarding->steps()->where('step_key', 'git_challenge')->sole();
+
+    expect($step->status)->toBe(OnboardingStepStatus::Done)
+        ->and($step->completed_at)->not->toBeNull()
+        ->and($onboarding->status)->toBe(OnboardingStatus::Completed)
+        ->and($onboarding->completed_at)->not->toBeNull()
+        ->and(resolve(OnboardingCompletionGate::class)->isCompleted($user, OnboardingType::Squads))
+        ->toBeTrue();
+});
+
+test('the form step alone does not make the user APTO', function (): void {
+    $user = User::factory()->create();
+    Onboarding::factory()->for($user)->completed()->create();
+
+    ExternalIdentity::factory()->create([
+        'model_type' => $user->getMorphClass(),
+        'model_id' => $user->id,
+        'provider' => IdentityProvider::GitHub,
+        'connected_at' => now(),
+        'disconnected_at' => null,
+    ]);
+
+    $onboarding = resolve(StartOnboarding::class)->handle($user, OnboardingType::Squads);
+
+    resolve(AdvanceStep::class)->handle($onboarding, ['data' => ['terms' => true]]);
+
+    $onboarding->refresh();
+
+    expect($onboarding->status)->toBe(OnboardingStatus::InProgress)
+        ->and($onboarding->completed_at)->toBeNull()
+        ->and(resolve(OnboardingCompletionGate::class)->isCompleted($user, OnboardingType::Squads))
+        ->toBeFalse();
 });


### PR DESCRIPTION
## Contexto

O step `git_challenge` já estava declarado no `SquadsOnboardingFlow` desde a #348, e o gate de GitHub vinculado entrou na #350. Só que ninguém conseguia concluir esse step: o `stepDto()` só conhecia o `form` e caía no `default => throw`, então qualquer tentativa de avançar pelo `AdvanceStep` morria com `InvalidArgumentException: Step não suportado: git_challenge`.

Este PR fecha essa ponta. Com o DTO no lugar, concluir o desafio marca o step como `done`, o `isComplete()` passa a ser verdadeiro, o onboarding Squads vira `completed` e o gate `isCompleted($user, Squads)` começa a devolver true, que é o que o domínio chama de **APTO**.

Vale dizer o que este PR **não** faz: a ligação automática com a aprovação do PR no GitHub é a #353. Aqui a conclusão acontece por avanço manual, via action interna.

Sobre o payload: o `GitChallengeDTO` aceita `data` opcional. O `git_challenge` não tem formulário pra preencher, quem conclui é um humano dizendo que aprovou, então exigir payload obrigatório travaria justamente o avanço manual que a issue pede. Quando a #353 trouxer o evento `GithubPullRequestApproved`, ela aperta esse contrato com os campos reais do PR.

Um detalhe pra quem for revisar: o critério de aceite da issue fala em `isCompleted(user, tenant, Squads)`, mas o gate entregue na #349 é `isCompleted(User, OnboardingType)` e a tabela `onboardings` não tem `tenant_id`. Segui o código, não o texto.

### Alterações

- `src/DTOs/GitChallengeDTO.php`: novo DTO do payload do desafio, seguindo a mesma forma do `WelcomeFormDTO`, com `data` opcional
- `src/Flows/SquadsOnboardingFlow.php`: registra o DTO no `match` do `stepDto()`
- `tests/Feature/SquadsOnboardingFlowTest.php`: dois cenários novos, concluindo pelo `AdvanceStep`

---

## Plano de Testes

- [x] Executar `make check` (rector, pint e phpstan sem erro)
- [x] Executar `make test` (959 testes, 3043 asserções, tudo verde)
- [x] Concluir o `git_challenge` pelo `AdvanceStep` e conferir step `done` + `completed_at` preenchido
- [x] Conferir que o onboarding Squads vai pra `completed` e o gate passa a devolver APTO
- [x] Conferir que só o `form` concluído não torna ninguém APTO

---

## Issues Relacionadas

Closes #352
Related to #341
Related to #353
