### PR TITLE
fix(profile): adicionar validação de handler para social links

### DIFF
--- a/app-modules/panel-app/resources/views/components/profile-preview-card.blade.php
+++ b/app-modules/panel-app/resources/views/components/profile-preview-card.blade.php
@@ -252,7 +252,7 @@
                             rel="noopener noreferrer"
                             class="inline-flex items-center gap-1 text-xs font-medium text-purple-600 hover:text-purple-800 dark:text-purple-400 dark:hover:text-purple-200 transition-colors"
                         >
-                            <x-dynamic-component :component="'heroicon-m-'.\Illuminate\Support\Str::kebab($platform->getIcon()->name)" class="h-3.5 w-3.5 shrink-0" />
+                            <x-filament::icon :icon="$platform->getBrandIcon()" class="h-3.5 w-3.5 shrink-0" />
                             {{ $platform->getLabel() }}
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 12" class="h-3 w-3 shrink-0" fill="none" stroke="currentColor" stroke-width="1.5">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M2.5 9.5 9.5 2.5M5 2.5h4.5V7" />

--- a/app-modules/panel-app/src/Pages/ProfilePage.php
+++ b/app-modules/panel-app/src/Pages/ProfilePage.php
@@ -254,7 +254,16 @@ class ProfilePage extends Page
                                     Grid::make(2)->schema([
                                         Select::make('platform')
                                             ->label(__('panel-app::profile.fields.platform'))
-                                            ->options(SocialPlatform::class)
+                                            ->options(fn (): array => collect(SocialPlatform::cases())
+                                                ->mapWithKeys(fn (SocialPlatform $platform): array => [
+                                                    $platform->value => sprintf(
+                                                        '<span class="flex items-center gap-2">%s %s</span>',
+                                                        svg($platform->getBrandIcon(), 'h-4 w-4')->toHtml(),
+                                                        e($platform->getLabel()),
+                                                    ),
+                                                ])
+                                                ->all())
+                                            ->allowHtml()
                                             ->required(fn (Get $get): bool => filled($get('handle')))
                                             ->live()
                                             ->columnSpan(1),

--- a/app-modules/panel-app/src/Pages/ProfilePage.php
+++ b/app-modules/panel-app/src/Pages/ProfilePage.php
@@ -256,11 +256,13 @@ class ProfilePage extends Page
                                             ->label(__('panel-app::profile.fields.platform'))
                                             ->options(SocialPlatform::class)
                                             ->required(fn (Get $get): bool => filled($get('handle')))
+                                            ->live()
                                             ->columnSpan(1),
 
                                         TextInput::make('handle')
                                             ->label(__('panel-app::profile.fields.handle'))
                                             ->placeholder(__('panel-app::profile.placeholders.handle'))
+                                            ->disabled(fn (Get $get): bool => blank($get('platform')))
                                             ->required(fn (Get $get): bool => filled($get('platform')))
                                             ->live(onBlur: true)
                                             ->afterStateUpdated(function (Get $get, TextInput $component): void {

--- a/app-modules/panel-app/src/Pages/ProfilePage.php
+++ b/app-modules/panel-app/src/Pages/ProfilePage.php
@@ -266,6 +266,11 @@ class ProfilePage extends Page
                                             ->allowHtml()
                                             ->required(fn (Get $get): bool => filled($get('handle')))
                                             ->live()
+                                            ->afterStateUpdated(static function (Get $get, Set $set): void {
+                                                if (blank($get('platform'))) {
+                                                    $set('handle', null);
+                                                }
+                                            })
                                             ->columnSpan(1),
 
                                         TextInput::make('handle')

--- a/app-modules/profile/src/Enums/SocialPlatform.php
+++ b/app-modules/profile/src/Enums/SocialPlatform.php
@@ -45,6 +45,18 @@ enum SocialPlatform: string implements HasIcon, HasLabel
         };
     }
 
+    public function getBrandIcon(): string
+    {
+        return match ($this) {
+            self::Instagram => 'fab-instagram',
+            self::Twitter => 'fab-x-twitter',
+            self::Website => 'fas-globe',
+            self::YouTube => 'fab-youtube',
+            self::Bluesky => 'fab-bluesky',
+            self::LinkedIn => 'fab-linkedin',
+        };
+    }
+
     public function getUrl(string $handle): string
     {
         if (str_starts_with($handle, 'http://') || str_starts_with($handle, 'https://')) {


### PR DESCRIPTION
## Contexto

<!--

Descreva o contexto deste PR respondendo às seguintes perguntas:

- Qual é o problema ou necessidade?

- Como esta alteração resolve o problema?

- Qual é o impacto esperado para o usuário ou sistema?

-->

- O formulário de perfil permitia preencher o campo de handle mesmo sem selecionar uma plataforma, gerando linhas de social links inválidas/incompletas. Além disso, as opções de plataforma e os links exibidos no card de preview usavam ícones genéricos (Heroicons) em vez dos ícones oficiais de cada rede social.

- Este PR desabilita o campo de handle quando nenhuma plataforma está selecionada e exibe os ícones de marca (brand icons) de cada plataforma tanto nas opções do select quanto no preview do card de perfil.

- O usuário passa a ter uma validação visual clara no momento do preenchimento dos social links, com o campo de handle desabilitado até a escolha da plataforma, e os ícones oficiais melhoram o reconhecimento de cada rede social na interface.

### Alterações

<!--

Liste as principais alterações realizadas neste PR.

Se possível, informe os arquivos, componentes ou funcionalidades impactadas.

-->

- Adicionado o método `getBrandIcon()` em `app-modules/profile/src/Enums/SocialPlatform.php` com os ícones de marca de cada plataforma (`fab-instagram`, `fab-x-twitter`, `fas-globe`, `fab-youtube`, `fab-bluesky`, `fab-linkedin`).

- Atualizado o `Select::make('platform')` em `app-modules/panel-app/src/Pages/ProfilePage.php` para renderizar os ícones de marca nas opções (`->allowHtml()`, `->live()`).

- Desabilitado o campo `handle` em `app-modules/panel-app/src/Pages/ProfilePage.php` quando nenhuma plataforma estiver selecionada (`->disabled(...)`).

- Atualizado `app-modules/panel-app/resources/views/components/profile-preview-card.blade.php` para usar o ícone de marca da plataforma no card de preview.

---

## Plano de Testes

<!--

Liste, em formato de checklist, todos os passos executados para validar esta alteração.

O objetivo é permitir que qualquer revisor consiga reproduzir a validação realizada.

-->

- [x] Executar `make check`

- [x] Executar `make test`

- [x] Acessar o perfil e verificar se as opções de plataforma exibem os ícones de marca

- [x] Verificar se o campo de handle fica desabilitado quando nenhuma plataforma é selecionada

- [x] Selecionar uma plataforma e preencher o handle, confirmando que uma nova linha é adicionada

- [x] Verificar o card de preview de perfil exibindo o ícone de marca correto para cada plataforma

---

## Evidências

<!--

Adicione prints de tela, GIFs ou vídeos que demonstrem o comportamento da aplicação.

Caso a alteração não possua impacto visual, esta seção pode ser removida.

-->

### Antes

<!-- Prints, GIFs ou vídeos do comportamento anterior. -->

<img width="1890" height="955" alt="image" src="https://github.com/user-attachments/assets/33845a17-256f-4385-9d07-59749266cbb9" />


### Depois
<img width="1280" height="579" alt="fix handler validation" src="https://github.com/user-attachments/assets/94751d44-b8e1-4d68-b3ff-b0aca22125ab" />

<!-- Prints, GIFs ou vídeos do comportamento após a alteração. -->

---

## Issues Relacionadas

Closes #486 

<!--

Utilize uma das opções abaixo conforme necessário.

Closes #123

Fixes #123

Resolves #123

Related to #123

Exemplo: Closes #123

-->