### PR TITLE
feat(squads): adiciona MarkExMember para saída/remoção de membro

### DIFF
--- a/app-modules/squads/src/Actions/MarkExMember.php
+++ b/app-modules/squads/src/Actions/MarkExMember.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Squads\Actions;
+
+use He4rt\Identity\User\Models\User;
+use He4rt\Squads\Enums\MembershipAction;
+use He4rt\Squads\Enums\SquadRole;
+use He4rt\Squads\Exceptions\NotAnActiveSquadMember;
+use He4rt\Squads\Models\Squad;
+use He4rt\Squads\Models\SquadMember;
+use He4rt\Squads\Policies\SquadPolicy;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Closes out a member's standing in a squad, marking them `ExMember`.
+ *
+ * If the subject holds the captain seat, vacating it needs no extra code —
+ * `Squad::captain()` resolves live off the pivot (`where role = captain`),
+ * so flipping the row to `ExMember` frees the seat by itself.
+ */
+final readonly class MarkExMember
+{
+    public function __construct(
+        private SquadPolicy $squadPolicy,
+        private RecordMembershipEvent $recordMembershipEvent,
+    ) {}
+
+    public function handle(User $actor, Squad $squad, User $subject, ?string $reason = null): SquadMember
+    {
+        $this->squadPolicy->authorize($actor, $squad);
+
+        return DB::transaction(function () use ($squad, $subject, $actor, $reason): SquadMember {
+            $member = SquadMember::query()
+                ->where('squad_id', $squad->id)
+                ->where('user_id', $subject->id)
+                ->whereNot('role', SquadRole::ExMember)
+                ->lockForUpdate()
+                ->first();
+
+            throw_if($member === null, NotAnActiveSquadMember::for($squad, $subject));
+
+            $fromRole = $member->role;
+            $member->update([
+                'role' => SquadRole::ExMember,
+                'left_at' => now(),
+            ]);
+
+            $this->recordMembershipEvent->handle(
+                squad: $squad,
+                subject: $subject,
+                action: MembershipAction::Leave,
+                fromRole: $fromRole,
+                toRole: SquadRole::ExMember,
+                actor: $actor,
+                reason: $reason,
+            );
+
+            return $member->refresh();
+        });
+    }
+}

--- a/app-modules/squads/tests/Feature/MarkExMemberTest.php
+++ b/app-modules/squads/tests/Feature/MarkExMemberTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Identity\User\Models\User;
+use He4rt\Squads\Actions\MarkExMember;
+use He4rt\Squads\Enums\MembershipAction;
+use He4rt\Squads\Enums\SquadRole;
+use He4rt\Squads\Exceptions\NotAnActiveSquadMember;
+use He4rt\Squads\Models\Squad;
+use He4rt\Squads\Models\SquadMember;
+use Illuminate\Auth\Access\AuthorizationException;
+
+beforeEach(function (): void {
+    config(['he4rt.admins' => 'guisaliba']);
+
+    $this->admin = User::factory()->create([
+        'username' => 'guisaliba',
+    ]);
+});
+
+test('captain marks an active member as ex-member and the trail records it', function (): void {
+    $squad = Squad::factory()->create();
+    $captain = User::factory()->create();
+    $subject = User::factory()->create();
+
+    SquadMember::factory()->create([
+        'squad_id' => $squad->id,
+        'user_id' => $captain->id,
+        'role' => SquadRole::Captain,
+    ]);
+    SquadMember::factory()->create([
+        'squad_id' => $squad->id,
+        'user_id' => $subject->id,
+        'role' => SquadRole::Member,
+    ]);
+
+    $member = resolve(MarkExMember::class)->handle(
+        actor: $captain,
+        squad: $squad,
+        subject: $subject,
+        reason: 'Inatividade prolongada.',
+    );
+
+    expect($member->role)->toBe(SquadRole::ExMember)
+        ->and($member->left_at)->not->toBeNull();
+
+    $this->assertDatabaseHas('squad_members', [
+        'squad_id' => $squad->id,
+        'user_id' => $subject->id,
+        'role' => SquadRole::ExMember->value,
+    ]);
+
+    $this->assertDatabaseHas('squad_membership_events', [
+        'squad_id' => $squad->id,
+        'user_id' => $subject->id,
+        'actor_id' => $captain->id,
+        'action' => MembershipAction::Leave->value,
+        'from_role' => SquadRole::Member->value,
+        'to_role' => SquadRole::ExMember->value,
+        'reason' => 'Inatividade prolongada.',
+    ]);
+});
+
+test('super-admin marks ex-member on a squad they do not belong to', function (): void {
+    $squad = Squad::factory()->create();
+    $subject = User::factory()->create();
+
+    SquadMember::factory()->create([
+        'squad_id' => $squad->id,
+        'user_id' => $subject->id,
+        'role' => SquadRole::Member,
+    ]);
+
+    $member = resolve(MarkExMember::class)->handle(
+        actor: $this->admin,
+        squad: $squad,
+        subject: $subject,
+    );
+
+    expect($member->role)->toBe(SquadRole::ExMember);
+});
+
+test('sub-captain can mark ex-member in their own squad', function (): void {
+    $squad = Squad::factory()->create();
+    $subCaptain = User::factory()->create();
+    $subject = User::factory()->create();
+
+    SquadMember::factory()->create([
+        'squad_id' => $squad->id,
+        'user_id' => $subCaptain->id,
+        'role' => SquadRole::SubCaptain,
+    ]);
+    SquadMember::factory()->create([
+        'squad_id' => $squad->id,
+        'user_id' => $subject->id,
+        'role' => SquadRole::Member,
+    ]);
+
+    $member = resolve(MarkExMember::class)->handle(
+        actor: $subCaptain,
+        squad: $squad,
+        subject: $subject,
+    );
+
+    expect($member->role)->toBe(SquadRole::ExMember);
+});
+
+test('marking the captain as ex-member leaves the squad vacant', function (): void {
+    $squad = Squad::factory()->create();
+    $captain = User::factory()->create();
+
+    SquadMember::factory()->create([
+        'squad_id' => $squad->id,
+        'user_id' => $captain->id,
+        'role' => SquadRole::Captain,
+    ]);
+
+    expect($squad->captain()->first())->not->toBeNull();
+
+    resolve(MarkExMember::class)->handle(
+        actor: $this->admin,
+        squad: $squad,
+        subject: $captain,
+    );
+
+    expect($squad->captain()->first())->toBeNull();
+});
+
+test('a common member cannot mark anyone ex-member', function (): void {
+    $squad = Squad::factory()->create();
+    $member = User::factory()->create();
+    $subject = User::factory()->create();
+
+    SquadMember::factory()->create([
+        'squad_id' => $squad->id,
+        'user_id' => $member->id,
+        'role' => SquadRole::Member,
+    ]);
+    SquadMember::factory()->create([
+        'squad_id' => $squad->id,
+        'user_id' => $subject->id,
+        'role' => SquadRole::Member,
+    ]);
+
+    resolve(MarkExMember::class)->handle(
+        actor: $member,
+        squad: $squad,
+        subject: $subject,
+    );
+})->throws(AuthorizationException::class);
+
+test('marking a subject with no active membership throws', function (): void {
+    $squad = Squad::factory()->create();
+    $outsider = User::factory()->create();
+
+    resolve(MarkExMember::class)->handle(
+        actor: $this->admin,
+        squad: $squad,
+        subject: $outsider,
+    );
+})->throws(NotAnActiveSquadMember::class);
+
+test('marking an already ex-member subject throws', function (): void {
+    $squad = Squad::factory()->create();
+    $subject = User::factory()->create();
+
+    SquadMember::factory()->create([
+        'squad_id' => $squad->id,
+        'user_id' => $subject->id,
+        'role' => SquadRole::ExMember,
+    ]);
+
+    resolve(MarkExMember::class)->handle(
+        actor: $this->admin,
+        squad: $squad,
+        subject: $subject,
+    );
+})->throws(NotAnActiveSquadMember::class);


### PR DESCRIPTION
Materializa a Action `MarkExMember`, consumindo a `SquadPolicy` já registrada em CONTEXT.md, para fechar o ciclo de saída/remoção de membro do squad.

- `handle(User $actor, Squad $squad, User $subject, ?string $reason = null): SquadMember` — autoriza via `SquadPolicy::authorize()` (capitão/vice-capitão do próprio squad, ou super-admin)
- Localiza a linha ativa do subject no squad (`lockForUpdate`); sem membership ativa, lança `NotAnActiveSquadMember`
- Atualiza `role => ex_member` e `left_at => now()` na mesma transação
- Grava o evento `MembershipAction::Leave` na trilha de auditoria via `RecordMembershipEvent`
- Como `Squad::captain()` resolve o capitão direto do pivot (`role = captain`), marcar o capitão como `ex_member` libera a vaga automaticamente, sem lógica extra

## Plano de testes
- [x] `MarkExMemberTest.php` — 7 cenários (captain/sub-captain/super-admin marcam, membro comum não pode, capitão marcado libera vaga, subject sem membership ativa, subject já ex_member), 7/7 verdes
- [x] Suite completa de `app-modules/squads` — 40/40 verdes
- [x] Pint limpo nos arquivos modificados

Closes #359 