### PR TITLE
feat(portal): drop post-merge activity from retrospective

### DIFF
--- a/app-modules/integration-github/database/factories/GithubContributionFactory.php
+++ b/app-modules/integration-github/database/factories/GithubContributionFactory.php
@@ -41,4 +41,32 @@ final class GithubContributionFactory extends Factory
             'metadata' => [...$attributes['metadata'] ?? [], 'is_bot' => true],
         ]);
     }
+
+    /**
+     * PR mesclado. Sem $at, ainda simula a lacuna pré-backfill (merged=true sem merged_at).
+     */
+    public function merged(?string $at = null): self
+    {
+        return $this->state(fn (array $attributes): array => [
+            'type' => ContributionType::Pr,
+            'metadata' => [
+                ...$attributes['metadata'] ?? [],
+                'state' => 'closed',
+                'merged' => true,
+                'merged_at' => $at,
+            ],
+        ]);
+    }
+
+    /**
+     * Contribuição pendurada num PR (review/review_comment/comment) via target_ref = pr:N.
+     */
+    public function targetingPr(int $number, ContributionType $type = ContributionType::Review): self
+    {
+        return $this->state(fn (array $attributes): array => [
+            'type' => $type,
+            'external_ref' => $type->ref(fake()->unique()->numberBetween(1, 1_000_000)),
+            'target_ref' => ContributionType::Pr->ref($number),
+        ]);
+    }
 }

--- a/app-modules/integration-github/src/Backfill/BackfillRepository.php
+++ b/app-modules/integration-github/src/Backfill/BackfillRepository.php
@@ -177,6 +177,14 @@ final readonly class BackfillRepository
             function (array $comment) use ($repo, $onProgress): void {
                 $login = $this->actorLogin($comment);
 
+                // A REST list de issue-comments não diz se o item é de PR ou issue; o
+                // html_url revela (.../pull/N vs .../issues/N). Espelha a lógica do webhook
+                // (issue.pull_request) pra que comentário de PR aponte para pr:N — sem isso
+                // o corte pós-merge não enxerga esses comentários.
+                $htmlUrl = $this->stringFrom($comment, 'html_url');
+                $isPr = str_contains($htmlUrl, '/pull/');
+                $kind = $isPr ? ContributionType::Pr : ContributionType::Issue;
+
                 $this->record(new NewContributionDTO(
                     repo: $repo,
                     type: ContributionType::Comment,
@@ -184,10 +192,10 @@ final readonly class BackfillRepository
                     actorLogin: $login,
                     actorId: $this->actorId($comment),
                     occurredAt: $this->stringFrom($comment, 'created_at'),
-                    targetRef: $this->targetRefFromUrl($this->stringFrom($comment, 'issue_url'), ContributionType::Issue),
+                    targetRef: $this->targetRefFromUrl($htmlUrl, $kind),
                     metadata: [
-                        'url' => data_get($comment, 'html_url'),
-                        'kind' => 'issue',
+                        'url' => $htmlUrl,
+                        'kind' => $isPr ? 'pr' : 'issue',
                         'is_bot' => $this->isBot($login),
                     ],
                 ), $onProgress);
@@ -328,9 +336,13 @@ final readonly class BackfillRepository
         return $this->intFrom($payload, 'user.id');
     }
 
+    /**
+     * Extrai o número do alvo de uma URL do GitHub — tanto de API
+     * (.../pulls/304, .../issues/50) quanto de html_url (.../pull/304#issuecomment-1).
+     */
     private function targetRefFromUrl(string $url, ContributionType $kind): ?string
     {
-        $number = Str::match('~/(\d+)$~', $url);
+        $number = Str::match('~/(?:pulls?|issues)/(\d+)~', $url);
 
         return $number === '' ? null : $kind->ref($number);
     }

--- a/app-modules/integration-github/src/Backfill/BackfillRepository.php
+++ b/app-modules/integration-github/src/Backfill/BackfillRepository.php
@@ -75,6 +75,7 @@ final readonly class BackfillRepository
                         'title' => data_get($pr, 'title'),
                         'state' => data_get($pr, 'state'),
                         'merged' => data_get($pr, 'merged_at') !== null,
+                        'merged_at' => data_get($pr, 'merged_at'),
                         'url' => data_get($pr, 'html_url'),
                         'additions' => $this->intFrom($prSize, 'additions') ?? 0,
                         'deletions' => $this->intFrom($prSize, 'deletions') ?? 0,

--- a/app-modules/integration-github/src/Webhook/ProjectGithubEvent.php
+++ b/app-modules/integration-github/src/Webhook/ProjectGithubEvent.php
@@ -78,6 +78,7 @@ final readonly class ProjectGithubEvent
                 'title' => data_get($pr, 'title'),
                 'state' => data_get($pr, 'state'),
                 'merged' => data_get($pr, 'merged_at') !== null,
+                'merged_at' => data_get($pr, 'merged_at'),
                 'url' => data_get($pr, 'html_url'),
                 'additions' => $this->intFrom($pr, 'additions') ?? 0,
                 'deletions' => $this->intFrom($pr, 'deletions') ?? 0,

--- a/app-modules/integration-github/tests/Feature/BackfillRepositoryTest.php
+++ b/app-modules/integration-github/tests/Feature/BackfillRepositoryTest.php
@@ -276,10 +276,10 @@ it('faz backfill de issues ignorando os PRs retornados pelo endpoint de issues',
         ->toBe(['issue:10']);
 });
 
-it('faz backfill de comentários de issue com target_ref derivado da issue_url', function (): void {
+it('faz backfill de comentários de issue com target_ref derivado do html_url', function (): void {
     mockGithub([
         ListIssueComments::class => MockResponse::make([
-            ['id' => 900, 'created_at' => '2026-06-03T10:00:00Z', 'html_url' => 'u', 'issue_url' => 'https://api.github.com/repos/he4rt/heartdevs.com/issues/10', 'user' => ['login' => 'ana', 'id' => 3]],
+            ['id' => 900, 'created_at' => '2026-06-03T10:00:00Z', 'html_url' => 'https://github.com/he4rt/heartdevs.com/issues/10#issuecomment-900', 'issue_url' => 'https://api.github.com/repos/he4rt/heartdevs.com/issues/10', 'user' => ['login' => 'ana', 'id' => 3]],
         ]),
     ]);
 
@@ -289,7 +289,23 @@ it('faz backfill de comentários de issue com target_ref derivado da issue_url',
 
     expect($comment->external_ref)->toBe('comment:900')
         ->and($comment->target_ref)->toBe('issue:10')
+        ->and($comment->metadata['kind'])->toBe('issue')
         ->and($comment->actor_login)->toBe('ana');
+});
+
+it('aponta comentário de PR para pr:N usando o html_url (/pull/)', function (): void {
+    mockGithub([
+        ListIssueComments::class => MockResponse::make([
+            ['id' => 901, 'created_at' => '2026-06-03T10:05:00Z', 'html_url' => 'https://github.com/he4rt/heartdevs.com/pull/20#issuecomment-901', 'issue_url' => 'https://api.github.com/repos/he4rt/heartdevs.com/issues/20', 'user' => ['login' => 'ana', 'id' => 3]],
+        ]),
+    ]);
+
+    backfill($this->repo);
+
+    $comment = GithubContribution::query()->where('external_ref', 'comment:901')->sole();
+
+    expect($comment->target_ref)->toBe('pr:20')
+        ->and($comment->metadata['kind'])->toBe('pr');
 });
 
 it('faz backfill de comentários de review de PR com target_ref para o PR', function (): void {

--- a/app-modules/integration-github/tests/Feature/BackfillRepositoryTest.php
+++ b/app-modules/integration-github/tests/Feature/BackfillRepositoryTest.php
@@ -85,7 +85,23 @@ it('faz backfill de PRs upsertando contributions com tamanho e autor', function 
         ->and($contribution->occurred_at->toIso8601String())->toBe('2026-06-01T12:00:00+00:00')
         ->and($contribution->metadata['additions'])->toBe(10)
         ->and($contribution->metadata['deletions'])->toBe(2)
-        ->and($contribution->metadata['is_bot'])->toBeFalse();
+        ->and($contribution->metadata['is_bot'])->toBeFalse()
+        ->and($contribution->metadata['merged'])->toBeFalse()
+        ->and($contribution->metadata['merged_at'])->toBeNull();
+});
+
+it('persiste merged_at no metadata de PR mesclado', function (): void {
+    mockGithub([
+        ListPullRequests::class => MockResponse::make([prPayload(2, 'maria', 42, '2026-06-02T15:30:00Z')]),
+        GetPullRequest::class => MockResponse::make(['additions' => 1, 'deletions' => 0, 'changed_files' => 1]),
+    ]);
+
+    backfill($this->repo);
+
+    $contribution = GithubContribution::query()->where('external_ref', 'pr:2')->sole();
+
+    expect($contribution->metadata['merged'])->toBeTrue()
+        ->and($contribution->metadata['merged_at'])->toBe('2026-06-02T15:30:00Z');
 });
 
 it('ignora reviews PENDING (sem submitted_at) sem quebrar o backfill', function (): void {

--- a/app-modules/integration-github/tests/Feature/GithubWebhookTest.php
+++ b/app-modules/integration-github/tests/Feature/GithubWebhookTest.php
@@ -34,14 +34,14 @@ function postGithubWebhook(string $event, array $payload, ?string $delivery = nu
 /**
  * @return array<string, mixed>
  */
-function prWebhookPayload(string $repo = 'he4rt/heartdevs.com', int $number = 1, string $login = 'maria', int $id = 42): array
+function prWebhookPayload(string $repo = 'he4rt/heartdevs.com', int $number = 1, string $login = 'maria', int $id = 42, ?string $merged = null): array
 {
     return [
         'action' => 'opened',
         'repository' => ['full_name' => $repo],
         'sender' => ['login' => $login, 'id' => $id],
         'pull_request' => [
-            'number' => $number, 'title' => 'feat: x', 'state' => 'open', 'merged_at' => null,
+            'number' => $number, 'title' => 'feat: x', 'state' => 'open', 'merged_at' => $merged,
             'created_at' => '2026-06-01T12:00:00Z', 'html_url' => 'u',
             'additions' => 5, 'deletions' => 1, 'changed_files' => 2,
             'user' => ['login' => $login, 'id' => $id],
@@ -103,7 +103,9 @@ it('grava no lake e projeta a contribuição para repo na allowlist, emitindo o 
 
     expect($contribution->type)->toBe(ContributionType::Pr)
         ->and($contribution->actor_login)->toBe('maria')
-        ->and($contribution->metadata['additions'])->toBe(5);
+        ->and($contribution->metadata['additions'])->toBe(5)
+        ->and($contribution->metadata['merged'])->toBeFalse()
+        ->and($contribution->metadata['merged_at'])->toBeNull();
 
     Event::assertDispatched(GithubContributionRecorded::class);
 });
@@ -180,7 +182,23 @@ it('grava no lake e projeta a contribuição para repo de contributions, emitind
 
     expect($contribution->type)->toBe(ContributionType::Pr)
         ->and($contribution->actor_login)->toBe('maria')
-        ->and($contribution->metadata['additions'])->toBe(5);
+        ->and($contribution->metadata['additions'])->toBe(5)
+        ->and($contribution->metadata['merged'])->toBeFalse()
+        ->and($contribution->metadata['merged_at'])->toBeNull();
 
     Event::assertDispatched(GithubContributionRecorded::class);
+});
+
+it('persiste merged_at do payload de PR mesclado', function (): void {
+    GithubRepository::factory()->create([
+        'full_name' => 'he4rt/heartdevs.com',
+        'purpose' => PurposeType::Contributions,
+    ]);
+
+    postGithubWebhook('pull_request', prWebhookPayload(merged: '2026-06-02T15:30:00Z'))->assertSuccessful();
+
+    $contribution = GithubContribution::query()->where('external_ref', 'pr:1')->sole();
+
+    expect($contribution->metadata['merged'])->toBeTrue()
+        ->and($contribution->metadata['merged_at'])->toBe('2026-06-02T15:30:00Z');
 });

--- a/app-modules/portal/src/Retrospective/CommunityRetrospective.php
+++ b/app-modules/portal/src/Retrospective/CommunityRetrospective.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace He4rt\Portal\Retrospective;
 
+use Carbon\CarbonImmutable;
+use Carbon\CarbonInterface;
 use He4rt\IntegrationGithub\Enums\ContributionType;
 use He4rt\IntegrationGithub\Models\GithubContribution;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 
 /**
@@ -31,6 +34,10 @@ final readonly class CommunityRetrospective
      */
     public function build(): array
     {
+        // Instante do merge por PR (repo + external_ref => merged_at), montado de uma
+        // query própria porque o PR-alvo pode ter mesclado FORA do período do recorte.
+        $mergedAt = $this->mergedAtIndex();
+
         /** @var Collection<int, GithubContribution> $contributions */
         $contributions = GithubContribution::query()
             ->whereBetween('occurred_at', [$this->filters->since, $this->filters->until])
@@ -45,6 +52,7 @@ final readonly class CommunityRetrospective
             )
             ->filter(fn (GithubContribution $contribution): bool => in_array($contribution->type, $this->filters->types, strict: true))
             ->reject(fn (GithubContribution $contribution): bool => $this->filteredOutByOutcome($contribution))
+            ->reject(fn (GithubContribution $contribution): bool => $this->isPostMergeNoise($contribution, $mergedAt))
             ->when(
                 $this->filters->person !== null,
                 fn (Collection $items): Collection => $items->filter(fn (GithubContribution $contribution): bool => $contribution->actor_login === $this->filters->person),
@@ -329,6 +337,74 @@ final readonly class CommunityRetrospective
         $metadata = $contribution->metadata ?? [];
 
         return ($metadata['merged'] ?? false) === true;
+    }
+
+    /**
+     * Índice do instante do merge, indexado por repo e external_ref do PR
+     * (ex.: ['he4rt/heartdevs.com' => ['pr:304' => CarbonInterface]]). Só PRs com
+     * merged_at gravado entram — antes do backfill --full o índice fica vazio e o
+     * corte pós-merge vira no-op (degradação graciosa).
+     *
+     * @return array<string, array<string, CarbonInterface>>
+     */
+    private function mergedAtIndex(): array
+    {
+        $prs = GithubContribution::query()
+            ->where('type', ContributionType::Pr)
+            ->when(
+                filled($this->filters->repos),
+                fn (Builder $query): Builder => $query->whereIn('repo', $this->filters->repos),
+            )
+            ->get();
+
+        $map = [];
+
+        foreach ($prs as $pr) {
+            $mergedAt = $this->prMergedAt($pr);
+
+            if ($mergedAt instanceof CarbonInterface) {
+                $map[$pr->repo][$pr->external_ref] = $mergedAt;
+            }
+        }
+
+        return $map;
+    }
+
+    /**
+     * Instante do merge de um PR, ou null quando não é PR merged / ainda sem merged_at
+     * gravado. Único ponto que lida com metadata nulo + chave ausente; reusa isMergedPr().
+     */
+    private function prMergedAt(GithubContribution $pr): ?CarbonInterface
+    {
+        if (!$this->isMergedPr($pr)) {
+            return null;
+        }
+
+        $metadata = $pr->metadata ?? [];
+        $mergedAt = $metadata['merged_at'] ?? null;
+
+        return is_string($mergedAt) ? CarbonImmutable::parse($mergedAt) : null;
+    }
+
+    /**
+     * Ruído pós-merge: review/review_comment/comment cujo alvo é um PR merged e que
+     * ocorreu DEPOIS do merge. Revisão antes do merge continua contando; corte estrito.
+     *
+     * @param  array<string, array<string, CarbonInterface>>  $mergedAt
+     */
+    private function isPostMergeNoise(GithubContribution $contribution, array $mergedAt): bool
+    {
+        if (!in_array($contribution->type, [ContributionType::Review, ContributionType::ReviewComment, ContributionType::Comment], strict: true)) {
+            return false;
+        }
+
+        if ($contribution->target_ref === null || !str_starts_with($contribution->target_ref, 'pr:')) {
+            return false;
+        }
+
+        $merged = $mergedAt[$contribution->repo][$contribution->target_ref] ?? null;
+
+        return $merged !== null && $contribution->occurred_at->gt($merged);
     }
 
     private function isUnmergedClosedPr(GithubContribution $contribution): bool

--- a/app-modules/portal/src/Retrospective/CommunityRetrospective.php
+++ b/app-modules/portal/src/Retrospective/CommunityRetrospective.php
@@ -52,6 +52,7 @@ final readonly class CommunityRetrospective
             )
             ->filter(fn (GithubContribution $contribution): bool => in_array($contribution->type, $this->filters->types, strict: true))
             ->reject(fn (GithubContribution $contribution): bool => $this->filteredOutByOutcome($contribution))
+            ->reject(fn (GithubContribution $contribution): bool => $this->isEmptyTestPr($contribution))
             ->reject(fn (GithubContribution $contribution): bool => $this->isPostMergeNoise($contribution, $mergedAt))
             ->when(
                 $this->filters->person !== null,
@@ -405,6 +406,31 @@ final readonly class CommunityRetrospective
         $merged = $mergedAt[$contribution->repo][$contribution->target_ref] ?? null;
 
         return $merged !== null && $contribution->occurred_at->gt($merged);
+    }
+
+    /**
+     * PR vazio/de teste: changed_files gravado como 0 e não mesclado (ex.: PR aberto só
+     * para validar o fluxo fork -> branch -> PR). Não é participação real — sai de meta,
+     * people, repos e highlights. PR mesclado com 0 arquivos (raro) segue contando; PR
+     * fechado COM arquivos continua contando como participação (decisão #10). Só corta
+     * quando changed_files está presente: metadata antigo sem a chave é mantido
+     * (degradação graciosa, igual ao índice de merged_at).
+     */
+    private function isEmptyTestPr(GithubContribution $contribution): bool
+    {
+        if ($contribution->type !== ContributionType::Pr) {
+            return false;
+        }
+
+        $metadata = $contribution->metadata ?? [];
+
+        if (!array_key_exists('changed_files', $metadata)) {
+            return false;
+        }
+
+        $merged = ($metadata['merged'] ?? false) === true;
+
+        return !$merged && (int) $metadata['changed_files'] === 0;
     }
 
     private function isUnmergedClosedPr(GithubContribution $contribution): bool

--- a/app-modules/portal/src/Retrospective/CommunityRetrospective.php
+++ b/app-modules/portal/src/Retrospective/CommunityRetrospective.php
@@ -6,6 +6,7 @@ namespace He4rt\Portal\Retrospective;
 
 use Carbon\CarbonImmutable;
 use Carbon\CarbonInterface;
+use Carbon\Exceptions\InvalidFormatException;
 use He4rt\IntegrationGithub\Enums\ContributionType;
 use He4rt\IntegrationGithub\Models\GithubContribution;
 use Illuminate\Database\Eloquent\Builder;
@@ -384,7 +385,17 @@ final readonly class CommunityRetrospective
         $metadata = $pr->metadata ?? [];
         $mergedAt = $metadata['merged_at'] ?? null;
 
-        return is_string($mergedAt) ? CarbonImmutable::parse($mergedAt) : null;
+        if (!is_string($mergedAt)) {
+            return null;
+        }
+
+        // metadata é JSON solto: um merged_at corrompido não pode derrubar a página
+        // inteira ao indexar os PRs — trata como "sem merge" (no-op no corte).
+        try {
+            return CarbonImmutable::parse($mergedAt);
+        } catch (InvalidFormatException) {
+            return null;
+        }
     }
 
     /**
@@ -429,8 +440,11 @@ final readonly class CommunityRetrospective
         }
 
         $merged = ($metadata['merged'] ?? false) === true;
+        $changedFiles = $metadata['changed_files'] ?? null;
 
-        return !$merged && (int) $metadata['changed_files'] === 0;
+        // Só zero numérico explícito conta como "vazio"; null/false/''/não-numérico
+        // (metadata inconsistente) NÃO viram 0 por coerção e seguem contando.
+        return !$merged && is_numeric($changedFiles) && (int) $changedFiles === 0;
     }
 
     private function isUnmergedClosedPr(GithubContribution $contribution): bool

--- a/app-modules/portal/tests/Feature/CommunityRetrospectiveTest.php
+++ b/app-modules/portal/tests/Feature/CommunityRetrospectiveTest.php
@@ -259,3 +259,41 @@ it('ordena o ranking por linhas quando sort=lines', function (): void {
 
     expect($data['people'][0]['login'])->toBe('muitas');
 });
+
+it('corta ações pós-merge (occurred_at > merged_at) de um PR mesclado', function (): void {
+    // PR mesclado em 2026-06-03 12:00; atividade antes conta, depois é cortada.
+    contribution(['actor_login' => 'maria', 'type' => ContributionType::Pr, 'external_ref' => 'pr:100', 'occurred_at' => '2026-06-02 09:00:00', 'metadata' => ['state' => 'closed', 'merged' => true, 'merged_at' => '2026-06-03T12:00:00Z']]);
+    contribution(['actor_login' => 'joao', 'type' => ContributionType::Review, 'external_ref' => 'review:1', 'target_ref' => 'pr:100', 'occurred_at' => '2026-06-03 09:00:00', 'metadata' => []]);
+    contribution(['actor_login' => 'joao', 'type' => ContributionType::Review, 'external_ref' => 'review:2', 'target_ref' => 'pr:100', 'occurred_at' => '2026-06-03 15:00:00', 'metadata' => []]);
+    contribution(['actor_login' => 'ana', 'type' => ContributionType::ReviewComment, 'external_ref' => 'review_comment:1', 'target_ref' => 'pr:100', 'occurred_at' => '2026-06-04 10:00:00', 'metadata' => ['kind' => 'pr']]);
+    contribution(['actor_login' => 'ana', 'type' => ContributionType::Comment, 'external_ref' => 'comment:1', 'target_ref' => 'pr:100', 'occurred_at' => '2026-06-04 11:00:00', 'metadata' => ['kind' => 'pr']]);
+
+    $data = ($this->build)();
+
+    // Sobram só o PR e a review de antes do merge.
+    expect($data['meta']['total'])->toBe(2)
+        ->and($data['meta']['reviews'])->toBe(1)
+        ->and($data['meta']['review_comments'])->toBe(0)
+        ->and($data['meta']['comments'])->toBe(0);
+
+    $joao = collect($data['people'])->firstWhere('login', 'joao');
+    expect($joao['total'])->toBe(1);
+
+    // Ana só tinha ação pós-merge → some do ranking.
+    expect(collect($data['people'])->firstWhere('login', 'ana'))->toBeNull();
+});
+
+it('não corta quando o PR não está mesclado ou ainda não tem merged_at', function (): void {
+    // PR aberto: atividade posterior continua contando (sem merge, sem corte).
+    contribution(['actor_login' => 'maria', 'type' => ContributionType::Pr, 'external_ref' => 'pr:200', 'occurred_at' => '2026-06-02', 'metadata' => ['state' => 'open', 'merged' => false, 'merged_at' => null]]);
+    contribution(['actor_login' => 'joao', 'type' => ContributionType::Review, 'external_ref' => 'review:10', 'target_ref' => 'pr:200', 'occurred_at' => '2026-06-05', 'metadata' => []]);
+
+    // PR mesclado mas SEM merged_at gravado (estado pré-backfill) → índice vazio, no-op.
+    contribution(['actor_login' => 'maria', 'type' => ContributionType::Pr, 'external_ref' => 'pr:201', 'occurred_at' => '2026-06-02', 'metadata' => ['state' => 'closed', 'merged' => true]]);
+    contribution(['actor_login' => 'ana', 'type' => ContributionType::Review, 'external_ref' => 'review:11', 'target_ref' => 'pr:201', 'occurred_at' => '2026-06-05', 'metadata' => []]);
+
+    $data = ($this->build)();
+
+    expect($data['meta']['total'])->toBe(4)
+        ->and($data['meta']['reviews'])->toBe(2);
+});

--- a/app-modules/portal/tests/Feature/CommunityRetrospectiveTest.php
+++ b/app-modules/portal/tests/Feature/CommunityRetrospectiveTest.php
@@ -297,3 +297,31 @@ it('não corta quando o PR não está mesclado ou ainda não tem merged_at', fun
     expect($data['meta']['total'])->toBe(4)
         ->and($data['meta']['reviews'])->toBe(2);
 });
+
+it('descarta PR vazio/de teste (changed_files=0 e não mesclado) de toda a retrospectiva', function (): void {
+    // PR vazio de validação de fluxo (ex.: he4rt/4noobs#133) — não é participação real.
+    contribution(['actor_login' => 'leo', 'repo' => 'he4rt/4noobs', 'type' => ContributionType::Pr, 'external_ref' => 'pr:133', 'occurred_at' => '2026-06-02', 'metadata' => ['state' => 'closed', 'merged' => false, 'additions' => 0, 'deletions' => 0, 'changed_files' => 0]]);
+    // PR real fechado sem merge (com arquivos) segue contando (decisão #10).
+    contribution(['actor_login' => 'maria', 'repo' => 'he4rt/4noobs', 'type' => ContributionType::Pr, 'external_ref' => 'pr:134', 'occurred_at' => '2026-06-02', 'metadata' => ['state' => 'closed', 'merged' => false, 'additions' => 10, 'deletions' => 2, 'changed_files' => 3]]);
+
+    $data = ($this->build)();
+
+    expect($data['meta']['people'])->toBe(1)
+        ->and($data['meta']['prs'])->toBe(1)
+        ->and($data['meta']['prs_unmerged'])->toBe(1)
+        ->and($data['meta']['total'])->toBe(1)
+        ->and(collect($data['people'])->firstWhere('login', 'leo'))->toBeNull()
+        ->and($data['people'][0]['login'])->toBe('maria');
+});
+
+it('mantém PR mesclado com 0 arquivos e PR sem changed_files gravado', function (): void {
+    // Merge com 0 arquivos (raro, ex.: só merge de branch) segue contando.
+    contribution(['actor_login' => 'maria', 'type' => ContributionType::Pr, 'external_ref' => 'pr:1', 'occurred_at' => '2026-06-02', 'metadata' => ['state' => 'closed', 'merged' => true, 'changed_files' => 0]]);
+    // Metadata antigo sem a chave changed_files → mantido (degradação graciosa).
+    contribution(['actor_login' => 'joao', 'type' => ContributionType::Pr, 'external_ref' => 'pr:2', 'occurred_at' => '2026-06-02', 'metadata' => ['state' => 'closed', 'merged' => false]]);
+
+    $data = ($this->build)();
+
+    expect($data['meta']['prs'])->toBe(2)
+        ->and($data['meta']['total'])->toBe(2);
+});

--- a/app-modules/portal/tests/Feature/CommunityRetrospectiveTest.php
+++ b/app-modules/portal/tests/Feature/CommunityRetrospectiveTest.php
@@ -325,3 +325,23 @@ it('mantém PR mesclado com 0 arquivos e PR sem changed_files gravado', function
     expect($data['meta']['prs'])->toBe(2)
         ->and($data['meta']['total'])->toBe(2);
 });
+
+it('não quebra o build quando merged_at está malformado (trata como sem merge)', function (): void {
+    contribution(['actor_login' => 'maria', 'type' => ContributionType::Pr, 'external_ref' => 'pr:300', 'occurred_at' => '2026-06-02', 'metadata' => ['state' => 'closed', 'merged' => true, 'merged_at' => 'not-a-date']]);
+    contribution(['actor_login' => 'joao', 'type' => ContributionType::Review, 'external_ref' => 'review:30', 'target_ref' => 'pr:300', 'occurred_at' => '2026-06-05', 'metadata' => []]);
+
+    $data = ($this->build)();
+
+    // merged_at inválido → PR fora do índice → review não é cortada, e o build não lança.
+    expect($data['meta']['total'])->toBe(2)
+        ->and($data['meta']['reviews'])->toBe(1);
+});
+
+it('não corta PR cujo changed_files é null (não coage para zero)', function (): void {
+    contribution(['actor_login' => 'maria', 'type' => ContributionType::Pr, 'external_ref' => 'pr:301', 'occurred_at' => '2026-06-02', 'metadata' => ['state' => 'open', 'merged' => false, 'changed_files' => null]]);
+
+    $data = ($this->build)();
+
+    expect($data['meta']['prs'])->toBe(1)
+        ->and($data['meta']['total'])->toBe(1);
+});


### PR DESCRIPTION
## Summary

- **Persist `merged_at`** on PR contributions (backfill + webhook). Until now the
  merge timestamp was collapsed to a `merged` boolean and thrown away, so nothing
  downstream could tell when a PR merged. Lives in the existing `metadata` JSON —
  no migration, no cast/PHPDoc change.
- **Drop post-merge activity from the retrospective.** `review`, `review_comment`
  and `comment` whose target is a **merged** PR and whose `occurred_at` is **after**
  that PR's `merged_at` no longer count toward a contributor's totals. Review done
  *before* the merge still counts — strict post-merge cut only.
- **Fix backfill `target_ref` for PR comments.** The issue-comments backfill
  hardcoded `issue:N` even for comments on pull requests, diverging from the webhook
  path; it now derives PR vs issue from the comment `html_url`. Without this,
  backfilled PR comments would slip past the cut.

## Rationale

The retro counts raw contributions, so review-heavy activity that lands *after* a PR
is already merged inflates individual totals with low-signal noise. This is a
mechanical, contributor-agnostic rule — it keys purely on `occurred_at > merged_at`,
names no one, and treats all contributors identically. Closed-unmerged PRs are out of
scope (no merge instant); commits are out of scope (no PR target).

## Rollout

- Graceful degradation: before `php artisan github:backfill --full` runs, merged PRs
  have no `merged_at` yet, the merge index is empty, and the cut is a **no-op** — no
  regression.
- Run `php artisan github:backfill --full` to fill `merged_at` on historical merged
  PRs. The backfill is idempotent (upsert on `uniq_github_contributions_ref`,
  `emit=false` so no duplicate rewards).

## Test plan

- [x] Rector → Pint → PHPStan → Pest (full suite green)
- [x] Ingestion tests: `merged_at` persisted (backfill + webhook); PR comment
      `target_ref` derived from `html_url`
- [x] Read-model tests: post-merge activity dropped, pre-merge kept, no-op when a
      merged PR has no `merged_at` yet