### PR TITLE
feat(squads): PromoteToSubCaptain / demote (#358)

### DIFF
--- a/app-modules/squads/CONTEXT.md
+++ b/app-modules/squads/CONTEXT.md
@@ -13,7 +13,7 @@ flow it actively conducts.
 | **Squad**                     | A crew with a clear objective. Lifecycle `status`: `draft` → `active` → `inactive` → `archived`. Created by a super-admin (the bottom-up proposal/validation happens off-system).             | A WhatsApp group (the informal precursor) — the Squad is the formalized record    |
 | **SquadMember**               | A row in the `squad_members` pivot: one person's standing in one squad. Carries `role`, `joined_at`, `left_at`.                                                                               | A community member generally — this is squad-scoped standing                      |
 | **Role (in squad)**           | The `squad_members.role` enum: `Captain` · `SubCaptain` · `Member` · `ExMember`. Confers power on the platform: Captain/Sub manage their own squad.                                           | A governance role (super-admin) — that is platform-wide, config-driven            |
-| **Captain / SubCaptain**      | The squad's leadership. They conduct their own squad on the platform: approve/reject candidacy, promote a sub, mark an `ExMember`.                                                            | The Head dos Squads (an off-system human role; in software it is the super-admin) |
+| **Captain / SubCaptain**      | The squad's leadership. Both can use general squad-management capabilities; only the Captain or a super-admin can promote or demote a SubCaptain.                                             | The Head dos Squads (an off-system human role; in software it is the super-admin) |
 | **ExMember**                  | A person who left (or was removed from) a squad. A role value, not a deletion. Does **not** count toward exclusivity. `left_at` dates the exit.                                               | A `Member` on leave — there is no "paused membership" state                       |
 | **Application (candidatura)** | An APTO person's request to join a squad (`squad_applications`, `pending`/`approved`/`rejected`). The captain decides; approval creates the membership in a transaction.                      | An onboarding (community/program entry) — that is upstream, in `onboarding`       |
 | **Exclusivity**               | A person may hold at most one _active_ membership (role in `Captain`/`SubCaptain`/`Member`) across all squads. Enforced on join.                                                              | A hard unique DB constraint — `ExMember` rows are allowed to pile up              |
@@ -21,14 +21,28 @@ flow it actively conducts.
 | **Super-admin**               | Platform governance authority, sourced from `config('he4rt.admins')` via `User::isAdmin()`. Creates squads, sets captains, overrides any squad action. Stands in for the "Head/Gestão" roles. | A Captain — a Captain's power is scoped to their own squad                        |
 | **APTO**                      | The gate this module consumes from `onboarding`: the person completed the `Squads` onboarding. Required to apply or to be in a squad.                                                         | An `active` Squad — APTO is about a person, not a squad                           |
 
+### Leadership capabilities
+
+| Capability                                | Captain        | SubCaptain     | Super-admin |
+| ----------------------------------------- | -------------- | -------------- | ----------- |
+| Promote `Member` -> `SubCaptain`          | Yes, own squad | No             | Yes         |
+| Demote `SubCaptain` -> `Member`           | Yes, own squad | No             | Yes         |
+| General `SquadPolicy::canManage()` action | Yes, own squad | Yes, own squad | Yes         |
+| Assign or replace `Captain`               | No             | No             | Yes         |
+
+More than one `SubCaptain` is allowed. Neither the product requirements nor the schema define a
+single-SubCaptain invariant. A vacancy remains the absence of a `Captain` row. `MarkExMember` is the
+current implemented path that can vacate the seat, while `PromoteToSubCaptain` never changes a
+`Captain` row.
+
 ## What this module records vs. conducts
 
 | Flow (P.O. doc)             | In this module (model B — record-keeping)                                                                      |
 | --------------------------- | -------------------------------------------------------------------------------------------------------------- |
 | Candidacy to existing squad | **Conducted**: application → captain decides → membership created (exclusivity checked).                       |
 | Squad creation (bottom-up)  | **Recorded**: super-admin registers the squad (draft→active) with its captain. Proposal/validation off-system. |
-| Captain election            | **Recorded**: runs off-system; the outcome is registered (set captain/sub via promote).                        |
-| Captain exit                | **Recorded**: mark `ExMember` / promote the sub (sub assumes) or leave the seat vacant.                        |
+| Captain election            | **Recorded**: runs off-system; the outcome is registered through `AssignCaptain`.                              |
+| Captain exit                | **Recorded**: `MarkExMember` vacates the seat; `AssignCaptain` can record a later replacement.                 |
 | Captain removal             | **Recorded**: runs off-system (moderator→management→Head); outcome registered (mark ExMember).                 |
 | Leadership reallocation     | **Recorded**: super-admin moves a leader to another squad.                                                     |
 

--- a/app-modules/squads/src/Actions/PromoteToSubCaptain.php
+++ b/app-modules/squads/src/Actions/PromoteToSubCaptain.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Squads\Actions;
+
+use He4rt\Identity\User\Models\User;
+use He4rt\Squads\Enums\MembershipAction;
+use He4rt\Squads\Enums\SquadRole;
+use He4rt\Squads\Exceptions\NotAnActiveSquadMember;
+use He4rt\Squads\Models\Squad;
+use He4rt\Squads\Models\SquadMember;
+use He4rt\Squads\Policies\SquadPolicy;
+use Illuminate\Support\Facades\DB;
+
+final readonly class PromoteToSubCaptain
+{
+    public function __construct(
+        private SquadPolicy $squadPolicy,
+        private RecordMembershipEvent $recordMembershipEvent,
+    ) {}
+
+    public function handle(User $actor, Squad $squad, User $subject, ?string $reason = null): SquadMember
+    {
+        $this->squadPolicy->authorize($actor, $squad);
+
+        return $this->transition($squad, $subject, $actor, SquadRole::SubCaptain, $reason);
+    }
+
+    public function demote(User $actor, Squad $squad, User $subject, ?string $reason = null): SquadMember
+    {
+        $this->squadPolicy->authorize($actor, $squad);
+
+        return $this->transition($squad, $subject, $actor, SquadRole::Member, $reason);
+    }
+
+    private function transition(
+        Squad $squad,
+        User $subject,
+        User $actor,
+        SquadRole $targetRole,
+        ?string $reason,
+    ): SquadMember {
+        return DB::transaction(function () use ($squad, $subject, $actor, $targetRole, $reason): SquadMember {
+            $member = SquadMember::query()
+                ->where('squad_id', $squad->id)
+                ->where('user_id', $subject->id)
+                ->whereNot('role', SquadRole::ExMember)
+                ->lockForUpdate()
+                ->first();
+
+            throw_if($member === null, NotAnActiveSquadMember::for($squad, $subject));
+
+            $fromRole = $member->role;
+
+            if ($fromRole === $targetRole) {
+                return $member;
+            }
+
+            $member->update([
+                'role' => $targetRole,
+            ]);
+
+            $this->recordMembershipEvent->handle(
+                squad: $squad,
+                subject: $subject,
+                action: $this->actionFor($fromRole, $targetRole),
+                fromRole: $fromRole,
+                toRole: $targetRole,
+                actor: $actor,
+                reason: $reason,
+            );
+
+            return $member->refresh();
+        });
+    }
+
+    private function actionFor(SquadRole $fromRole, SquadRole $targetRole): MembershipAction
+    {
+        return $fromRole === SquadRole::Member && $targetRole === SquadRole::SubCaptain
+            ? MembershipAction::Promote
+            : MembershipAction::Demote;
+    }
+}

--- a/app-modules/squads/src/Actions/PromoteToSubCaptain.php
+++ b/app-modules/squads/src/Actions/PromoteToSubCaptain.php
@@ -14,6 +14,20 @@ use He4rt\Squads\Policies\SquadPolicy;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Facades\DB;
 
+/**
+ * Records the outcome of an off-system promotion to sub-captain, together
+ * with its inverse demotion back to `Member` — one governance concern in
+ * both directions, mirroring how `AssignCaptain` owns the captain seat.
+ *
+ * The name follows the module's action map (`CONTEXT.md`), which records
+ * outcomes rather than personas: this is not an action "for" a sub-captain;
+ * it records someone BECOMING one (or leaving that role) after a decision
+ * made off-platform, appending `promote`/`demote` to the audit trail.
+ *
+ * The seated captain is above sub-captain authority: only super-admins or
+ * the captain themselves may move that row, matching the admin-only rule
+ * `AssignCaptain` applies when it replaces an incumbent.
+ */
 final readonly class PromoteToSubCaptain
 {
     public function __construct(

--- a/app-modules/squads/src/Actions/PromoteToSubCaptain.php
+++ b/app-modules/squads/src/Actions/PromoteToSubCaptain.php
@@ -11,6 +11,7 @@ use He4rt\Squads\Exceptions\NotAnActiveSquadMember;
 use He4rt\Squads\Models\Squad;
 use He4rt\Squads\Models\SquadMember;
 use He4rt\Squads\Policies\SquadPolicy;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Facades\DB;
 
 final readonly class PromoteToSubCaptain
@@ -52,6 +53,17 @@ final readonly class PromoteToSubCaptain
             throw_if($member === null, NotAnActiveSquadMember::for($squad, $subject));
 
             $fromRole = $member->role;
+
+            // The captain seat is only moved by super-admins (via `AssignCaptain`
+            // or this action) or by the seated captain stepping down themselves.
+            // Leadership roles below the seat never outrank it, so they cannot
+            // record a transition over the current `Captain`.
+            throw_if(
+                $fromRole === SquadRole::Captain
+                    && !$actor->isAdmin()
+                    && !$actor->is($subject),
+                AuthorizationException::class,
+            );
 
             if ($fromRole === $targetRole) {
                 return $member;

--- a/app-modules/squads/src/Actions/PromoteToSubCaptain.php
+++ b/app-modules/squads/src/Actions/PromoteToSubCaptain.php
@@ -7,26 +7,20 @@ namespace He4rt\Squads\Actions;
 use He4rt\Identity\User\Models\User;
 use He4rt\Squads\Enums\MembershipAction;
 use He4rt\Squads\Enums\SquadRole;
+use He4rt\Squads\Exceptions\InvalidSquadRoleTransition;
 use He4rt\Squads\Exceptions\NotAnActiveSquadMember;
 use He4rt\Squads\Models\Squad;
 use He4rt\Squads\Models\SquadMember;
 use He4rt\Squads\Policies\SquadPolicy;
-use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Facades\DB;
 
 /**
- * Records the outcome of an off-system promotion to sub-captain, together
- * with its inverse demotion back to `Member` — one governance concern in
- * both directions, mirroring how `AssignCaptain` owns the captain seat.
+ * Records the off-system Member -> SubCaptain result and its inverse,
+ * SubCaptain -> Member, in the membership ledger.
  *
- * The name follows the module's action map (`CONTEXT.md`), which records
- * outcomes rather than personas: this is not an action "for" a sub-captain;
- * it records someone BECOMING one (or leaving that role) after a decision
- * made off-platform, appending `promote`/`demote` to the audit trail.
- *
- * The seated captain is above sub-captain authority: only super-admins or
- * the captain themselves may move that row, matching the admin-only rule
- * `AssignCaptain` applies when it replaces an incumbent.
+ * This action never mutates the captain seat. `AssignCaptain` owns captain
+ * assignment and replacement, while `MarkExMember` currently owns vacancy.
+ * The governance decision remains off-platform; this action records its result.
  */
 final readonly class PromoteToSubCaptain
 {
@@ -37,26 +31,52 @@ final readonly class PromoteToSubCaptain
 
     public function handle(User $actor, Squad $squad, User $subject, ?string $reason = null): SquadMember
     {
-        $this->squadPolicy->authorize($actor, $squad);
+        $this->squadPolicy->authorizeSubCaptainManagement($actor, $squad);
 
-        return $this->transition($squad, $subject, $actor, SquadRole::SubCaptain, $reason);
+        return $this->transition(
+            squad: $squad,
+            subject: $subject,
+            actor: $actor,
+            expectedRole: SquadRole::Member,
+            targetRole: SquadRole::SubCaptain,
+            action: MembershipAction::Promote,
+            reason: $reason,
+        );
     }
 
     public function demote(User $actor, Squad $squad, User $subject, ?string $reason = null): SquadMember
     {
-        $this->squadPolicy->authorize($actor, $squad);
+        $this->squadPolicy->authorizeSubCaptainManagement($actor, $squad);
 
-        return $this->transition($squad, $subject, $actor, SquadRole::Member, $reason);
+        return $this->transition(
+            squad: $squad,
+            subject: $subject,
+            actor: $actor,
+            expectedRole: SquadRole::SubCaptain,
+            targetRole: SquadRole::Member,
+            action: MembershipAction::Demote,
+            reason: $reason,
+        );
     }
 
     private function transition(
         Squad $squad,
         User $subject,
         User $actor,
+        SquadRole $expectedRole,
         SquadRole $targetRole,
+        MembershipAction $action,
         ?string $reason,
     ): SquadMember {
-        return DB::transaction(function () use ($squad, $subject, $actor, $targetRole, $reason): SquadMember {
+        return DB::transaction(function () use (
+            $squad,
+            $subject,
+            $actor,
+            $expectedRole,
+            $targetRole,
+            $action,
+            $reason,
+        ): SquadMember {
             $member = SquadMember::query()
                 ->where('squad_id', $squad->id)
                 ->where('user_id', $subject->id)
@@ -68,20 +88,14 @@ final readonly class PromoteToSubCaptain
 
             $fromRole = $member->role;
 
-            // The captain seat is only moved by super-admins (via `AssignCaptain`
-            // or this action) or by the seated captain stepping down themselves.
-            // Leadership roles below the seat never outrank it, so they cannot
-            // record a transition over the current `Captain`.
-            throw_if(
-                $fromRole === SquadRole::Captain
-                    && !$actor->isAdmin()
-                    && !$actor->is($subject),
-                AuthorizationException::class,
-            );
-
             if ($fromRole === $targetRole) {
                 return $member;
             }
+
+            throw_if(
+                $fromRole !== $expectedRole,
+                InvalidSquadRoleTransition::between($fromRole, $targetRole)
+            );
 
             $member->update([
                 'role' => $targetRole,
@@ -90,7 +104,7 @@ final readonly class PromoteToSubCaptain
             $this->recordMembershipEvent->handle(
                 squad: $squad,
                 subject: $subject,
-                action: $this->actionFor($fromRole, $targetRole),
+                action: $action,
                 fromRole: $fromRole,
                 toRole: $targetRole,
                 actor: $actor,
@@ -99,12 +113,5 @@ final readonly class PromoteToSubCaptain
 
             return $member->refresh();
         });
-    }
-
-    private function actionFor(SquadRole $fromRole, SquadRole $targetRole): MembershipAction
-    {
-        return $fromRole === SquadRole::Member && $targetRole === SquadRole::SubCaptain
-            ? MembershipAction::Promote
-            : MembershipAction::Demote;
     }
 }

--- a/app-modules/squads/src/Exceptions/InvalidSquadRoleTransition.php
+++ b/app-modules/squads/src/Exceptions/InvalidSquadRoleTransition.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Squads\Exceptions;
+
+use Exception;
+use He4rt\Squads\Enums\SquadRole;
+
+final class InvalidSquadRoleTransition extends Exception
+{
+    public static function between(SquadRole $from, SquadRole $to): self
+    {
+        return new self(
+            sprintf('Cannot transition squad member role from "%s" to "%s".', $from->value, $to->value)
+        );
+    }
+}

--- a/app-modules/squads/src/Policies/SquadPolicy.php
+++ b/app-modules/squads/src/Policies/SquadPolicy.php
@@ -29,4 +29,22 @@ final class SquadPolicy
     {
         throw_unless($this->canManage($actor, $squad), AuthorizationException::class);
     }
+
+    public function canManageSubCaptains(User $actor, Squad $squad): bool
+    {
+        if ($actor->isAdmin()) {
+            return true;
+        }
+
+        return SquadMember::query()
+            ->where('squad_id', $squad->id)
+            ->where('user_id', $actor->id)
+            ->where('role', SquadRole::Captain)
+            ->exists();
+    }
+
+    public function authorizeSubCaptainManagement(User $actor, Squad $squad): void
+    {
+        throw_unless($this->canManageSubCaptains($actor, $squad), AuthorizationException::class);
+    }
 }

--- a/app-modules/squads/tests/Feature/PromoteToSubCaptainTest.php
+++ b/app-modules/squads/tests/Feature/PromoteToSubCaptainTest.php
@@ -1,0 +1,312 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Identity\User\Models\User;
+use He4rt\Squads\Actions\PromoteToSubCaptain;
+use He4rt\Squads\Enums\MembershipAction;
+use He4rt\Squads\Enums\SquadRole;
+use He4rt\Squads\Exceptions\NotAnActiveSquadMember;
+use He4rt\Squads\Models\Squad;
+use He4rt\Squads\Models\SquadMember;
+use He4rt\Squads\Models\SquadMembershipEvent;
+use Illuminate\Auth\Access\AuthorizationException;
+
+beforeEach(function (): void {
+    config(['he4rt.admins' => 'guisaliba']);
+
+    $this->admin = User::factory()->create([
+        'username' => 'guisaliba',
+    ]);
+});
+
+test('a captain promotes a member to sub-captain and records the transition', function (): void {
+    $squad = Squad::factory()->create();
+    $captain = User::factory()->create();
+    $subject = User::factory()->create();
+
+    SquadMember::factory()->create([
+        'squad_id' => $squad->id,
+        'user_id' => $captain->id,
+        'role' => SquadRole::Captain,
+    ]);
+    SquadMember::factory()->create([
+        'squad_id' => $squad->id,
+        'user_id' => $subject->id,
+        'role' => SquadRole::Member,
+    ]);
+
+    $member = resolve(PromoteToSubCaptain::class)->handle(
+        actor: $captain,
+        squad: $squad,
+        subject: $subject,
+        reason: 'Elected off-system.',
+    );
+
+    expect($member->role)->toBe(SquadRole::SubCaptain);
+
+    $this->assertDatabaseHas('squad_membership_events', [
+        'squad_id' => $squad->id,
+        'user_id' => $subject->id,
+        'actor_id' => $captain->id,
+        'action' => MembershipAction::Promote->value,
+        'from_role' => SquadRole::Member->value,
+        'to_role' => SquadRole::SubCaptain->value,
+        'reason' => 'Elected off-system.',
+    ]);
+});
+
+test('a captain demotes a sub-captain to member and records the transition', function (): void {
+    $squad = Squad::factory()->create();
+    $captain = User::factory()->create();
+    $subject = User::factory()->create();
+
+    SquadMember::factory()->create([
+        'squad_id' => $squad->id,
+        'user_id' => $captain->id,
+        'role' => SquadRole::Captain,
+    ]);
+    SquadMember::factory()->create([
+        'squad_id' => $squad->id,
+        'user_id' => $subject->id,
+        'role' => SquadRole::SubCaptain,
+    ]);
+
+    $member = resolve(PromoteToSubCaptain::class)->demote(
+        actor: $captain,
+        squad: $squad,
+        subject: $subject,
+    );
+
+    expect($member->role)->toBe(SquadRole::Member);
+
+    $this->assertDatabaseHas('squad_membership_events', [
+        'squad_id' => $squad->id,
+        'user_id' => $subject->id,
+        'actor_id' => $captain->id,
+        'action' => MembershipAction::Demote->value,
+        'from_role' => SquadRole::SubCaptain->value,
+        'to_role' => SquadRole::Member->value,
+    ]);
+});
+
+test('a captain can become a sub-captain and vacate the captain seat', function (): void {
+    $squad = Squad::factory()->create();
+    $captain = User::factory()->create();
+
+    SquadMember::factory()->create([
+        'squad_id' => $squad->id,
+        'user_id' => $captain->id,
+        'role' => SquadRole::Captain,
+    ]);
+
+    $member = resolve(PromoteToSubCaptain::class)->handle(
+        actor: $captain,
+        squad: $squad,
+        subject: $captain,
+    );
+
+    expect($member->role)->toBe(SquadRole::SubCaptain)
+        ->and($squad->captain()->first())->toBeNull();
+
+    $this->assertDatabaseHas('squad_membership_events', [
+        'squad_id' => $squad->id,
+        'user_id' => $captain->id,
+        'actor_id' => $captain->id,
+        'action' => MembershipAction::Demote->value,
+        'from_role' => SquadRole::Captain->value,
+        'to_role' => SquadRole::SubCaptain->value,
+    ]);
+});
+
+test('a super-admin can demote a captain to member', function (): void {
+    $squad = Squad::factory()->create();
+    $captain = User::factory()->create();
+
+    SquadMember::factory()->create([
+        'squad_id' => $squad->id,
+        'user_id' => $captain->id,
+        'role' => SquadRole::Captain,
+    ]);
+
+    $member = resolve(PromoteToSubCaptain::class)->demote(
+        actor: $this->admin,
+        squad: $squad,
+        subject: $captain,
+    );
+
+    expect($member->role)->toBe(SquadRole::Member)
+        ->and($squad->captain()->first())->toBeNull();
+
+    $this->assertDatabaseHas('squad_membership_events', [
+        'squad_id' => $squad->id,
+        'user_id' => $captain->id,
+        'actor_id' => $this->admin->id,
+        'action' => MembershipAction::Demote->value,
+        'from_role' => SquadRole::Captain->value,
+        'to_role' => SquadRole::Member->value,
+    ]);
+});
+
+test('a sub-captain can promote a member in their own squad', function (): void {
+    $squad = Squad::factory()->create();
+    $subCaptain = User::factory()->create();
+    $subject = User::factory()->create();
+
+    SquadMember::factory()->create([
+        'squad_id' => $squad->id,
+        'user_id' => $subCaptain->id,
+        'role' => SquadRole::SubCaptain,
+    ]);
+    SquadMember::factory()->create([
+        'squad_id' => $squad->id,
+        'user_id' => $subject->id,
+        'role' => SquadRole::Member,
+    ]);
+
+    resolve(PromoteToSubCaptain::class)->handle(
+        actor: $subCaptain,
+        squad: $squad,
+        subject: $subject,
+    );
+
+    $this->assertDatabaseHas('squad_members', [
+        'squad_id' => $squad->id,
+        'user_id' => $subject->id,
+        'role' => SquadRole::SubCaptain->value,
+    ]);
+});
+
+test('a common member cannot change a squad role', function (): void {
+    $squad = Squad::factory()->create();
+    $actor = User::factory()->create();
+    $subject = User::factory()->create();
+
+    SquadMember::factory()->create([
+        'squad_id' => $squad->id,
+        'user_id' => $actor->id,
+        'role' => SquadRole::Member,
+    ]);
+    SquadMember::factory()->create([
+        'squad_id' => $squad->id,
+        'user_id' => $subject->id,
+        'role' => SquadRole::Member,
+    ]);
+
+    resolve(PromoteToSubCaptain::class)->handle(
+        actor: $actor,
+        squad: $squad,
+        subject: $subject,
+    );
+})->throws(AuthorizationException::class);
+
+test('a leader cannot change a different squad', function (): void {
+    $ownSquad = Squad::factory()->create();
+    $otherSquad = Squad::factory()->create();
+    $captain = User::factory()->create();
+    $subject = User::factory()->create();
+
+    SquadMember::factory()->create([
+        'squad_id' => $ownSquad->id,
+        'user_id' => $captain->id,
+        'role' => SquadRole::Captain,
+    ]);
+    SquadMember::factory()->create([
+        'squad_id' => $otherSquad->id,
+        'user_id' => $subject->id,
+        'role' => SquadRole::Member,
+    ]);
+
+    resolve(PromoteToSubCaptain::class)->handle(
+        actor: $captain,
+        squad: $otherSquad,
+        subject: $subject,
+    );
+})->throws(AuthorizationException::class);
+
+test('a missing active membership cannot be changed', function (): void {
+    $squad = Squad::factory()->create();
+    $subject = User::factory()->create();
+
+    resolve(PromoteToSubCaptain::class)->handle(
+        actor: $this->admin,
+        squad: $squad,
+        subject: $subject,
+    );
+})->throws(NotAnActiveSquadMember::class);
+
+test('an ex-member cannot be changed', function (): void {
+    $squad = Squad::factory()->create();
+    $subject = User::factory()->create();
+
+    SquadMember::factory()->create([
+        'squad_id' => $squad->id,
+        'user_id' => $subject->id,
+        'role' => SquadRole::ExMember,
+    ]);
+
+    resolve(PromoteToSubCaptain::class)->handle(
+        actor: $this->admin,
+        squad: $squad,
+        subject: $subject,
+    );
+})->throws(NotAnActiveSquadMember::class);
+
+test('same-state role changes create no event', function (): void {
+    $squad = Squad::factory()->create();
+    $captain = User::factory()->create();
+    $subCaptain = User::factory()->create();
+    $member = User::factory()->create();
+
+    SquadMember::factory()->create([
+        'squad_id' => $squad->id,
+        'user_id' => $captain->id,
+        'role' => SquadRole::Captain,
+    ]);
+    SquadMember::factory()->create([
+        'squad_id' => $squad->id,
+        'user_id' => $subCaptain->id,
+        'role' => SquadRole::SubCaptain,
+    ]);
+    SquadMember::factory()->create([
+        'squad_id' => $squad->id,
+        'user_id' => $member->id,
+        'role' => SquadRole::Member,
+    ]);
+
+    resolve(PromoteToSubCaptain::class)->handle(
+        actor: $captain,
+        squad: $squad,
+        subject: $subCaptain,
+    );
+    resolve(PromoteToSubCaptain::class)->demote(
+        actor: $captain,
+        squad: $squad,
+        subject: $member,
+    );
+
+    expect(SquadMembershipEvent::query()->where('squad_id', $squad->id)->count())->toBe(0);
+});
+
+test('a sub-captain can demote themselves', function (): void {
+    $squad = Squad::factory()->create();
+    $subCaptain = User::factory()->create();
+
+    SquadMember::factory()->create([
+        'squad_id' => $squad->id,
+        'user_id' => $subCaptain->id,
+        'role' => SquadRole::SubCaptain,
+    ]);
+
+    resolve(PromoteToSubCaptain::class)->demote(
+        actor: $subCaptain,
+        squad: $squad,
+        subject: $subCaptain,
+    );
+
+    $this->assertDatabaseHas('squad_members', [
+        'squad_id' => $squad->id,
+        'user_id' => $subCaptain->id,
+        'role' => SquadRole::Member->value,
+    ]);
+});

--- a/app-modules/squads/tests/Feature/PromoteToSubCaptainTest.php
+++ b/app-modules/squads/tests/Feature/PromoteToSubCaptainTest.php
@@ -288,6 +288,52 @@ test('same-state role changes create no event', function (): void {
     expect(SquadMembershipEvent::query()->where('squad_id', $squad->id)->count())->toBe(0);
 });
 
+test('a sub-captain cannot demote the squad captain', function (): void {
+    $squad = Squad::factory()->create();
+    $subCaptain = User::factory()->create();
+    $captain = User::factory()->create();
+
+    SquadMember::factory()->create([
+        'squad_id' => $squad->id,
+        'user_id' => $subCaptain->id,
+        'role' => SquadRole::SubCaptain,
+    ]);
+    SquadMember::factory()->create([
+        'squad_id' => $squad->id,
+        'user_id' => $captain->id,
+        'role' => SquadRole::Captain,
+    ]);
+
+    resolve(PromoteToSubCaptain::class)->demote(
+        actor: $subCaptain,
+        squad: $squad,
+        subject: $captain,
+    );
+})->throws(AuthorizationException::class);
+
+test('a sub-captain cannot move the captain down to sub-captain', function (): void {
+    $squad = Squad::factory()->create();
+    $subCaptain = User::factory()->create();
+    $captain = User::factory()->create();
+
+    SquadMember::factory()->create([
+        'squad_id' => $squad->id,
+        'user_id' => $subCaptain->id,
+        'role' => SquadRole::SubCaptain,
+    ]);
+    SquadMember::factory()->create([
+        'squad_id' => $squad->id,
+        'user_id' => $captain->id,
+        'role' => SquadRole::Captain,
+    ]);
+
+    resolve(PromoteToSubCaptain::class)->handle(
+        actor: $subCaptain,
+        squad: $squad,
+        subject: $captain,
+    );
+})->throws(AuthorizationException::class);
+
 test('a sub-captain can demote themselves', function (): void {
     $squad = Squad::factory()->create();
     $subCaptain = User::factory()->create();

--- a/app-modules/squads/tests/Feature/PromoteToSubCaptainTest.php
+++ b/app-modules/squads/tests/Feature/PromoteToSubCaptainTest.php
@@ -6,6 +6,7 @@ use He4rt\Identity\User\Models\User;
 use He4rt\Squads\Actions\PromoteToSubCaptain;
 use He4rt\Squads\Enums\MembershipAction;
 use He4rt\Squads\Enums\SquadRole;
+use He4rt\Squads\Exceptions\InvalidSquadRoleTransition;
 use He4rt\Squads\Exceptions\NotAnActiveSquadMember;
 use He4rt\Squads\Models\Squad;
 use He4rt\Squads\Models\SquadMember;
@@ -56,6 +57,34 @@ test('a captain promotes a member to sub-captain and records the transition', fu
     ]);
 });
 
+test('a super-admin promotes a member without belonging to the squad', function (): void {
+    $squad = Squad::factory()->create();
+    $subject = User::factory()->create();
+
+    SquadMember::factory()->create([
+        'squad_id' => $squad->id,
+        'user_id' => $subject->id,
+        'role' => SquadRole::Member,
+    ]);
+
+    $member = resolve(PromoteToSubCaptain::class)->handle(
+        actor: $this->admin,
+        squad: $squad,
+        subject: $subject,
+    );
+
+    expect($member->role)->toBe(SquadRole::SubCaptain);
+
+    $this->assertDatabaseHas('squad_membership_events', [
+        'squad_id' => $squad->id,
+        'user_id' => $subject->id,
+        'actor_id' => $this->admin->id,
+        'action' => MembershipAction::Promote->value,
+        'from_role' => SquadRole::Member->value,
+        'to_role' => SquadRole::SubCaptain->value,
+    ]);
+});
+
 test('a captain demotes a sub-captain to member and records the transition', function (): void {
     $squad = Squad::factory()->create();
     $captain = User::factory()->create();
@@ -90,65 +119,73 @@ test('a captain demotes a sub-captain to member and records the transition', fun
     ]);
 });
 
-test('a captain can become a sub-captain and vacate the captain seat', function (): void {
+test('a super-admin demotes a sub-captain without belonging to the squad', function (): void {
     $squad = Squad::factory()->create();
-    $captain = User::factory()->create();
+    $subject = User::factory()->create();
 
     SquadMember::factory()->create([
         'squad_id' => $squad->id,
-        'user_id' => $captain->id,
-        'role' => SquadRole::Captain,
-    ]);
-
-    $member = resolve(PromoteToSubCaptain::class)->handle(
-        actor: $captain,
-        squad: $squad,
-        subject: $captain,
-    );
-
-    expect($member->role)->toBe(SquadRole::SubCaptain)
-        ->and($squad->captain()->first())->toBeNull();
-
-    $this->assertDatabaseHas('squad_membership_events', [
-        'squad_id' => $squad->id,
-        'user_id' => $captain->id,
-        'actor_id' => $captain->id,
-        'action' => MembershipAction::Demote->value,
-        'from_role' => SquadRole::Captain->value,
-        'to_role' => SquadRole::SubCaptain->value,
-    ]);
-});
-
-test('a super-admin can demote a captain to member', function (): void {
-    $squad = Squad::factory()->create();
-    $captain = User::factory()->create();
-
-    SquadMember::factory()->create([
-        'squad_id' => $squad->id,
-        'user_id' => $captain->id,
-        'role' => SquadRole::Captain,
+        'user_id' => $subject->id,
+        'role' => SquadRole::SubCaptain,
     ]);
 
     $member = resolve(PromoteToSubCaptain::class)->demote(
         actor: $this->admin,
         squad: $squad,
-        subject: $captain,
+        subject: $subject,
     );
 
-    expect($member->role)->toBe(SquadRole::Member)
-        ->and($squad->captain()->first())->toBeNull();
+    expect($member->role)->toBe(SquadRole::Member);
 
     $this->assertDatabaseHas('squad_membership_events', [
         'squad_id' => $squad->id,
-        'user_id' => $captain->id,
+        'user_id' => $subject->id,
         'actor_id' => $this->admin->id,
         'action' => MembershipAction::Demote->value,
-        'from_role' => SquadRole::Captain->value,
+        'from_role' => SquadRole::SubCaptain->value,
         'to_role' => SquadRole::Member->value,
     ]);
 });
 
-test('a sub-captain can promote a member in their own squad', function (): void {
+test('a captain cannot become a sub-captain through this action', function (): void {
+    $squad = Squad::factory()->create();
+    $captain = User::factory()->create();
+
+    $membership = SquadMember::factory()->create([
+        'squad_id' => $squad->id,
+        'user_id' => $captain->id,
+        'role' => SquadRole::Captain,
+    ]);
+
+    expect(fn () => resolve(PromoteToSubCaptain::class)->handle(
+        actor: $this->admin,
+        squad: $squad,
+        subject: $captain,
+    ))->toThrow(InvalidSquadRoleTransition::class)
+        ->and($membership->refresh()->role)->toBe(SquadRole::Captain)
+        ->and(SquadMembershipEvent::query()->where('squad_id', $squad->id)->count())->toBe(0);
+});
+
+test('a captain cannot become a member through this action', function (): void {
+    $squad = Squad::factory()->create();
+    $captain = User::factory()->create();
+
+    $membership = SquadMember::factory()->create([
+        'squad_id' => $squad->id,
+        'user_id' => $captain->id,
+        'role' => SquadRole::Captain,
+    ]);
+
+    expect(fn () => resolve(PromoteToSubCaptain::class)->demote(
+        actor: $this->admin,
+        squad: $squad,
+        subject: $captain,
+    ))->toThrow(InvalidSquadRoleTransition::class)
+        ->and($membership->refresh()->role)->toBe(SquadRole::Captain)
+        ->and(SquadMembershipEvent::query()->where('squad_id', $squad->id)->count())->toBe(0);
+});
+
+test('a sub-captain cannot promote a member in their own squad', function (): void {
     $squad = Squad::factory()->create();
     $subCaptain = User::factory()->create();
     $subject = User::factory()->create();
@@ -158,23 +195,19 @@ test('a sub-captain can promote a member in their own squad', function (): void 
         'user_id' => $subCaptain->id,
         'role' => SquadRole::SubCaptain,
     ]);
-    SquadMember::factory()->create([
+    $membership = SquadMember::factory()->create([
         'squad_id' => $squad->id,
         'user_id' => $subject->id,
         'role' => SquadRole::Member,
     ]);
 
-    resolve(PromoteToSubCaptain::class)->handle(
+    expect(fn () => resolve(PromoteToSubCaptain::class)->handle(
         actor: $subCaptain,
         squad: $squad,
         subject: $subject,
-    );
-
-    $this->assertDatabaseHas('squad_members', [
-        'squad_id' => $squad->id,
-        'user_id' => $subject->id,
-        'role' => SquadRole::SubCaptain->value,
-    ]);
+    ))->toThrow(AuthorizationException::class)
+        ->and($membership->refresh()->role)->toBe(SquadRole::Member)
+        ->and(SquadMembershipEvent::query()->where('squad_id', $squad->id)->count())->toBe(0);
 });
 
 test('a common member cannot change a squad role', function (): void {
@@ -187,18 +220,20 @@ test('a common member cannot change a squad role', function (): void {
         'user_id' => $actor->id,
         'role' => SquadRole::Member,
     ]);
-    SquadMember::factory()->create([
+    $membership = SquadMember::factory()->create([
         'squad_id' => $squad->id,
         'user_id' => $subject->id,
         'role' => SquadRole::Member,
     ]);
 
-    resolve(PromoteToSubCaptain::class)->handle(
+    expect(fn () => resolve(PromoteToSubCaptain::class)->handle(
         actor: $actor,
         squad: $squad,
         subject: $subject,
-    );
-})->throws(AuthorizationException::class);
+    ))->toThrow(AuthorizationException::class)
+        ->and($membership->refresh()->role)->toBe(SquadRole::Member)
+        ->and(SquadMembershipEvent::query()->where('squad_id', $squad->id)->count())->toBe(0);
+});
 
 test('a leader cannot change a different squad', function (): void {
     $ownSquad = Squad::factory()->create();
@@ -211,46 +246,51 @@ test('a leader cannot change a different squad', function (): void {
         'user_id' => $captain->id,
         'role' => SquadRole::Captain,
     ]);
-    SquadMember::factory()->create([
+    $membership = SquadMember::factory()->create([
         'squad_id' => $otherSquad->id,
         'user_id' => $subject->id,
         'role' => SquadRole::Member,
     ]);
 
-    resolve(PromoteToSubCaptain::class)->handle(
+    expect(fn () => resolve(PromoteToSubCaptain::class)->handle(
         actor: $captain,
         squad: $otherSquad,
         subject: $subject,
-    );
-})->throws(AuthorizationException::class);
+    ))->toThrow(AuthorizationException::class)
+        ->and($membership->refresh()->role)->toBe(SquadRole::Member)
+        ->and(SquadMembershipEvent::query()->where('squad_id', $otherSquad->id)->count())->toBe(0);
+});
 
-test('a missing active membership cannot be changed', function (): void {
+test('a missing active membership cannot be changed with :method', function (string $method): void {
     $squad = Squad::factory()->create();
     $subject = User::factory()->create();
 
-    resolve(PromoteToSubCaptain::class)->handle(
+    expect(fn () => resolve(PromoteToSubCaptain::class)->{$method}(
         actor: $this->admin,
         squad: $squad,
         subject: $subject,
-    );
-})->throws(NotAnActiveSquadMember::class);
+    ))->toThrow(NotAnActiveSquadMember::class)
+        ->and(SquadMembershipEvent::query()->where('squad_id', $squad->id)->count())->toBe(0);
+})->with(['handle', 'demote']);
 
-test('an ex-member cannot be changed', function (): void {
+test('an ex-member cannot be changed with :method', function (string $method): void {
     $squad = Squad::factory()->create();
     $subject = User::factory()->create();
 
-    SquadMember::factory()->create([
+    $membership = SquadMember::factory()->create([
         'squad_id' => $squad->id,
         'user_id' => $subject->id,
         'role' => SquadRole::ExMember,
     ]);
 
-    resolve(PromoteToSubCaptain::class)->handle(
+    expect(fn () => resolve(PromoteToSubCaptain::class)->{$method}(
         actor: $this->admin,
         squad: $squad,
         subject: $subject,
-    );
-})->throws(NotAnActiveSquadMember::class);
+    ))->toThrow(NotAnActiveSquadMember::class)
+        ->and($membership->refresh()->role)->toBe(SquadRole::ExMember)
+        ->and(SquadMembershipEvent::query()->where('squad_id', $squad->id)->count())->toBe(0);
+})->with(['handle', 'demote']);
 
 test('same-state role changes create no event', function (): void {
     $squad = Squad::factory()->create();
@@ -263,12 +303,12 @@ test('same-state role changes create no event', function (): void {
         'user_id' => $captain->id,
         'role' => SquadRole::Captain,
     ]);
-    SquadMember::factory()->create([
+    $subCaptainMembership = SquadMember::factory()->create([
         'squad_id' => $squad->id,
         'user_id' => $subCaptain->id,
         'role' => SquadRole::SubCaptain,
     ]);
-    SquadMember::factory()->create([
+    $memberMembership = SquadMember::factory()->create([
         'squad_id' => $squad->id,
         'user_id' => $member->id,
         'role' => SquadRole::Member,
@@ -285,74 +325,51 @@ test('same-state role changes create no event', function (): void {
         subject: $member,
     );
 
-    expect(SquadMembershipEvent::query()->where('squad_id', $squad->id)->count())->toBe(0);
+    expect($subCaptainMembership->refresh()->role)->toBe(SquadRole::SubCaptain)
+        ->and($memberMembership->refresh()->role)->toBe(SquadRole::Member)
+        ->and(SquadMembershipEvent::query()->where('squad_id', $squad->id)->count())->toBe(0);
 });
 
-test('a sub-captain cannot demote the squad captain', function (): void {
+test('a sub-captain cannot demote another sub-captain', function (): void {
     $squad = Squad::factory()->create();
     $subCaptain = User::factory()->create();
-    $captain = User::factory()->create();
+    $subject = User::factory()->create();
 
     SquadMember::factory()->create([
         'squad_id' => $squad->id,
         'user_id' => $subCaptain->id,
         'role' => SquadRole::SubCaptain,
     ]);
-    SquadMember::factory()->create([
+    $membership = SquadMember::factory()->create([
         'squad_id' => $squad->id,
-        'user_id' => $captain->id,
-        'role' => SquadRole::Captain,
+        'user_id' => $subject->id,
+        'role' => SquadRole::SubCaptain,
     ]);
 
-    resolve(PromoteToSubCaptain::class)->demote(
+    expect(fn () => resolve(PromoteToSubCaptain::class)->demote(
         actor: $subCaptain,
         squad: $squad,
-        subject: $captain,
-    );
-})->throws(AuthorizationException::class);
+        subject: $subject,
+    ))->toThrow(AuthorizationException::class)
+        ->and($membership->refresh()->role)->toBe(SquadRole::SubCaptain)
+        ->and(SquadMembershipEvent::query()->where('squad_id', $squad->id)->count())->toBe(0);
+});
 
-test('a sub-captain cannot move the captain down to sub-captain', function (): void {
-    $squad = Squad::factory()->create();
-    $subCaptain = User::factory()->create();
-    $captain = User::factory()->create();
-
-    SquadMember::factory()->create([
-        'squad_id' => $squad->id,
-        'user_id' => $subCaptain->id,
-        'role' => SquadRole::SubCaptain,
-    ]);
-    SquadMember::factory()->create([
-        'squad_id' => $squad->id,
-        'user_id' => $captain->id,
-        'role' => SquadRole::Captain,
-    ]);
-
-    resolve(PromoteToSubCaptain::class)->handle(
-        actor: $subCaptain,
-        squad: $squad,
-        subject: $captain,
-    );
-})->throws(AuthorizationException::class);
-
-test('a sub-captain can demote themselves', function (): void {
+test('a sub-captain cannot demote themselves', function (): void {
     $squad = Squad::factory()->create();
     $subCaptain = User::factory()->create();
 
-    SquadMember::factory()->create([
+    $membership = SquadMember::factory()->create([
         'squad_id' => $squad->id,
         'user_id' => $subCaptain->id,
         'role' => SquadRole::SubCaptain,
     ]);
 
-    resolve(PromoteToSubCaptain::class)->demote(
+    expect(fn () => resolve(PromoteToSubCaptain::class)->demote(
         actor: $subCaptain,
         squad: $squad,
         subject: $subCaptain,
-    );
-
-    $this->assertDatabaseHas('squad_members', [
-        'squad_id' => $squad->id,
-        'user_id' => $subCaptain->id,
-        'role' => SquadRole::Member->value,
-    ]);
+    ))->toThrow(AuthorizationException::class)
+        ->and($membership->refresh()->role)->toBe(SquadRole::SubCaptain)
+        ->and(SquadMembershipEvent::query()->where('squad_id', $squad->id)->count())->toBe(0);
 });

--- a/app-modules/squads/tests/Feature/SquadPolicyTest.php
+++ b/app-modules/squads/tests/Feature/SquadPolicyTest.php
@@ -94,3 +94,67 @@ describe('SquadPolicy', static function (): void {
         $policy->authorize($member, $squad);
     })->throws(AuthorizationException::class);
 });
+
+describe('SquadPolicy sub-captain management', static function (): void {
+    test('a captain can manage sub-captains in their own squad', function (): void {
+        $squad = Squad::factory()->create();
+        $captain = User::factory()->create();
+
+        SquadMember::factory()->create([
+            'squad_id' => $squad->id,
+            'user_id' => $captain->id,
+            'role' => SquadRole::Captain,
+        ]);
+
+        expect(resolve(SquadPolicy::class)->canManageSubCaptains($captain, $squad))->toBeTrue();
+    });
+
+    test('a super-admin can manage sub-captains in any squad', function (): void {
+        config(['he4rt.admins' => 'guisaliba']);
+
+        $squad = Squad::factory()->create();
+        $admin = User::factory()->create(['username' => 'guisaliba']);
+
+        expect(resolve(SquadPolicy::class)->canManageSubCaptains($admin, $squad))->toBeTrue();
+    });
+
+    test('a sub-captain cannot manage sub-captains', function (): void {
+        $squad = Squad::factory()->create();
+        $subCaptain = User::factory()->create();
+
+        SquadMember::factory()->create([
+            'squad_id' => $squad->id,
+            'user_id' => $subCaptain->id,
+            'role' => SquadRole::SubCaptain,
+        ]);
+
+        expect(resolve(SquadPolicy::class)->canManageSubCaptains($subCaptain, $squad))->toBeFalse();
+    });
+
+    test('a common member cannot manage sub-captains', function (): void {
+        $squad = Squad::factory()->create();
+        $member = User::factory()->create();
+
+        SquadMember::factory()->create([
+            'squad_id' => $squad->id,
+            'user_id' => $member->id,
+            'role' => SquadRole::Member,
+        ]);
+
+        expect(resolve(SquadPolicy::class)->canManageSubCaptains($member, $squad))->toBeFalse();
+    });
+
+    test('a captain cannot manage sub-captains in another squad', function (): void {
+        $ownSquad = Squad::factory()->create();
+        $otherSquad = Squad::factory()->create();
+        $captain = User::factory()->create();
+
+        SquadMember::factory()->create([
+            'squad_id' => $ownSquad->id,
+            'user_id' => $captain->id,
+            'role' => SquadRole::Captain,
+        ]);
+
+        expect(resolve(SquadPolicy::class)->canManageSubCaptains($captain, $otherSquad))->toBeFalse();
+    });
+});


### PR DESCRIPTION
Closes #358

Parent: #342

## What changed

- `PromoteToSubCaptain::handle()` agora registra somente `Member -> SubCaptain`.
- `PromoteToSubCaptain::demote()` agora registra somente `SubCaptain -> Member`.
- Somente o capitão da própria squad ou um super-admin pode promover ou rebaixar subcapitães.
- Transições com a origem ativa incorreta lançam `InvalidSquadRoleTransition`.
- Chamadas no estado final esperado continuam idempotentes e não criam evento.
- Cada método público fornece o `MembershipAction` explicitamente; o fallback genérico de `actionFor()` foi removido.
- A Action não altera mais a cadeira de capitão. `AssignCaptain` registra atribuição/substituição e `MarkExMember` pode deixar a cadeira vaga.
- Mais de um `SubCaptain` continua permitido, pois não existe requisito de produto nem invariante de schema que limite essa quantidade.
- `SquadPolicy::canManage()` continua permitindo as capacidades gerais de capitão/subcapitão; a nova capacidade específica exige capitão ou super-admin.

## Concurrency

O lock da linha do subject serializa `PromoteToSubCaptain` e `AssignCaptain` quando os dois operam sobre a mesma pessoa. Com a validação estrita de origem, uma promoção atrasada que encontra `Captain` falha com `InvalidSquadRoleTransition`.

Em pessoas diferentes, esta Action não disputa o índice parcial de capitão porque nunca grava `Captain`. A corrida real está entre mutações da cadeira de capitão, como dois `AssignCaptain` concorrentes ou `AssignCaptain` contra `MarkExMember`. O conserto por lock da squad foi separado em #527.

## Verification

- `vendor/bin/pest --compact app-modules/squads/tests/Feature/PromoteToSubCaptainTest.php`: 16 testes, 42 assertions.
- `vendor/bin/pest --compact app-modules/squads/tests/Feature/SquadPolicyTest.php`: 10 testes, 12 assertions.
- `vendor/bin/pest --compact app-modules/squads/tests`: 61 testes, 132 assertions.
- `make test`: 987 testes, 3094 assertions.
- `make test-pint`: passou.
- `make test-rector`: passou, sem alterações.
- `make phpstan`: passou, sem erros.
- `git diff --check`: passou.