### PR TITLE
feat(portal): adicionar página /artigos com o acervo do dev.to

### DIFF
--- a/app-modules/portal/resources/views/articles.blade.php
+++ b/app-modules/portal/resources/views/articles.blade.php
@@ -1,0 +1,243 @@
+@php
+    // Payload mínimo para o recorte e a lente no cliente: quem assina e quais temas
+    // cada artigo carrega. Os cards já vêm renderizados do servidor — o Alpine só
+    // decide o que fica visível e o que esmaece.
+    $lensItems = collect($articles)
+        ->map(fn ($article): array => [
+            'a' => $article->authorUsername,
+            'n' => $article->authorName,
+            't' => $article->tags,
+        ])
+        ->values()
+        ->all();
+@endphp
+
+<div x-data="articlesFeed(@js($lensItems))" class="pb-20">
+    <x-portal::articles.opening-band :stats="$stats" :highlight="$highlight" />
+
+    <div class="mx-auto grid max-w-[1720px] gap-7 px-6 lg:grid-cols-[minmax(0,1fr)_320px] lg:px-12">
+        <div class="min-w-0">
+            @if ($articles === [])
+                {{-- O acervo vem de terceiro; quando o dev.to não responde a página
+                     continua de pé e diz o que houve, em vez de fingir que não há artigos. --}}
+                <div class="border-outline-low bg-elevation-01dp flex flex-col items-center gap-3 rounded-lg border border-dashed p-12 text-center">
+                    <p class="text-text-high text-sm font-semibold">Não deu para carregar o acervo agora.</p>
+                    <p class="text-text-medium max-w-sm text-xs">
+                        Os artigos vivem no dev.to e a listagem não respondeu. Tente recarregar em instantes — ou vá
+                        direto para a organização.
+                    </p>
+                    <x-he4rt::button href="https://dev.to/he4rt" target="_blank" rel="noopener" size="sm">
+                        Abrir no dev.to
+                    </x-he4rt::button>
+                </div>
+            @else
+            <x-portal::articles.toolbar :topics="$topics" :total="count($articles)" />
+
+            {{-- A grade é o padrão do servidor; o Alpine só troca para lista. Assim a
+                 página nasce com layout correto mesmo antes (ou sem) o JS. --}}
+            <div
+                class="grid gap-4 [grid-template-columns:repeat(auto-fill,minmax(260px,1fr))]"
+                x-bind:class="view === 'list' ? 'is-list !grid-cols-1' : ''"
+            >
+                @foreach ($articles as $index => $article)
+                    <x-portal::articles.card :article="$article" :index="$index" />
+                @endforeach
+            </div>
+
+            <div
+                x-show="visibleCount === 0"
+                x-cloak
+                style="display: none"
+                class="border-outline-low bg-elevation-01dp mt-4 flex flex-col items-center gap-3 rounded-lg border border-dashed p-10 text-center"
+            >
+                <p class="text-text-high text-sm font-semibold">Nenhum artigo com essa combinação.</p>
+                <p class="text-text-medium max-w-sm text-xs">
+                    O tema e a pessoa selecionados não se cruzam no acervo. As duas listas seguem ativas — dá para
+                    trocar o recorte sem sair daqui.
+                </p>
+                <button
+                    type="button"
+                    x-on:click="clearAll()"
+                    class="from-primary to-secondary text-text-light cursor-pointer rounded-md bg-gradient-to-br px-4 py-2 text-xs font-semibold transition-all duration-300 hover:scale-[1.02] active:scale-95"
+                >
+                    limpar tudo
+                </button>
+            </div>
+            @endif
+        </div>
+
+        {{-- No telefone a coluna de pessoas vai para baixo do feed: empilhar 17 linhas
+             acima dos cards custaria a dobra inteira. --}}
+        @if ($authors !== [])
+            <div class="order-last lg:sticky lg:top-4 lg:order-none lg:self-start">
+                <x-portal::articles.author-rail :authors="$authors" />
+            </div>
+        @endif
+    </div>
+
+    {{-- Componente class-based: o Livewire 4 exige @assets/@script para JS de componente.
+         @assets é o bloco certo aqui — roda uma vez por página e antes dos scripts,
+         que é o que o registro de Alpine.data() precisa para existir quando o Alpine sobe. --}}
+    @assets
+    <script>
+        document.addEventListener('alpine:init', () => {
+            Alpine.data('articlesFeed', (items) => ({
+                items,
+                author: null,
+                topic: null,
+                view: 'grid',
+                authorSort: 'articles',
+                topicsOpen: false,
+                topicsMaxHeight: 420,
+                lensType: null,
+                lensKey: null,
+                lensTimer: null,
+                lensEnabled: false,
+
+                // Recorte compartilhável: sem isso, "olha os artigos da Cherry" não cabe
+                // num link. Os valores são conferidos contra o acervo antes de aplicar,
+                // para um parâmetro inventado não deixar a página num estado vazio.
+                syncUrl() {
+                    const url = new URL(window.location.href)
+                    this.author ? url.searchParams.set('autor', this.author) : url.searchParams.delete('autor')
+                    this.topic ? url.searchParams.set('tema', this.topic) : url.searchParams.delete('tema')
+                    window.history.replaceState({}, '', url)
+                },
+
+                readUrl() {
+                    const params = new URLSearchParams(window.location.search)
+                    const autor = params.get('autor')
+                    const tema = params.get('tema')
+
+                    if (autor && this.items.some((item) => item.a === autor)) this.author = autor
+                    if (tema && this.items.some((item) => item.t.includes(tema))) this.topic = tema
+                },
+
+                init() {
+                    this.readUrl()
+                    this.$watch('author', () => this.syncUrl())
+                    this.$watch('topic', () => this.syncUrl())
+
+                    // A lente é um afeto de ponteiro: no toque viraria clique acidental,
+                    // e sob reduced-motion não deve piscar opacidade.
+                    this.lensEnabled =
+                        window.matchMedia('(hover: hover) and (pointer: fine)').matches &&
+                        !window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+                    this.$watch('topicsOpen', (open) => open && this.$nextTick(() => this.measurePanel()))
+                    window.addEventListener('resize', () => this.measurePanel(), { passive: true })
+                    window.addEventListener('scroll', () => this.topicsOpen && this.measurePanel(), { passive: true })
+
+                    // As webfontes chegam depois e empurram a faixa de abertura: sem
+                    // remedir aqui, a primeira medida do painel mente.
+                    if (document.fonts && document.fonts.ready) {
+                        document.fonts.ready.then(() => this.measurePanel())
+                    }
+                },
+
+                measurePanel() {
+                    const panel = this.$refs.topicsPanel
+                    if (!panel) return
+                    const top = panel.getBoundingClientRect().top
+                    this.topicsMaxHeight = Math.max(180, window.innerHeight - top - 16)
+                },
+
+                matchesFilters(index) {
+                    const item = this.items[index]
+                    if (this.author && item.a !== this.author) return false
+                    if (this.topic && !item.t.includes(this.topic)) return false
+                    return true
+                },
+
+                isVisible(index) {
+                    return this.matchesFilters(index)
+                },
+
+                get visibleCount() {
+                    return this.items.reduce((total, _, index) => total + (this.matchesFilters(index) ? 1 : 0), 0)
+                },
+
+                get hasFilters() {
+                    return this.author !== null || this.topic !== null
+                },
+
+                clearAll() {
+                    this.author = null
+                    this.topic = null
+                },
+
+                toggleAuthor(username) {
+                    this.author = this.author === username ? null : username
+                },
+
+                toggleTopic(tag) {
+                    this.topic = this.topic === tag ? null : tag
+                },
+
+                authorName(username) {
+                    const item = this.items.find((candidate) => candidate.a === username)
+                    return item ? item.n : username
+                },
+
+                lensEnter(type, key) {
+                    if (!this.lensEnabled) return
+                    // O atraso evita a página piscar quando o ponteiro atravessa a lista.
+                    clearTimeout(this.lensTimer)
+                    this.lensTimer = setTimeout(() => {
+                        this.lensType = type
+                        this.lensKey = key
+                    }, 120)
+                },
+
+                lensLeave() {
+                    clearTimeout(this.lensTimer)
+                    this.lensType = null
+                    this.lensKey = null
+                },
+
+                get lensOn() {
+                    return this.lensEnabled && this.lensKey !== null
+                },
+
+                get lensArticles() {
+                    if (!this.lensOn) return null
+                    if (this.lensType === 'article') return new Set([this.lensKey])
+
+                    const key = this.lensKey
+                    const matches =
+                        this.lensType === 'author'
+                            ? (item) => item.a === key
+                            : (item) => item.t.includes(key)
+
+                    const found = new Set()
+                    this.items.forEach((item, index) => matches(item) && found.add(index))
+                    return found
+                },
+
+                get lensAuthors() {
+                    if (!this.lensOn) return null
+                    const found = new Set()
+                    this.lensArticles.forEach((index) => found.add(this.items[index].a))
+                    return found
+                },
+
+                get lensTopics() {
+                    if (!this.lensOn) return null
+                    const found = new Set()
+                    this.lensArticles.forEach((index) => this.items[index].t.forEach((tag) => found.add(tag)))
+                    return found
+                },
+
+                // Esmaece o que não se relaciona, em vez de acender o que se relaciona:
+                // lê mais rápido e não transforma a página num painel de luzes.
+                isDim(kind, key) {
+                    if (!this.lensOn) return false
+                    if (kind === 'article') return !this.lensArticles.has(key)
+                    if (kind === 'author') return !this.lensAuthors.has(key)
+                    return !this.lensTopics.has(key)
+                },
+            }))
+        })
+    </script>
+    @endassets
+</div>

--- a/app-modules/portal/resources/views/components/articles/author-rail.blade.php
+++ b/app-modules/portal/resources/views/components/articles/author-rail.blade.php
@@ -1,0 +1,68 @@
+@props([
+    'authors',
+])
+
+@php
+    // Posto de cada pessoa quando a coluna é ordenada por alcance. A reordenação
+    // acontece por `order` no flex, o que preserva a renderização no servidor.
+    $byReactions = collect($authors)->sortByDesc(fn ($author): int => $author->reactions)->values();
+    $reactionRank = $byReactions->mapWithKeys(fn ($author, int $rank): array => [$author->username => $rank])->all();
+@endphp
+
+<aside class="flex flex-col gap-3" aria-labelledby="articles-authors-heading">
+    <div class="flex items-baseline justify-between gap-2">
+        <h2 id="articles-authors-heading" class="text-text-medium font-mono text-xs tracking-[0.2em] uppercase">
+            Quem escreve
+        </h2>
+        <span class="text-text-low font-mono text-[0.65rem]">artigos · reações</span>
+    </div>
+
+    {{-- Volume e alcance divergem no acervo: quem publicou uma vez pode ter mais
+         reações que quem publicou quatro. Por isso as duas ordens são oferecidas. --}}
+    <div class="flex items-center gap-1" role="group" aria-label="Ordenar pessoas">
+        @foreach ([['articles', 'artigos'], ['reactions', 'reações']] as [$mode, $label])
+            <button
+                type="button"
+                x-on:click="authorSort = '{{ $mode }}'"
+                x-bind:aria-pressed="authorSort === '{{ $mode }}' ? 'true' : 'false'"
+                x-bind:class="authorSort === '{{ $mode }}'
+                    ? 'border-transparent bg-gradient-to-br from-primary to-secondary text-text-light'
+                    : 'border-outline-dark text-text-medium hover:border-primary hover:bg-primary/10'"
+                class="flex-1 cursor-pointer rounded-md border px-2 py-1.5 text-xs font-medium transition-all duration-300 active:scale-95"
+            >
+                {{ $label }}
+            </button>
+        @endforeach
+    </div>
+
+    <ul class="flex flex-col">
+        @foreach ($authors as $author)
+            <li x-bind:style="{ order: authorSort === 'reactions' ? {{ $reactionRank[$author->username] }} : {{ $loop->index }} }">
+                <button
+                    type="button"
+                    x-on:click="toggleAuthor(@js($author->username))"
+                    x-on:mouseenter="lensEnter('author', @js($author->username))"
+                    x-on:mouseleave="lensLeave()"
+                    x-bind:aria-pressed="author === @js($author->username) ? 'true' : 'false'"
+                    x-bind:class="{
+                        'bg-primary/16': author === @js($author->username),
+                        'opacity-30': isDim('author', @js($author->username)),
+                    }"
+                    class="hover:bg-primary/10 text-text-high flex w-full cursor-pointer items-center gap-2.5 rounded-md px-2 py-1.5 text-start transition-[background-color,opacity] duration-200"
+                >
+                    <img src="{{ $author->avatar }}" alt="" loading="lazy" decoding="async" width="90" height="90" class="size-7 shrink-0 rounded-full" />
+                    <span class="min-w-0 flex-1 truncate text-xs font-medium">{{ $author->name }}</span>
+                    <span class="text-text-medium shrink-0 font-mono text-xs tabular-nums">
+                        {{ $author->articleCount }}
+                        <span class="text-text-low mx-0.5" aria-hidden="true">·</span>
+                        {{ $author->reactions }}
+                    </span>
+                </button>
+            </li>
+        @endforeach
+    </ul>
+
+    <p class="text-text-low border-outline-low border-t pt-3 font-mono text-[0.65rem]">
+        {{ count($authors) }} pessoas no acervo
+    </p>
+</aside>

--- a/app-modules/portal/resources/views/components/articles/card.blade.php
+++ b/app-modules/portal/resources/views/components/articles/card.blade.php
@@ -1,0 +1,64 @@
+@props([
+    'article',
+    'index',
+])
+
+<article
+    x-show="isVisible({{ $index }})"
+    x-bind:class="{ 'opacity-30 saturate-50': isDim('article', {{ $index }}) }"
+    x-on:mouseenter="lensEnter('article', {{ $index }})"
+    x-on:mouseleave="lensLeave()"
+    class="border-outline-low bg-elevation-01dp hover:border-primary relative flex flex-col gap-3 rounded-lg border p-4 transition-[border-color,transform,opacity,filter] duration-300 hover:scale-[1.02] motion-reduce:transition-none motion-reduce:hover:scale-100 [.is-list_&]:flex-row [.is-list_&]:items-start [.is-list_&]:gap-4 [.is-list_&]:hover:scale-100"
+>
+    @if ($article->coverImage)
+        <img
+            src="{{ $article->coverImage }}"
+            alt=""
+            loading="lazy"
+            decoding="async"
+            class="aspect-video w-full shrink-0 rounded-sm object-cover [.is-list_&]:w-28"
+        />
+    @else
+        <x-portal::articles.cover-fallback class="aspect-video w-full shrink-0 rounded-sm [.is-list_&]:w-28" />
+    @endif
+
+    <div class="flex min-w-0 flex-1 flex-col gap-2">
+        @if ($article->tags !== [])
+            <ul class="flex flex-wrap gap-1.5">
+                @foreach (array_slice($article->tags, 0, 2) as $tag)
+                    <li
+                        class="border-primary/32 bg-primary/5 text-text-medium rounded-lg border px-2 py-0.5 font-mono text-[0.65rem]"
+                    >
+                        #{{ $tag }}
+                    </li>
+                @endforeach
+            </ul>
+        @endif
+
+        <h3 class="text-text-high line-clamp-3 text-sm leading-snug font-semibold">
+            <a
+                href="{{ $article->url }}"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="after:absolute after:inset-0 focus-visible:outline-none"
+            >
+                {{ $article->title }}
+            </a>
+        </h3>
+
+        {{-- A API entrega a descrição já truncada; o clamp evita que o "…" dela pareça quebra de layout. --}}
+        <p class="text-text-medium line-clamp-2 text-xs leading-relaxed">{{ $article->description }}</p>
+
+        <div class="text-text-medium mt-auto flex flex-wrap items-center gap-x-3 gap-y-1 pt-1 text-[0.7rem]">
+            <span class="flex min-w-0 items-center gap-1.5">
+                <img src="{{ $article->authorAvatar }}" alt="" loading="lazy" decoding="async" width="90" height="90" class="size-4 shrink-0 rounded-full" />
+                <span class="text-text-high truncate font-medium">{{ $article->authorName }}</span>
+            </span>
+            <span class="ms-auto flex items-center gap-2.5 font-mono tabular-nums">
+                <span title="reações">♥ {{ $article->reactions }}</span>
+                <span title="comentários">💬 {{ $article->comments }}</span>
+                <span title="tempo de leitura">{{ $article->readingMinutes }} min</span>
+            </span>
+        </div>
+    </div>
+</article>

--- a/app-modules/portal/resources/views/components/articles/cover-fallback.blade.php
+++ b/app-modules/portal/resources/views/components/articles/cover-fallback.blade.php
@@ -1,0 +1,9 @@
+{{-- Cinco dos artigos do acervo não têm capa na API. O bloco abaixo ocupa exatamente
+     a mesma proporção do cover real, para a grade não ficar dentada. --}}
+<div
+    {{ $attributes->class('flex items-center justify-center overflow-hidden') }}
+    style="background: linear-gradient(to bottom right, color-mix(in srgb, var(--primary) 22%, transparent), color-mix(in srgb, var(--secondary) 22%, transparent))"
+    aria-hidden="true"
+>
+    <span class="text-text-medium font-mono text-2xl tracking-[0.3em] opacity-70">&lt;/&gt;</span>
+</div>

--- a/app-modules/portal/resources/views/components/articles/opening-band.blade.php
+++ b/app-modules/portal/resources/views/components/articles/opening-band.blade.php
@@ -1,0 +1,93 @@
+@props([
+    'stats',
+    'highlight' => null,
+])
+
+<section class="relative overflow-hidden px-6 pt-10 pb-8 lg:px-12 lg:pt-14">
+    {{-- glow da marca: assinatura do portal, sob o conteúdo --}}
+    <div
+        aria-hidden="true"
+        class="pointer-events-none absolute inset-x-0 -top-24 -z-10 mx-auto h-64 max-w-4xl rounded-full opacity-60 blur-3xl"
+        style="background: radial-gradient(60% 120% at 50% 0%, color-mix(in oklab, var(--primary) 40%, transparent), transparent 70%)"
+    ></div>
+
+    <div class="mx-auto grid max-w-[1720px] gap-8 lg:grid-cols-[minmax(0,1fr)_420px] lg:items-start lg:gap-12">
+        <div class="flex flex-col gap-5">
+            <p class="text-text-medium flex items-center gap-3 font-mono text-xs tracking-[0.2em] uppercase">
+                <span aria-hidden="true" class="bg-outline-low inline-block h-px w-8"></span>
+                Learn in public · acervo no dev.to
+            </p>
+
+            <h1 class="text-text-high text-4xl leading-[1.08] font-bold tracking-tight lg:text-5xl">
+                O que a <span class="text-primary">He4rt</span> escreveu, e quem escreveu.
+            </h1>
+
+            <p class="text-text-medium max-w-xl text-base leading-relaxed">
+                Os artigos ao centro, quem escreve à direita, os temas a um clique na barra. Passe o mouse em qualquer
+                entidade para ver o que se relaciona com ela nas outras.
+            </p>
+
+            <dl class="text-text-medium flex flex-wrap items-center gap-x-6 gap-y-2 text-sm">
+                @foreach ([['articles', 'artigos'], ['authors', 'autores'], ['topics', 'temas'], ['reactions', 'reações']] as [$key, $label])
+                    <div class="flex items-baseline gap-2">
+                        <dt class="sr-only">{{ $label }}</dt>
+                        <dd class="text-text-high font-mono text-lg font-semibold tabular-nums">
+                            {{ number_format($stats[$key], 0, ',', '.') }}
+                        </dd>
+                        <span aria-hidden="true">{{ $label }}</span>
+                    </div>
+                    @if (! $loop->last)
+                        <span aria-hidden="true" class="text-text-low">·</span>
+                    @endif
+                @endforeach
+            </dl>
+        </div>
+
+        @if ($highlight)
+            <article
+                class="border-outline-low bg-elevation-01dp relative flex flex-col gap-4 rounded-lg border p-4 transition-colors duration-300 hover:border-primary sm:flex-row lg:flex-col"
+            >
+                @if ($highlight->coverImage)
+                    <img
+                        src="{{ $highlight->coverImage }}"
+                        alt=""
+                        loading="lazy"
+                        decoding="async"
+                        class="aspect-video w-full rounded-sm object-cover sm:w-40 lg:w-full"
+                    />
+                @else
+                    <x-portal::articles.cover-fallback class="aspect-video w-full rounded-sm sm:w-40 lg:w-full" />
+                @endif
+
+                <div class="flex min-w-0 flex-col gap-2">
+                    <span
+                        class="border-primary/32 bg-primary/5 text-text-high w-fit rounded-full border px-3 py-1 font-mono text-[0.65rem] tracking-wide"
+                    >
+                        ★ destaque · mais reagido dos últimos 12 meses
+                    </span>
+
+                    <h2 class="text-text-high line-clamp-3 text-lg leading-snug font-semibold">
+                        <a
+                            href="{{ $highlight->url }}"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="after:absolute after:inset-0 focus-visible:outline-none"
+                        >
+                            {{ $highlight->title }}
+                        </a>
+                    </h2>
+
+                    <div class="text-text-medium flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
+                        <span class="flex items-center gap-2">
+                            <img src="{{ $highlight->authorAvatar }}" alt="" loading="lazy" decoding="async" width="90" height="90" class="size-5 rounded-full" />
+                            <span class="text-text-high font-medium">{{ $highlight->authorName }}</span>
+                        </span>
+                        <span class="font-mono tabular-nums">♥ {{ $highlight->reactions }}</span>
+                        <span class="font-mono tabular-nums">{{ $highlight->readingMinutes }} min</span>
+                        <span class="font-mono">{{ $highlight->publishedLabel() }}</span>
+                    </div>
+                </div>
+            </article>
+        @endif
+    </div>
+</section>

--- a/app-modules/portal/resources/views/components/articles/toolbar.blade.php
+++ b/app-modules/portal/resources/views/components/articles/toolbar.blade.php
@@ -1,0 +1,75 @@
+@props([
+    'topics',
+    'total',
+])
+
+{{-- Barra de controle do acervo. Fica sticky dentro da coluna de artigos: como o
+     containing block de um grid item é a própria área da grid, promovê-la a filha
+     direta do grid faria o sticky morrer em silêncio. --}}
+<div class="bg-elevation-surface/93 border-outline-low sticky top-0 z-30 -mx-1 mb-4 border-b px-1 pt-2 pb-3 backdrop-blur-xl">
+    <div class="flex flex-wrap items-center gap-x-3 gap-y-2">
+        <h2 class="text-text-medium font-mono text-xs tracking-[0.2em] uppercase">Artigos</h2>
+
+        <x-portal::articles.topics-panel :topics="$topics" :total="$total" />
+
+        <span class="text-text-low font-mono text-xs">↓ mais recentes</span>
+
+        <p class="text-text-medium ms-auto font-mono text-xs tabular-nums" aria-live="polite">
+            <span class="text-text-high font-semibold" x-text="visibleCount">{{ $total }}</span>
+            de {{ $total }} artigos
+        </p>
+
+        <div class="flex items-center gap-1" role="group" aria-label="Modo de visualização">
+            @foreach ([['grid', 'Grade', 'heroicon-o-squares-2x2'], ['list', 'Lista', 'heroicon-o-bars-3']] as [$mode, $label, $icon])
+                <button
+                    type="button"
+                    x-on:click="view = '{{ $mode }}'"
+                    x-bind:aria-pressed="view === '{{ $mode }}' ? 'true' : 'false'"
+                    x-bind:class="view === '{{ $mode }}'
+                        ? 'border-transparent bg-gradient-to-br from-primary to-secondary text-text-light'
+                        : 'border-outline-dark text-text-medium hover:border-primary hover:bg-primary/10'"
+                    class="flex size-9 cursor-pointer items-center justify-center rounded-md border transition-all duration-300 hover:scale-[1.02] active:scale-95"
+                    aria-label="{{ $label }}"
+                    title="{{ $label }}"
+                >
+                    <x-filament::icon :icon="$icon" class="h-4 w-4" />
+                </button>
+            @endforeach
+        </div>
+    </div>
+
+    {{-- Segunda linha: só existe quando há recorte ativo. --}}
+    <div class="mt-2 flex flex-wrap items-center gap-2" x-show="hasFilters" x-cloak style="display: none">
+        <template x-if="author">
+            <button
+                type="button"
+                x-on:click="author = null"
+                class="border-primary/32 bg-primary/5 text-text-high hover:bg-primary/32 inline-flex cursor-pointer items-center gap-2 rounded-xl border px-2.5 py-1.5 text-xs font-medium transition-all duration-300 active:scale-95"
+            >
+                <span x-text="authorName(author)"></span>
+                <span aria-hidden="true">×</span>
+                <span class="sr-only">Remover filtro de autor</span>
+            </button>
+        </template>
+
+        <template x-if="topic">
+            <button
+                type="button"
+                x-on:click="topic = null"
+                class="border-primary/32 bg-primary/5 text-text-high hover:bg-primary/32 inline-flex cursor-pointer items-center gap-2 rounded-xl border px-2.5 py-1.5 font-mono text-xs font-medium transition-all duration-300 active:scale-95"
+            >
+                <span x-text="'#' + topic"></span>
+                <span aria-hidden="true">×</span>
+                <span class="sr-only">Remover filtro de tema</span>
+            </button>
+        </template>
+
+        <button
+            type="button"
+            x-on:click="clearAll()"
+            class="text-text-medium hover:text-text-high cursor-pointer text-xs underline underline-offset-4 transition-colors"
+        >
+            limpar tudo
+        </button>
+    </div>
+</div>

--- a/app-modules/portal/resources/views/components/articles/topics-panel.blade.php
+++ b/app-modules/portal/resources/views/components/articles/topics-panel.blade.php
@@ -1,0 +1,68 @@
+@props([
+    'topics',
+    'total',
+])
+
+<div class="relative" x-on:keydown.escape.window="topicsOpen = false">
+    <button
+        type="button"
+        x-on:click="topicsOpen = ! topicsOpen"
+        x-bind:aria-expanded="topicsOpen ? 'true' : 'false'"
+        x-bind:class="topic
+            ? 'border-transparent bg-gradient-to-br from-primary to-secondary text-text-light'
+            : 'border-outline-dark text-text-high hover:border-primary hover:bg-primary/10'"
+        class="flex cursor-pointer items-center gap-2 rounded-md border px-3 py-1.5 text-xs font-medium transition-all duration-300 hover:scale-[1.02] active:scale-95"
+        aria-controls="articles-topics-panel"
+    >
+        <span class="font-mono">#</span>
+        temas
+        <span x-show="topic" x-cloak style="display: none" class="font-mono tabular-nums">1</span>
+        <span aria-hidden="true" class="text-[0.6rem]">▾</span>
+    </button>
+
+    <div
+        id="articles-topics-panel"
+        x-show="topicsOpen"
+        x-cloak
+        style="display: none"
+        x-transition.opacity.duration.150ms
+        x-on:click.outside="topicsOpen = false"
+        x-ref="topicsPanel"
+        {{-- Objeto, não string: `x-bind:style` com string vira setAttribute('style', ...)
+             e apaga o `display: none` que o x-show escreve, deixando o painel aberto
+             no load. Com objeto o Alpine escreve só a propriedade ligada. --}}
+        x-bind:style="{ maxHeight: topicsMaxHeight + 'px' }"
+        class="border-outline-low bg-elevation-02dp absolute start-0 top-full z-50 mt-2 w-[min(22rem,calc(100vw-3rem))] overflow-y-auto overscroll-contain rounded-lg border p-2 shadow-lg shadow-black/20"
+        style="scrollbar-width: thin"
+    >
+        <p class="text-text-medium px-2 pt-1 pb-2 font-mono text-[0.65rem] tracking-[0.15em] uppercase">
+            {{ count($topics) }} temas · barra = fatia do acervo
+        </p>
+
+        @foreach ($topics as $entry)
+            @php($share = round($entry->share($total) * 100))
+            <button
+                type="button"
+                x-on:click="toggleTopic(@js($entry->tag)); topicsOpen = false"
+                x-on:mouseenter="lensEnter('topic', @js($entry->tag))"
+                x-on:mouseleave="lensLeave()"
+                x-bind:aria-pressed="topic === @js($entry->tag) ? 'true' : 'false'"
+                x-bind:class="{
+                    'bg-primary/16': topic === @js($entry->tag),
+                    'opacity-30': isDim('topic', @js($entry->tag)),
+                }"
+                class="hover:bg-primary/10 group flex w-full cursor-pointer items-center gap-3 rounded-md px-2 py-1.5 text-start transition-[background-color,opacity] duration-200"
+            >
+                <span class="text-text-high min-w-0 flex-1 truncate font-mono text-xs">#{{ $entry->tag }}</span>
+
+                {{-- A barra é o argumento honesto: um tema presente em quase todo
+                     artigo preenche a linha inteira e se denuncia como rótulo, não recorte. --}}
+                <span aria-hidden="true" class="bg-outline-low/40 h-1 w-24 shrink-0 overflow-hidden rounded-full">
+                    <span class="from-primary to-secondary block h-full rounded-full bg-gradient-to-r" style="width: {{ $share }}%"></span>
+                </span>
+
+                <span class="text-text-medium w-6 shrink-0 text-end font-mono text-xs tabular-nums">{{ $entry->count }}</span>
+            </button>
+        @endforeach
+    </div>
+</div>

--- a/app-modules/portal/src/Articles/Article.php
+++ b/app-modules/portal/src/Articles/Article.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Portal\Articles;
+
+use Carbon\CarbonImmutable;
+
+final readonly class Article
+{
+    /**
+     * @param  list<string>  $tags
+     */
+    public function __construct(
+        public int $id,
+        public string $title,
+        public string $description,
+        public string $url,
+        public CarbonImmutable $publishedAt,
+        public int $reactions,
+        public int $comments,
+        public int $readingMinutes,
+        public ?string $coverImage,
+        public array $tags,
+        public string $authorName,
+        public string $authorUsername,
+        public string $authorAvatar,
+    ) {}
+
+    /**
+     * O corpo devolvido pela API é `array<array-key, mixed>` — nunca a forma que
+     * esperamos —, então cada campo é lido com guarda e default próprios.
+     *
+     * @param  array<array-key, mixed>  $payload
+     */
+    public static function fromApi(array $payload): self
+    {
+        /** @var array<string, mixed> $user */
+        $user = is_array($payload['user'] ?? null) ? $payload['user'] : [];
+
+        /** @var list<string> $tags */
+        $tags = array_values(array_filter(
+            is_array($payload['tag_list'] ?? null) ? $payload['tag_list'] : [],
+            is_string(...),
+        ));
+
+        return new self(
+            id: (int) ($payload['id'] ?? 0),
+            title: (string) ($payload['title'] ?? ''),
+            description: (string) ($payload['description'] ?? ''),
+            url: self::safeUrl($payload['url'] ?? null),
+            publishedAt: CarbonImmutable::parse((string) ($payload['published_at'] ?? 'now')),
+            reactions: (int) ($payload['positive_reactions_count'] ?? 0),
+            comments: (int) ($payload['comments_count'] ?? 0),
+            readingMinutes: (int) ($payload['reading_time_minutes'] ?? 0),
+            // A API devolve null em artigos sem capa — a view cai no fallback `</>`.
+            coverImage: self::safeUrl($payload['cover_image'] ?? null) ?: null,
+            tags: $tags,
+            authorName: (string) ($user['name'] ?? ''),
+            authorUsername: (string) ($user['username'] ?? ''),
+            authorAvatar: self::safeUrl($user['profile_image_90'] ?? null),
+        );
+    }
+
+    public function publishedLabel(): string
+    {
+        return $this->publishedAt
+            ->timezone(config()->string('app.display_timezone'))
+            ->translatedFormat('M \d\e Y');
+    }
+
+    /**
+     * O acervo é payload de terceiro e vai direto para `href`/`src`. Um `javascript:`
+     * vindo de uma resposta adulterada viraria XSS que o escape do Blade não pega,
+     * porque o problema é o esquema, não os caracteres.
+     */
+    private static function safeUrl(mixed $value): string
+    {
+        if (!is_string($value) || $value === '') {
+            return '';
+        }
+
+        $scheme = parse_url($value, PHP_URL_SCHEME);
+
+        return in_array($scheme, ['http', 'https'], strict: true) ? $value : '';
+    }
+}

--- a/app-modules/portal/src/Articles/ArticleAuthor.php
+++ b/app-modules/portal/src/Articles/ArticleAuthor.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Portal\Articles;
+
+final readonly class ArticleAuthor
+{
+    public function __construct(
+        public string $username,
+        public string $name,
+        public string $avatar,
+        public int $articleCount,
+        public int $reactions,
+    ) {}
+}

--- a/app-modules/portal/src/Articles/ArticleFeed.php
+++ b/app-modules/portal/src/Articles/ArticleFeed.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Portal\Articles;
+
+use Carbon\CarbonImmutable;
+use He4rt\IntegrationDevTo\Polling\DevToApiClient;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Read model do acervo de artigos publicados na organização do dev.to.
+ *
+ * A fonte é a API, não o banco: `devto:sync-articles` só persiste artigos de
+ * autores com identidade He4rt vinculada, então a tabela cobre um subconjunto —
+ * enquanto esta página precisa creditar todo mundo que escreveu pela org.
+ */
+final class ArticleFeed
+{
+    private const string CACHE_KEY = 'portal.articles.devto-org';
+
+    /** @var list<Article>|null */
+    private ?array $articles = null;
+
+    public function __construct(
+        private readonly DevToApiClient $client,
+    ) {}
+
+    /** @return list<Article> */
+    public function articles(): array
+    {
+        if ($this->articles !== null) {
+            return $this->articles;
+        }
+
+        $articles = [];
+
+        foreach ($this->fetch() as $item) {
+            if (!is_array($item)) {
+                continue;
+            }
+
+            $articles[] = Article::fromApi($item);
+        }
+
+        usort($articles, fn (Article $a, Article $b): int => $b->publishedAt <=> $a->publishedAt);
+
+        return $this->articles = $articles;
+    }
+
+    /**
+     * Ordenados por volume e, no empate, por alcance. As duas métricas divergem
+     * de propósito — quem escreveu uma vez pode ter mais reações que quem escreveu
+     * quatro —, e por isso a coluna de pessoas mostra as duas.
+     *
+     * @return list<ArticleAuthor>
+     */
+    public function authors(): array
+    {
+        return Collection::make($this->articles())
+            ->groupBy(fn (Article $article): string => $article->authorUsername)
+            ->map(function (Collection $items, string $username): ArticleAuthor {
+                /** @var Article $first */
+                $first = $items->first();
+
+                return new ArticleAuthor(
+                    username: $username,
+                    name: $first->authorName !== '' ? $first->authorName : $username,
+                    avatar: $first->authorAvatar,
+                    articleCount: $items->count(),
+                    reactions: (int) $items->sum(fn (Article $article): int => $article->reactions),
+                );
+            })
+            ->sortByDesc(fn (ArticleAuthor $author): int => $author->articleCount * 100_000 + $author->reactions)
+            ->pipe(fn (Collection $authors): array => array_values($authors->all()));
+    }
+
+    /** @return list<ArticleTopic> */
+    public function topics(): array
+    {
+        return Collection::make($this->articles())
+            ->flatMap(fn (Article $article): array => $article->tags)
+            ->countBy()
+            ->map(fn (int $count, string $tag): ArticleTopic => new ArticleTopic($tag, $count))
+            ->sortByDesc(fn (ArticleTopic $topic): int => $topic->count)
+            ->pipe(fn (Collection $topics): array => array_values($topics->all()));
+    }
+
+    /**
+     * @return array{articles: int, authors: int, topics: int, reactions: int}
+     */
+    public function stats(): array
+    {
+        return [
+            'articles' => count($this->articles()),
+            'authors' => count($this->authors()),
+            'topics' => count($this->topics()),
+            'reactions' => (int) Collection::make($this->articles())->sum(fn (Article $article): int => $article->reactions),
+        ];
+    }
+
+    /**
+     * Destaque: o mais reagido dos últimos 12 meses, e não o mais reagido de todos
+     * os tempos — o campeão histórico é um guia de 2023 já usado como CTA em outro
+     * lugar do site, e repeti-lo aqui gastaria a primeira dobra com algo conhecido.
+     */
+    public function highlight(): ?Article
+    {
+        $cutoff = CarbonImmutable::now()->subYear();
+
+        $recent = Collection::make($this->articles())
+            ->filter(fn (Article $article): bool => $article->publishedAt->greaterThanOrEqualTo($cutoff));
+
+        $pool = $recent->isNotEmpty() ? $recent : Collection::make($this->articles());
+
+        return $pool->sortByDesc(fn (Article $article): int => $article->reactions)->first();
+    }
+
+    /**
+     * O acervo é de terceiro: uma indisponibilidade do dev.to não pode derrubar
+     * uma página institucional.
+     *
+     * `flexible` serve o valor fresco até o TTL e continua servindo o obsoleto por
+     * até um dia enquanto revalida em segundo plano — assim ninguém paga a latência
+     * da revalidação, e uma queda do dev.to depois do primeiro sucesso mantém a
+     * página com conteúdo em vez de cair no estado de indisponível.
+     *
+     * @return array<array-key, mixed>
+     */
+    private function fetch(): array
+    {
+        $ttl = config()->integer('integration-devto.polling_interval_minutes');
+
+        try {
+            /** @var array<array-key, mixed> $payload */
+            $payload = Cache::flexible(
+                self::CACHE_KEY,
+                [now()->addMinutes($ttl), now()->addDay()],
+                function (): array {
+                    $articles = $this->client->getArticlesByOrg(config()->string('integration-devto.org_slug'));
+
+                    // Estourar aqui impede que uma resposta vazia entre em cache e
+                    // preserva o valor anterior para a janela obsoleta continuar servindo.
+                    throw_if($articles === [], RuntimeException::class, 'dev.to devolveu um acervo vazio');
+
+                    return $articles;
+                },
+            );
+
+            return $payload;
+        } catch (Throwable $throwable) {
+            Log::warning('Portal: acervo do dev.to indisponível', ['exception' => $throwable->getMessage()]);
+
+            /** @var array<array-key, mixed> $stale */
+            $stale = Cache::get(self::CACHE_KEY) ?? [];
+
+            return $stale;
+        }
+    }
+}

--- a/app-modules/portal/src/Articles/ArticleTopic.php
+++ b/app-modules/portal/src/Articles/ArticleTopic.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Portal\Articles;
+
+final readonly class ArticleTopic
+{
+    public function __construct(
+        public string $tag,
+        public int $count,
+    ) {}
+
+    /**
+     * Fatia do acervo que carrega este tema. É o que revela, na barra de
+     * proporção, que uma tag presente em quase todo artigo rotula em vez de filtrar.
+     */
+    public function share(int $total): float
+    {
+        return $total > 0 ? $this->count / $total : 0.0;
+    }
+}

--- a/app-modules/portal/src/Livewire/ArticlesPage.php
+++ b/app-modules/portal/src/Livewire/ArticlesPage.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Portal\Livewire;
+
+use He4rt\Portal\Articles\ArticleFeed;
+use Illuminate\Contracts\View\View;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+/**
+ * Página institucional do acervo de artigos.
+ *
+ * O componente só monta o read model: recorte por tema e por pessoa, alternância
+ * de visualização e a lente de relação vivem no Alpine, porque a lente reage a
+ * hover e não sobreviveria a um round-trip por evento.
+ */
+#[Layout(name: 'portal::components.layouts.app')]
+final class ArticlesPage extends Component
+{
+    public function render(ArticleFeed $feed): View
+    {
+        return view('portal::articles', [
+            'articles' => $feed->articles(),
+            'authors' => $feed->authors(),
+            'topics' => $feed->topics(),
+            'stats' => $feed->stats(),
+            'highlight' => $feed->highlight(),
+        ]);
+    }
+}

--- a/app-modules/portal/src/PortalServiceProvider.php
+++ b/app-modules/portal/src/PortalServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace He4rt\Portal;
 
+use He4rt\Portal\Livewire\ArticlesPage;
 use He4rt\Portal\Livewire\CommunityRetrospectivePage;
 use He4rt\Portal\Livewire\HeroSection;
 use He4rt\Portal\Livewire\Homepage;
@@ -45,6 +46,13 @@ class PortalServiceProvider extends ServiceProvider
             ->withHead(
                 title: 'Nossas redes',
                 description: 'Todos os canais oficiais da He4rt Developers: Discord, GitHub, LinkedIn, Instagram, X e WhatsApp.',
+            );
+
+        Route::get('/artigos', ArticlesPage::class)
+            ->name('articles')
+            ->withHead(
+                title: 'Artigos da comunidade',
+                description: 'Os artigos publicados pela organização He4rt Developers no dev.to, por tema e por quem escreveu.',
             );
 
         Route::get('/comunidade/retrospectiva', CommunityRetrospectivePage::class)

--- a/app-modules/portal/tests/Feature/ArticlesPageTest.php
+++ b/app-modules/portal/tests/Feature/ArticlesPageTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Portal\Articles\ArticleFeed;
+use He4rt\Portal\Livewire\ArticlesPage;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+
+use function Pest\Livewire\livewire;
+
+/**
+ * @param  array<string, mixed>  $overrides
+ * @return array<string, mixed>
+ */
+function devToArticle(array $overrides = []): array
+{
+    return array_merge([
+        'id' => 1,
+        'title' => 'Um artigo qualquer',
+        'description' => 'Resumo curto vindo da API.',
+        'url' => 'https://dev.to/he4rt/um-artigo-qualquer',
+        'published_at' => now()->subMonth()->toIso8601String(),
+        'positive_reactions_count' => 10,
+        'comments_count' => 2,
+        'reading_time_minutes' => 4,
+        'cover_image' => 'https://example.test/capa.png',
+        'tag_list' => ['braziliandevs'],
+        'user' => [
+            'name' => 'Alguém da Comunidade',
+            'username' => 'alguem',
+            'profile_image_90' => 'https://example.test/avatar.png',
+        ],
+    ], $overrides);
+}
+
+beforeEach(function (): void {
+    Cache::flush();
+});
+
+it('lista os artigos da organização com autores e temas', function (): void {
+    Http::fake([
+        'dev.to/api/articles*' => Http::response([
+            devToArticle(['id' => 1, 'title' => 'Índices em produção', 'user' => ['name' => 'Fernando', 'username' => 'fernando', 'profile_image_90' => 'https://example.test/f.png']]),
+            devToArticle(['id' => 2, 'title' => 'Testes que importam', 'tag_list' => ['testing'], 'user' => ['name' => 'Alicia', 'username' => 'alicia', 'profile_image_90' => 'https://example.test/a.png']]),
+        ]),
+    ]);
+
+    livewire(ArticlesPage::class)
+        ->assertOk()
+        ->assertSee('Índices em produção')
+        ->assertSee('Testes que importam')
+        ->assertSee('Fernando')
+        ->assertSee('Alicia')
+        ->assertSee('#testing');
+});
+
+it('elege como destaque o mais reagido dos últimos 12 meses, não o campeão histórico', function (): void {
+    Http::fake([
+        'dev.to/api/articles*' => Http::response([
+            devToArticle(['id' => 1, 'title' => 'Campeão histórico', 'positive_reactions_count' => 565, 'published_at' => now()->subYears(3)->toIso8601String()]),
+            devToArticle(['id' => 2, 'title' => 'Destaque recente', 'positive_reactions_count' => 215, 'published_at' => now()->subMonths(2)->toIso8601String()]),
+        ]),
+    ]);
+
+    $highlight = resolve(ArticleFeed::class)->highlight();
+
+    expect($highlight?->title)->toBe('Destaque recente');
+});
+
+it('agrega volume e alcance por pessoa', function (): void {
+    Http::fake([
+        'dev.to/api/articles*' => Http::response([
+            devToArticle(['id' => 1, 'positive_reactions_count' => 100]),
+            devToArticle(['id' => 2, 'positive_reactions_count' => 40]),
+        ]),
+    ]);
+
+    $authors = resolve(ArticleFeed::class)->authors();
+
+    expect($authors)->toHaveCount(1)
+        ->and($authors[0]->articleCount)->toBe(2)
+        ->and($authors[0]->reactions)->toBe(140);
+});
+
+it('preserva a capa nula para a view cair no fallback', function (): void {
+    Http::fake([
+        'dev.to/api/articles*' => Http::response([
+            devToArticle(['id' => 1, 'cover_image' => null]),
+        ]),
+    ]);
+
+    expect(resolve(ArticleFeed::class)->articles()[0]->coverImage)->toBeNull();
+});
+
+it('mede a fatia do acervo que cada tema carrega', function (): void {
+    Http::fake([
+        'dev.to/api/articles*' => Http::response([
+            devToArticle(['id' => 1, 'tag_list' => ['braziliandevs', 'career']]),
+            devToArticle(['id' => 2, 'tag_list' => ['braziliandevs']]),
+        ]),
+    ]);
+
+    $feed = resolve(ArticleFeed::class);
+    $topics = $feed->topics();
+
+    expect($topics[0]->tag)->toBe('braziliandevs')
+        ->and($topics[0]->share($feed->stats()['articles']))->toBe(1.0);
+});
+
+it('responde na rota /artigos', function (): void {
+    Http::fake([
+        'dev.to/api/articles*' => Http::response([devToArticle()]),
+    ]);
+
+    $this->get('/artigos')
+        ->assertOk()
+        ->assertSee('Learn in public', escape: false);
+});
+
+it('não derruba a página quando o dev.to falha', function (): void {
+    Http::fake([
+        'dev.to/api/articles*' => Http::response(status: 503),
+    ]);
+
+    $this->get('/artigos')
+        ->assertOk()
+        ->assertSee('Não deu para carregar o acervo agora.');
+});
+
+it('não guarda em cache um acervo vazio', function (): void {
+    Http::fake([
+        'dev.to/api/articles*' => Http::response([]),
+    ]);
+
+    expect(resolve(ArticleFeed::class)->articles())->toBeEmpty()
+        ->and(Cache::has('portal.articles.devto-org'))->toBeFalse();
+});
+
+it('descarta esquema de URL perigoso vindo da API', function (): void {
+    Http::fake([
+        'dev.to/api/articles*' => Http::response([
+            devToArticle([
+                'url' => 'javascript:alert(document.cookie)',
+                'cover_image' => 'javascript:void(0)',
+                'user' => ['name' => 'X', 'username' => 'x', 'profile_image_90' => 'data:text/html,<script>'],
+            ]),
+        ]),
+    ]);
+
+    $article = resolve(ArticleFeed::class)->articles()[0];
+
+    expect($article->url)->toBeEmpty()
+        ->and($article->coverImage)->toBeNull()
+        ->and($article->authorAvatar)->toBeEmpty();
+});
+
+it('preserva http e https', function (): void {
+    Http::fake([
+        'dev.to/api/articles*' => Http::response([devToArticle(['url' => 'https://dev.to/he4rt/x'])]),
+    ]);
+
+    expect(resolve(ArticleFeed::class)->articles()[0]->url)->toBe('https://dev.to/he4rt/x');
+});
+
+it('serve o acervo obsoleto quando o dev.to cai depois de um sucesso', function (): void {
+    Http::fake(['dev.to/api/articles*' => Http::response([devToArticle(['title' => 'Do cache'])])]);
+    expect(resolve(ArticleFeed::class)->articles())->toHaveCount(1);
+
+    // a partir daqui o dev.to está fora do ar
+    Http::fake(['dev.to/api/articles*' => Http::response(status: 500)]);
+    $this->travel(31)->minutes();
+
+    $this->get('/artigos')
+        ->assertOk()
+        ->assertSee('Do cache')
+        ->assertDontSee('Não deu para carregar o acervo agora.');
+});


### PR DESCRIPTION
## Contexto

A He4rt publica artigos numa organização do dev.to, mas não havia onde vê-los dentro do site — e a
seção de artigos da homepage ainda mostrava seis cards de *lorem ipsum* com um avatar fixo.

Esta PR adiciona `/artigos`: uma página institucional com foco duplo em **conteúdo** e em **quem
escreve**. O objetivo é dar visibilidade a quem escreve na org (Learn in Public) e centralizar a
descoberta fora do dev.to, com a identidade visual do portal.

Hoje o acervo tem 29 artigos de 17 pessoas, de mar/2023 a ago/2026.

**A fonte é a API, não o banco.** O `devto:sync-articles` só persiste artigos de autores com
identidade He4rt vinculada, então a tabela cobre um subconjunto — enquanto a página precisa creditar
todo mundo que escreveu pela org. O `DevToApiClient` existente já atende, sem mudança no módulo de
integração.

### Alterações

- **`app-modules/portal/src/Articles/`** — read model do acervo, espelhando o `src/Retrospective/`
  que já existia: DTOs (`Article`, `ArticleAuthor`, `ArticleTopic`) e o `ArticleFeed`, que agrega
  autores, temas, estatísticas e o destaque.
- **`src/Livewire/ArticlesPage.php`** + rota `/artigos` no `PortalServiceProvider`, no mesmo padrão
  das outras páginas do portal (`->withHead()`).
- **`resources/views/components/articles/`** — componentes Blade: faixa de abertura, barra de
  controle, painel de temas, card, coluna de pessoas e o fallback de capa.
- **11 testes** cobrindo agregação, destaque, capa nula, segurança de URL, degradação e a rota.

Decisões que valem a revisão:

- **Interação no Alpine, não no Livewire.** A lente de relação (passar o mouse numa entidade esmaece
  o que não se relaciona nas outras colunas) reage a *hover* e não sobreviveria a um round-trip por
  evento. Os cards vêm renderizados do servidor e o Alpine só decide o que fica visível — a grade é
  padrão no HTML, então a página nasce com layout correto mesmo antes do JS.
- **`Cache::flexible`** serve o acervo obsoleto por até um dia enquanto revalida em segundo plano.
  Uma queda do dev.to depois do primeiro sucesso mantém a página com conteúdo; a falha total cai num
  estado explícito em vez de 500.
- **Allowlist de esquema nas URLs da API.** `javascript:`/`data:` viram vazio — o escape do Blade não
  protege contra esquema, só contra caracteres.
- **`@assets` em vez de `<script>` cru.** Componente class-based exige isso no Livewire 4, e
  `@script` rodaria depois do Alpine subir, tarde demais para registrar o `Alpine.data()` que o
  `x-data` da raiz consome.
- **`x-bind:style` com objeto, não string.** Em string o Alpine faz `setAttribute('style', ...)` e
  apaga o `display:none` do `x-show` — o que deixava o painel de temas aberto no load.
- **O destaque é o mais reagido dos últimos 12 meses**, não o campeão histórico: o topo absoluto é um
  guia de 2023 já usado como CTA em outro lugar do site.
- **Sem `#[Lazy]`**, de propósito: é página indexável, o conteúdo precisa estar no HTML inicial.

---

## Plano de Testes

- [x] `vendor/bin/pint` — limpo
- [x] `vendor/bin/phpstan analyse app-modules/portal/src` — 0 erros
- [x] `php artisan test app-modules/portal/tests` — **80 testes passando** (11 novos)
- [x] Render conferido nos temas claro e escuro com o CSS compilado
- [x] Interação verificada em navegador headless com cliques reais: filtro por autor → 2 resultados,
      combinado com `#career` → 1, limpar → 29, com a URL sincronizando nos três passos e zero erro
      de console
- [x] Degradação coberta por teste: dev.to fora do ar após um sucesso → a página segue servindo o
      acervo obsoleto em vez do estado de indisponível

---

## Evidências

Página nova, sem "antes". Screenshots de 1440×1150 nos dois temas foram gerados durante a validação
(grade de 3 cards por linha, painel de temas com as barras de proporção, coluna de pessoas com volume
e alcance lado a lado). Posso anexar aqui se ajudar na revisão.

Dois pontos que ficaram **sem verificação em navegador real** e que agradeço se o revisor olhar:

- a lente por *hover* — o headless reporta `pointer: fine = false`, então só a mecânica foi exercitada;
- a animação de abertura do painel de temas — o `x-transition` depende de `requestAnimationFrame`,
  que não dispara sob `--virtual-time-budget`.

---

## Observações

- `x-he4rt::tag` tem um bug pré-existente: usa `$target`/`$rel` sem declarar em `@props`, então quebra
  se receber `href`. Por isso as tags aqui usam botões próprios em vez do componente. Não corrigi para
  não misturar escopo.
- No telefone, a coluna de pessoas empilha as 17 linhas e custa altura antes do primeiro card. Um
  corte com "ver todos" resolveria, mas mexe na exigência de mostrar todo mundo — deixei a decisão em
  aberto.
