### PR TITLE
fix(portal): não deixar payload malformado do dev.to derrubar /artigos

### DIFF
--- a/app-modules/portal/src/Articles/Article.php
+++ b/app-modules/portal/src/Articles/Article.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace He4rt\Portal\Articles;
 
 use Carbon\CarbonImmutable;
+use Throwable;
 
 final readonly class Article
 {
@@ -31,9 +32,14 @@ final readonly class Article
      * O corpo devolvido pela API é `array<array-key, mixed>` — nunca a forma que
      * esperamos —, então cada campo é lido com guarda e default próprios.
      *
+     * Devolve `null` quando o item não sustenta as duas invariantes de um artigo
+     * exibível: ter título e ter data confiável. Sem data não há lugar na ordenação
+     * nem na janela de 12 meses do destaque, e `Carbon::parse('')` devolveria *hoje*
+     * — o item furado subiria ao topo do feed em vez de sumir.
+     *
      * @param  array<array-key, mixed>  $payload
      */
-    public static function fromApi(array $payload): self
+    public static function fromApi(array $payload): ?self
     {
         /** @var array<string, mixed> $user */
         $user = is_array($payload['user'] ?? null) ? $payload['user'] : [];
@@ -44,20 +50,27 @@ final readonly class Article
             is_string(...),
         ));
 
+        $title = self::text($payload['title'] ?? null);
+        $publishedAt = self::parseDate($payload['published_at'] ?? null);
+
+        if ($title === '' || !$publishedAt instanceof CarbonImmutable) {
+            return null;
+        }
+
         return new self(
-            id: (int) ($payload['id'] ?? 0),
-            title: (string) ($payload['title'] ?? ''),
-            description: (string) ($payload['description'] ?? ''),
+            id: self::number($payload['id'] ?? null),
+            title: $title,
+            description: self::text($payload['description'] ?? null),
             url: self::safeUrl($payload['url'] ?? null),
-            publishedAt: CarbonImmutable::parse((string) ($payload['published_at'] ?? 'now')),
-            reactions: (int) ($payload['positive_reactions_count'] ?? 0),
-            comments: (int) ($payload['comments_count'] ?? 0),
-            readingMinutes: (int) ($payload['reading_time_minutes'] ?? 0),
+            publishedAt: $publishedAt,
+            reactions: self::number($payload['positive_reactions_count'] ?? null),
+            comments: self::number($payload['comments_count'] ?? null),
+            readingMinutes: self::number($payload['reading_time_minutes'] ?? null),
             // A API devolve null em artigos sem capa — a view cai no fallback `</>`.
             coverImage: self::safeUrl($payload['cover_image'] ?? null) ?: null,
             tags: $tags,
-            authorName: (string) ($user['name'] ?? ''),
-            authorUsername: (string) ($user['username'] ?? ''),
+            authorName: self::text($user['name'] ?? null),
+            authorUsername: self::text($user['username'] ?? null),
             authorAvatar: self::safeUrl($user['profile_image_90'] ?? null),
         );
     }
@@ -67,6 +80,42 @@ final readonly class Article
         return $this->publishedAt
             ->timezone(config()->string('app.display_timezone'))
             ->translatedFormat('M \d\e Y');
+    }
+
+    /**
+     * Texto de campo que a API promete como string. Array e objeto viram vazio em
+     * vez de `Array` com warning — ou de `Error` fatal, no caso de objeto sem
+     * `__toString`, que derrubaria a página inteira por um campo cosmético.
+     */
+    private static function text(mixed $value): string
+    {
+        return match (true) {
+            is_string($value) => mb_trim($value),
+            is_int($value), is_float($value) => (string) $value,
+            default => '',
+        };
+    }
+
+    private static function number(mixed $value): int
+    {
+        return is_numeric($value) ? (int) $value : 0;
+    }
+
+    /**
+     * `Carbon::parse` lança em texto livre e devolve *agora* para string vazia, então
+     * a data precisa ser validada antes, não interpretada com otimismo.
+     */
+    private static function parseDate(mixed $value): ?CarbonImmutable
+    {
+        if (!is_string($value) || mb_trim($value) === '') {
+            return null;
+        }
+
+        try {
+            return CarbonImmutable::parse($value);
+        } catch (Throwable) {
+            return null;
+        }
     }
 
     /**

--- a/app-modules/portal/src/Articles/ArticleFeed.php
+++ b/app-modules/portal/src/Articles/ArticleFeed.php
@@ -37,14 +37,35 @@ final class ArticleFeed
             return $this->articles;
         }
 
-        $articles = [];
+        $payload = $this->fetch();
 
-        foreach ($this->fetch() as $item) {
-            if (!is_array($item)) {
+        $articles = [];
+        $rejected = 0;
+
+        foreach ($payload as $item) {
+            $article = is_array($item) ? Article::fromApi($item) : null;
+
+            if (!$article instanceof Article) {
+                $rejected++;
+
                 continue;
             }
 
-            $articles[] = Article::fromApi($item);
+            $articles[] = $article;
+        }
+
+        if ($rejected > 0) {
+            Log::warning('Portal: itens do acervo do dev.to descartados por payload inválido', [
+                'descartados' => $rejected,
+                'aceitos' => count($articles),
+            ]);
+        }
+
+        // Payload com itens mas nenhum aproveitável é contrato quebrado, não acervo
+        // vazio. Sem descartar o cache, a janela obsoleta serviria o mesmo lixo por
+        // um dia inteiro — e a revalidação em segundo plano nunca o substituiria.
+        if ($articles === [] && $payload !== []) {
+            Cache::forget(self::CACHE_KEY);
         }
 
         usort($articles, fn (Article $a, Article $b): int => $b->publishedAt <=> $a->publishedAt);

--- a/app-modules/portal/tests/Feature/ArticlesPageTest.php
+++ b/app-modules/portal/tests/Feature/ArticlesPageTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use He4rt\Portal\Articles\Article;
 use He4rt\Portal\Articles\ArticleFeed;
 use He4rt\Portal\Livewire\ArticlesPage;
 use Illuminate\Support\Facades\Cache;
@@ -175,4 +176,68 @@ it('serve o acervo obsoleto quando o dev.to cai depois de um sucesso', function 
         ->assertOk()
         ->assertSee('Do cache')
         ->assertDontSee('Não deu para carregar o acervo agora.');
+});
+
+it('descarta artigo com data impossível de interpretar em vez de derrubar a página', function (): void {
+    Http::fake([
+        'dev.to/api/articles*' => Http::response([
+            devToArticle(['id' => 1, 'title' => 'Válido']),
+            devToArticle(['id' => 2, 'title' => 'Data podre', 'published_at' => 'amanhã cedo']),
+        ]),
+    ]);
+
+    $articles = resolve(ArticleFeed::class)->articles();
+
+    expect($articles)->toHaveCount(1)
+        ->and($articles[0]->title)->toBe('Válido');
+});
+
+it('descarta data vazia em vez de assumir hoje e jogar o artigo para o topo', function (): void {
+    Http::fake([
+        'dev.to/api/articles*' => Http::response([
+            devToArticle(['id' => 1, 'title' => 'Real', 'published_at' => now()->subMonth()->toIso8601String()]),
+            devToArticle(['id' => 2, 'title' => 'Sem data', 'published_at' => '']),
+        ]),
+    ]);
+
+    $articles = resolve(ArticleFeed::class)->articles();
+
+    expect($articles)->toHaveCount(1)
+        ->and($articles[0]->title)->toBe('Real');
+});
+
+it('não quebra com campo de texto que não é texto', function (): void {
+    Http::fake([
+        'dev.to/api/articles*' => Http::response([
+            devToArticle(['id' => 1, 'title' => ['isto' => 'é um array']]),
+            devToArticle(['id' => 2, 'title' => 'Sobrevivente']),
+        ]),
+    ]);
+
+    $titles = array_map(fn (Article $article): string => $article->title, resolve(ArticleFeed::class)->articles());
+
+    expect($titles)->toContain('Sobrevivente');
+});
+
+it('não deixa payload inteiro inválido envenenar a janela obsoleta do cache', function (): void {
+    Http::fake([
+        'dev.to/api/articles*' => Http::response([
+            devToArticle(['id' => 1, 'published_at' => 'lixo']),
+            devToArticle(['id' => 2, 'published_at' => 'mais lixo']),
+        ]),
+    ]);
+
+    expect(resolve(ArticleFeed::class)->articles())->toBeEmpty()
+        ->and(Cache::has('portal.articles.devto-org'))->toBeFalse();
+});
+
+it('mantém a página de pé quando um item do acervo está corrompido', function (): void {
+    Http::fake([
+        'dev.to/api/articles*' => Http::response([
+            devToArticle(['id' => 1, 'title' => 'Artigo bom']),
+            devToArticle(['id' => 2, 'published_at' => 'quebrado']),
+        ]),
+    ]);
+
+    $this->get('/artigos')->assertOk()->assertSee('Artigo bom');
 });


### PR DESCRIPTION
## Contexto

Revisão defensiva da página `/artigos` (mergeada em #506) encontrou um buraco no
tratamento do acervo: o `try/catch` cobria a **chamada HTTP**, não a
**desserialização**. Ou seja, "dev.to fora do ar" estava tratado, mas "dev.to
mudou o contrato" — a falha mais provável de uma API de terceiro — derrubava a
página pública.

Três falhas distintas, todas alcançáveis a partir de uma resposta **200**:

| Entrada | Resultado antes |
| --- | --- |
| `published_at` com texto livre | `InvalidFormatException` → **500** |
| campo de texto vindo como objeto | `Error: could not be converted to string` → **500** |
| `published_at` vazio | vira **hoje** silenciosamente → sobe ao topo do feed e pode virar o destaque |
| `published_at: "0000-00-00"` | vira ano **-0001** silenciosamente |

O agravante era o cache. O `Cache::flexible` guarda o payload por até um dia, então
uma única resposta ruim virava **24h de erro**, e a janela obsoleta re-servia o mesmo
lixo — a revalidação em segundo plano nunca o substituía.

### Alterações

- **`Article::fromApi()` agora é total** — devolve `null` quando o item não sustenta
  as duas invariantes de um artigo exibível: **ter título** e **ter data confiável**.
  Sem data não há lugar na ordenação nem na janela de 12 meses do destaque, e
  interpretar string vazia como "agora" é corrupção silenciosa, pior que erro.
- **Guardas de tipo na leitura de campo** — array e objeto viram vazio em vez de
  warning ou fatal.
- **`ArticleFeed`** descarta os inválidos, registra quantos caíram (para o contrato
  quebrado ser diagnosticável em log) e **esquece a chave de cache** quando o payload
  veio com itens mas nenhum aproveitável.

---

## Plano de Testes

Escritos **antes** da correção, os cinco falhavam pelos motivos acima:

- [x] artigo com data impossível de interpretar é descartado, página segue de pé
- [x] data vazia é descartada em vez de virar "hoje" e furar a ordenação
- [x] campo de texto que não é texto não quebra a página
- [x] payload inteiro inválido não envenena a janela obsoleta do cache
- [x] um item corrompido no meio não derruba os artigos válidos (rota responde 200)
- [x] `vendor/bin/pint` limpo · `vendor/bin/phpstan` 0 erros
- [x] `php artisan test app-modules/portal/tests` — **85 testes passando**

---

## Risco aceito conscientemente

O `DevToApiClient` não declara timeout e herda os **30s** padrão do Laravel. A
exposição é **uma** requisição de cold start (o `flexible` revalida depois da
resposta, então ninguém mais espera), e o client é compartilhado com
`devto:sync-articles` — mexer nele muda o comportamento do comando de polling, o
que fica fora do escopo desta correção. Fica registrado para quem for tocar o
módulo de integração.

---

## Issues Relacionadas

Related to #506
