### PR TITLE
feat(panel-admin): RBAC com roles e policies no painel admin

### DIFF
--- a/app-modules/events/tests/Feature/EventResourceTest.php
+++ b/app-modules/events/tests/Feature/EventResourceTest.php
@@ -15,7 +15,6 @@ use He4rt\Events\Enrollment\Models\Enrollment;
 use He4rt\Events\Enrollment\Models\EnrollmentPolicy;
 use He4rt\Events\Event\Enums\EventType;
 use He4rt\Events\Event\Models\Event;
-use He4rt\Identity\User\Models\User;
 use He4rt\PanelAdmin\Filament\Resources\Events\EventResource;
 use He4rt\PanelAdmin\Filament\Resources\Events\Pages\CreateEvent;
 use He4rt\PanelAdmin\Filament\Resources\Events\Pages\EditEvent;
@@ -26,9 +25,8 @@ use He4rt\PanelAdmin\Filament\Resources\Events\RelationManagers\EnrollmentsRelat
 use function Pest\Livewire\livewire;
 
 beforeEach(function (): void {
-    $admin = User::factory()->create(['username' => 'events-test-admin']);
+    $admin = panelAdminUser();
 
-    config(['he4rt.admins' => 'events-test-admin']);
     $this->actingAs($admin);
 
     Filament::setCurrentPanel(Filament::getPanel('admin'));

--- a/app-modules/identity/database/migrations/2026_08_22_205629_create_permission_tables.php
+++ b/app-modules/identity/database/migrations/2026_08_22_205629_create_permission_tables.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Contracts\Cache\Factory;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $teams = config('permission.teams');
+        $tableNames = config('permission.table_names');
+        $columnNames = config('permission.column_names');
+        $pivotRole = $columnNames['role_pivot_key'] ?? 'role_id';
+        $pivotPermission = $columnNames['permission_pivot_key'] ?? 'permission_id';
+
+        throw_if(blank($tableNames), 'Error: config/permission.php not loaded. Run [php artisan config:clear] and try again.');
+        throw_if($teams && blank($columnNames['team_foreign_key'] ?? null), 'Error: team_foreign_key on config/permission.php not loaded. Run [php artisan config:clear] and try again.');
+
+        /**
+         * See `docs/prerequisites.md` for suggested lengths on 'name' and 'guard_name' if "1071 Specified key was too long" errors are encountered.
+         */
+        Schema::create($tableNames['permissions'], static function (Blueprint $table): void {
+            $table->id(); // permission id
+            $table->string('name');
+            $table->string('guard_name');
+            $table->timestampsTz();
+
+            $table->unique(['name', 'guard_name']);
+        });
+
+        /**
+         * See `docs/prerequisites.md` for suggested lengths on 'name' and 'guard_name' if "1071 Specified key was too long" errors are encountered.
+         */
+        Schema::create($tableNames['roles'], static function (Blueprint $table) use ($teams, $columnNames): void {
+            $table->id(); // role id
+            if ($teams || config('permission.testing')) { // permission.testing is a fix for sqlite testing
+                $table->unsignedBigInteger($columnNames['team_foreign_key'])->nullable();
+                $table->index($columnNames['team_foreign_key'], 'roles_team_foreign_key_index');
+            }
+
+            $table->string('name');
+            $table->string('guard_name');
+            $table->timestampsTz();
+            if ($teams || config('permission.testing')) {
+                $table->unique([$columnNames['team_foreign_key'], 'name', 'guard_name']);
+            } else {
+                $table->unique(['name', 'guard_name']);
+            }
+        });
+
+        Schema::create($tableNames['model_has_permissions'], static function (Blueprint $table) use ($tableNames, $columnNames, $pivotPermission, $teams): void {
+            $table->unsignedBigInteger($pivotPermission);
+
+            $table->string('model_type');
+            $table->uuid($columnNames['model_morph_key']);
+            $table->index([$columnNames['model_morph_key'], 'model_type'], 'model_has_permissions_model_id_model_type_index');
+
+            $table->foreign($pivotPermission)
+                ->references('id') // permission id
+                ->on($tableNames['permissions'])
+                ->cascadeOnDelete();
+            if ($teams) {
+                $table->unsignedBigInteger($columnNames['team_foreign_key']);
+                $table->index($columnNames['team_foreign_key'], 'model_has_permissions_team_foreign_key_index');
+
+                $table->primary([$columnNames['team_foreign_key'], $pivotPermission, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_permissions_permission_model_type_primary');
+            } else {
+                $table->primary([$pivotPermission, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_permissions_permission_model_type_primary');
+            }
+        });
+
+        Schema::create($tableNames['model_has_roles'], static function (Blueprint $table) use ($tableNames, $columnNames, $pivotRole, $teams): void {
+            $table->unsignedBigInteger($pivotRole);
+
+            $table->string('model_type');
+            $table->uuid($columnNames['model_morph_key']);
+            $table->index([$columnNames['model_morph_key'], 'model_type'], 'model_has_roles_model_id_model_type_index');
+
+            $table->foreign($pivotRole)
+                ->references('id') // role id
+                ->on($tableNames['roles'])
+                ->cascadeOnDelete();
+            if ($teams) {
+                $table->unsignedBigInteger($columnNames['team_foreign_key']);
+                $table->index($columnNames['team_foreign_key'], 'model_has_roles_team_foreign_key_index');
+
+                $table->primary([$columnNames['team_foreign_key'], $pivotRole, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_roles_role_model_type_primary');
+            } else {
+                $table->primary([$pivotRole, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_roles_role_model_type_primary');
+            }
+        });
+
+        Schema::create($tableNames['role_has_permissions'], static function (Blueprint $table) use ($tableNames, $pivotRole, $pivotPermission): void {
+            $table->unsignedBigInteger($pivotPermission);
+            $table->unsignedBigInteger($pivotRole);
+
+            $table->foreign($pivotPermission)
+                ->references('id') // permission id
+                ->on($tableNames['permissions'])
+                ->cascadeOnDelete();
+
+            $table->foreign($pivotRole)
+                ->references('id') // role id
+                ->on($tableNames['roles'])
+                ->cascadeOnDelete();
+
+            $table->primary([$pivotPermission, $pivotRole], 'role_has_permissions_permission_id_role_id_primary');
+        });
+
+        resolve(Factory::class)
+            ->store(config('permission.cache.store') !== 'default' ? config('permission.cache.store') : null)
+            ->forget(config('permission.cache.key'));
+    }
+
+    public function down(): void
+    {
+        $tableNames = config('permission.table_names');
+
+        throw_if(blank($tableNames), 'Error: config/permission.php not found and defaults could not be merged. Please publish the package configuration before proceeding, or drop the tables manually.');
+
+        Schema::dropIfExists($tableNames['role_has_permissions']);
+        Schema::dropIfExists($tableNames['model_has_roles']);
+        Schema::dropIfExists($tableNames['model_has_permissions']);
+        Schema::dropIfExists($tableNames['roles']);
+        Schema::dropIfExists($tableNames['permissions']);
+    }
+};

--- a/app-modules/identity/src/User/Models/User.php
+++ b/app-modules/identity/src/User/Models/User.php
@@ -53,11 +53,6 @@ final class User extends Authenticatable implements FilamentUser, HasMedia, HasN
     use InteractsWithMedia;
     use Notifiable;
 
-    public function isAdmin(): bool
-    {
-        return in_array($this->username, str(config('he4rt.admins'))->explode(',')->toArray(), strict: true);
-    }
-
     /**
      * @return MorphMany<ExternalIdentity, $this>
      */
@@ -93,8 +88,8 @@ final class User extends Authenticatable implements FilamentUser, HasMedia, HasN
     public function canAccessPanel(Panel $panel): bool
     {
         return match ($panel->getId()) {
-            'admin' => app()->isProduction() ? $this->isAdmin() : true,
-            default => true
+            'admin' => $this->roles()->exists(),
+            default => true,
         };
     }
 

--- a/app-modules/identity/src/User/Models/User.php
+++ b/app-modules/identity/src/User/Models/User.php
@@ -25,6 +25,7 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
+use Spatie\Permission\Traits\HasRoles;
 
 /**
  * @property string $id
@@ -47,6 +48,7 @@ final class User extends Authenticatable implements FilamentUser, HasMedia, HasN
     use HasAddress;
     /** @use HasFactory<UserFactory> */
     use HasFactory;
+    use HasRoles;
     use HasUuids;
     use InteractsWithMedia;
     use Notifiable;

--- a/app-modules/identity/tests/Feature/Access/PermissionTablesTest.php
+++ b/app-modules/identity/tests/Feature/Access/PermissionTablesTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Identity\User\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Spatie\Permission\Models\Role;
+
+test('permission tables exist', function (): void {
+    expect(Schema::hasTable('permissions'))->toBeTrue()
+        ->and(Schema::hasTable('roles'))->toBeTrue()
+        ->and(Schema::hasTable('model_has_roles'))->toBeTrue()
+        ->and(Schema::hasTable('model_has_permissions'))->toBeTrue()
+        ->and(Schema::hasTable('role_has_permissions'))->toBeTrue();
+});
+
+test('model_morph_key stores a uuid, not a bigint', function (): void {
+    expect(Schema::getColumnType('model_has_roles', 'model_id'))->toBe('uuid')
+        ->and(Schema::getColumnType('model_has_permissions', 'model_id'))->toBe('uuid');
+});
+
+test('role timestamps are timezone aware', function (): void {
+    expect(Schema::getColumnType('roles', 'created_at', fullDefinition: true))
+        ->toContain('with time zone')
+        ->and(Schema::getColumnType('permissions', 'updated_at', fullDefinition: true))
+        ->toContain('with time zone');
+});
+
+test('assigning a role to a uuid user keeps the uuid intact', function (): void {
+    $user = User::factory()->create();
+    $role = Role::create(['name' => 'moderation:viewer', 'guard_name' => 'web']);
+
+    $user->assignRole($role);
+
+    $pivot = DB::table('model_has_roles')
+        ->where('role_id', $role->id)
+        ->sole();
+
+    expect($pivot->model_id)->toBe($user->id)
+        ->and($user->fresh()->hasRole('moderation:viewer'))->toBeTrue();
+});
+
+test('the pivot stores the morph alias instead of the fqcn', function (): void {
+    $user = User::factory()->create();
+    $user->assignRole(Role::create(['name' => 'discord:viewer', 'guard_name' => 'web']));
+
+    expect(DB::table('model_has_roles')->value('model_type'))->toBe('user');
+});

--- a/app-modules/panel-admin/src/PanelAdminServiceProvider.php
+++ b/app-modules/panel-admin/src/PanelAdminServiceProvider.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace He4rt\PanelAdmin;
 
 use BezhanSalleh\FilamentShield\Facades\FilamentShield;
-use Filament\Facades\Filament;
 use Filament\Navigation\NavigationBuilder;
 use Filament\Navigation\NavigationItem;
 use Filament\Panel;
@@ -113,27 +112,16 @@ class PanelAdminServiceProvider extends ServiceProvider
 
     /**
      * Authorising a panel screen is a presentation concern, so the policies live in this
-     * module instead of beside each domain model. Shield only looks for a sibling
-     * "Policies" directory whenever a model sits under "Models", so it never finds them
-     * and Laravel's own discovery does not either. Bind each one here.
+     * module instead of beside each domain model. Neither Laravel's discovery nor
+     * Shield's looks here, so teach the Gate where to look. Names that do not resolve
+     * are discarded by the Gate, and the framework default stays as a fallback.
      */
     private function registerPanelPolicies(): void
     {
-        Filament::serving(function (): void {
-            foreach (Filament::getPanel('admin')->getResources() as $resource) {
-                $model = $resource::getModel();
-
-                if (!is_string($model)) {
-                    continue;
-                }
-
-                $policy = 'He4rt\\PanelAdmin\\Policies\\'.class_basename($model).'Policy';
-
-                if (class_exists($policy)) {
-                    Gate::policy($model, $policy);
-                }
-            }
-        });
+        Gate::guessPolicyNamesUsing(fn (string $model): array => [
+            'He4rt\\PanelAdmin\\Policies\\'.class_basename($model).'Policy',
+            'App\\Policies\\'.class_basename($model).'Policy',
+        ]);
     }
 
     private function buildNavigation(NavigationBuilder $builder): NavigationBuilder

--- a/app-modules/panel-admin/src/PanelAdminServiceProvider.php
+++ b/app-modules/panel-admin/src/PanelAdminServiceProvider.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace He4rt\PanelAdmin;
 
+use BezhanSalleh\FilamentShield\Facades\FilamentShield;
+use Filament\Facades\Filament;
 use Filament\Navigation\NavigationBuilder;
 use Filament\Navigation\NavigationItem;
 use Filament\Panel;
@@ -18,7 +20,9 @@ use He4rt\PanelAdmin\Moderation\Livewire\ModerationQueue;
 use He4rt\PanelAdmin\Moderation\ModerationCluster;
 use He4rt\PanelAdmin\Pages\Dashboard;
 use He4rt\PanelAdmin\Twitch\TwitchCluster;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
 use Livewire\Livewire;
 
 class PanelAdminServiceProvider extends ServiceProvider
@@ -86,12 +90,50 @@ class PanelAdminServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
+        $this->configureShield();
+
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'panel-admin');
         $this->loadTranslationsFrom(__DIR__.'/../lang', 'panel-admin');
 
         Livewire::component('moderation-queue', ModerationQueue::class);
         Livewire::component('appeal-queue', AppealQueue::class);
         Livewire::component('moderation-dashboard', ModerationDashboardLivewire::class);
+    }
+
+    private function configureShield(): void
+    {
+        // Shield refuses the '_' separator alongside snake case, so the config carries a
+        // placeholder separator and this builder joins the parts itself.
+        FilamentShield::buildPermissionKeyUsing(
+            fn (string $affix, string $subject): string => Str::snake($affix).'_'.Str::snake($subject),
+        );
+
+        $this->registerPanelPolicies();
+    }
+
+    /**
+     * Authorising a panel screen is a presentation concern, so the policies live in this
+     * module instead of beside each domain model. Shield only looks for a sibling
+     * "Policies" directory whenever a model sits under "Models", so it never finds them
+     * and Laravel's own discovery does not either. Bind each one here.
+     */
+    private function registerPanelPolicies(): void
+    {
+        Filament::serving(function (): void {
+            foreach (Filament::getPanel('admin')->getResources() as $resource) {
+                $model = $resource::getModel();
+
+                if (!is_string($model)) {
+                    continue;
+                }
+
+                $policy = 'He4rt\\PanelAdmin\\Policies\\'.class_basename($model).'Policy';
+
+                if (class_exists($policy)) {
+                    Gate::policy($model, $policy);
+                }
+            }
+        });
     }
 
     private function buildNavigation(NavigationBuilder $builder): NavigationBuilder

--- a/app-modules/panel-admin/src/Policies/DiscordChannelPolicy.php
+++ b/app-modules/panel-admin/src/Policies/DiscordChannelPolicy.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\PanelAdmin\Policies;
+
+use He4rt\IntegrationDiscord\Models\DiscordChannel;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Foundation\Auth\User as AuthUser;
+
+class DiscordChannelPolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('view_any_discord_channel');
+    }
+
+    public function view(AuthUser $authUser, DiscordChannel $discordChannel): bool
+    {
+        return $authUser->can('view_discord_channel');
+    }
+
+    public function create(AuthUser $authUser): bool
+    {
+        return $authUser->can('create_discord_channel');
+    }
+
+    public function update(AuthUser $authUser, DiscordChannel $discordChannel): bool
+    {
+        return $authUser->can('update_discord_channel');
+    }
+
+    public function delete(AuthUser $authUser, DiscordChannel $discordChannel): bool
+    {
+        return $authUser->can('delete_discord_channel');
+    }
+
+    public function deleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('delete_any_discord_channel');
+    }
+
+    public function restore(AuthUser $authUser, DiscordChannel $discordChannel): bool
+    {
+        return $authUser->can('restore_discord_channel');
+    }
+
+    public function forceDelete(AuthUser $authUser, DiscordChannel $discordChannel): bool
+    {
+        return $authUser->can('force_delete_discord_channel');
+    }
+
+    public function forceDeleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('force_delete_any_discord_channel');
+    }
+
+    public function restoreAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('restore_any_discord_channel');
+    }
+
+    public function replicate(AuthUser $authUser, DiscordChannel $discordChannel): bool
+    {
+        return $authUser->can('replicate_discord_channel');
+    }
+
+    public function reorder(AuthUser $authUser): bool
+    {
+        return $authUser->can('reorder_discord_channel');
+    }
+}

--- a/app-modules/panel-admin/src/Policies/DiscordEventLogPolicy.php
+++ b/app-modules/panel-admin/src/Policies/DiscordEventLogPolicy.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\PanelAdmin\Policies;
+
+use He4rt\IntegrationDiscord\Models\DiscordEventLog;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Foundation\Auth\User as AuthUser;
+
+class DiscordEventLogPolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('view_any_discord_event_log');
+    }
+
+    public function view(AuthUser $authUser, DiscordEventLog $discordEventLog): bool
+    {
+        return $authUser->can('view_discord_event_log');
+    }
+
+    public function create(AuthUser $authUser): bool
+    {
+        return $authUser->can('create_discord_event_log');
+    }
+
+    public function update(AuthUser $authUser, DiscordEventLog $discordEventLog): bool
+    {
+        return $authUser->can('update_discord_event_log');
+    }
+
+    public function delete(AuthUser $authUser, DiscordEventLog $discordEventLog): bool
+    {
+        return $authUser->can('delete_discord_event_log');
+    }
+
+    public function deleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('delete_any_discord_event_log');
+    }
+
+    public function restore(AuthUser $authUser, DiscordEventLog $discordEventLog): bool
+    {
+        return $authUser->can('restore_discord_event_log');
+    }
+
+    public function forceDelete(AuthUser $authUser, DiscordEventLog $discordEventLog): bool
+    {
+        return $authUser->can('force_delete_discord_event_log');
+    }
+
+    public function forceDeleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('force_delete_any_discord_event_log');
+    }
+
+    public function restoreAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('restore_any_discord_event_log');
+    }
+
+    public function replicate(AuthUser $authUser, DiscordEventLog $discordEventLog): bool
+    {
+        return $authUser->can('replicate_discord_event_log');
+    }
+
+    public function reorder(AuthUser $authUser): bool
+    {
+        return $authUser->can('reorder_discord_event_log');
+    }
+}

--- a/app-modules/panel-admin/src/Policies/DiscordGuildPolicy.php
+++ b/app-modules/panel-admin/src/Policies/DiscordGuildPolicy.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\PanelAdmin\Policies;
+
+use He4rt\IntegrationDiscord\Models\DiscordGuild;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Foundation\Auth\User as AuthUser;
+
+class DiscordGuildPolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('view_any_discord_guild');
+    }
+
+    public function view(AuthUser $authUser, DiscordGuild $discordGuild): bool
+    {
+        return $authUser->can('view_discord_guild');
+    }
+
+    public function create(AuthUser $authUser): bool
+    {
+        return $authUser->can('create_discord_guild');
+    }
+
+    public function update(AuthUser $authUser, DiscordGuild $discordGuild): bool
+    {
+        return $authUser->can('update_discord_guild');
+    }
+
+    public function delete(AuthUser $authUser, DiscordGuild $discordGuild): bool
+    {
+        return $authUser->can('delete_discord_guild');
+    }
+
+    public function deleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('delete_any_discord_guild');
+    }
+
+    public function restore(AuthUser $authUser, DiscordGuild $discordGuild): bool
+    {
+        return $authUser->can('restore_discord_guild');
+    }
+
+    public function forceDelete(AuthUser $authUser, DiscordGuild $discordGuild): bool
+    {
+        return $authUser->can('force_delete_discord_guild');
+    }
+
+    public function forceDeleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('force_delete_any_discord_guild');
+    }
+
+    public function restoreAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('restore_any_discord_guild');
+    }
+
+    public function replicate(AuthUser $authUser, DiscordGuild $discordGuild): bool
+    {
+        return $authUser->can('replicate_discord_guild');
+    }
+
+    public function reorder(AuthUser $authUser): bool
+    {
+        return $authUser->can('reorder_discord_guild');
+    }
+}

--- a/app-modules/panel-admin/src/Policies/DiscordMemberPolicy.php
+++ b/app-modules/panel-admin/src/Policies/DiscordMemberPolicy.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\PanelAdmin\Policies;
+
+use He4rt\IntegrationDiscord\Models\DiscordMember;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Foundation\Auth\User as AuthUser;
+
+class DiscordMemberPolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('view_any_discord_member');
+    }
+
+    public function view(AuthUser $authUser, DiscordMember $discordMember): bool
+    {
+        return $authUser->can('view_discord_member');
+    }
+
+    public function create(AuthUser $authUser): bool
+    {
+        return $authUser->can('create_discord_member');
+    }
+
+    public function update(AuthUser $authUser, DiscordMember $discordMember): bool
+    {
+        return $authUser->can('update_discord_member');
+    }
+
+    public function delete(AuthUser $authUser, DiscordMember $discordMember): bool
+    {
+        return $authUser->can('delete_discord_member');
+    }
+
+    public function deleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('delete_any_discord_member');
+    }
+
+    public function restore(AuthUser $authUser, DiscordMember $discordMember): bool
+    {
+        return $authUser->can('restore_discord_member');
+    }
+
+    public function forceDelete(AuthUser $authUser, DiscordMember $discordMember): bool
+    {
+        return $authUser->can('force_delete_discord_member');
+    }
+
+    public function forceDeleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('force_delete_any_discord_member');
+    }
+
+    public function restoreAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('restore_any_discord_member');
+    }
+
+    public function replicate(AuthUser $authUser, DiscordMember $discordMember): bool
+    {
+        return $authUser->can('replicate_discord_member');
+    }
+
+    public function reorder(AuthUser $authUser): bool
+    {
+        return $authUser->can('reorder_discord_member');
+    }
+}

--- a/app-modules/panel-admin/src/Policies/DiscordRolePolicy.php
+++ b/app-modules/panel-admin/src/Policies/DiscordRolePolicy.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\PanelAdmin\Policies;
+
+use He4rt\IntegrationDiscord\Models\DiscordRole;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Foundation\Auth\User as AuthUser;
+
+class DiscordRolePolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('view_any_discord_role');
+    }
+
+    public function view(AuthUser $authUser, DiscordRole $discordRole): bool
+    {
+        return $authUser->can('view_discord_role');
+    }
+
+    public function create(AuthUser $authUser): bool
+    {
+        return $authUser->can('create_discord_role');
+    }
+
+    public function update(AuthUser $authUser, DiscordRole $discordRole): bool
+    {
+        return $authUser->can('update_discord_role');
+    }
+
+    public function delete(AuthUser $authUser, DiscordRole $discordRole): bool
+    {
+        return $authUser->can('delete_discord_role');
+    }
+
+    public function deleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('delete_any_discord_role');
+    }
+
+    public function restore(AuthUser $authUser, DiscordRole $discordRole): bool
+    {
+        return $authUser->can('restore_discord_role');
+    }
+
+    public function forceDelete(AuthUser $authUser, DiscordRole $discordRole): bool
+    {
+        return $authUser->can('force_delete_discord_role');
+    }
+
+    public function forceDeleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('force_delete_any_discord_role');
+    }
+
+    public function restoreAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('restore_any_discord_role');
+    }
+
+    public function replicate(AuthUser $authUser, DiscordRole $discordRole): bool
+    {
+        return $authUser->can('replicate_discord_role');
+    }
+
+    public function reorder(AuthUser $authUser): bool
+    {
+        return $authUser->can('reorder_discord_role');
+    }
+}

--- a/app-modules/panel-admin/src/Policies/EventPolicy.php
+++ b/app-modules/panel-admin/src/Policies/EventPolicy.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\PanelAdmin\Policies;
+
+use He4rt\Events\Event\Models\Event;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Foundation\Auth\User as AuthUser;
+
+class EventPolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('view_any_event');
+    }
+
+    public function view(AuthUser $authUser, Event $event): bool
+    {
+        return $authUser->can('view_event');
+    }
+
+    public function create(AuthUser $authUser): bool
+    {
+        return $authUser->can('create_event');
+    }
+
+    public function update(AuthUser $authUser, Event $event): bool
+    {
+        return $authUser->can('update_event');
+    }
+
+    public function delete(AuthUser $authUser, Event $event): bool
+    {
+        return $authUser->can('delete_event');
+    }
+
+    public function deleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('delete_any_event');
+    }
+
+    public function restore(AuthUser $authUser, Event $event): bool
+    {
+        return $authUser->can('restore_event');
+    }
+
+    public function forceDelete(AuthUser $authUser, Event $event): bool
+    {
+        return $authUser->can('force_delete_event');
+    }
+
+    public function forceDeleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('force_delete_any_event');
+    }
+
+    public function restoreAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('restore_any_event');
+    }
+
+    public function replicate(AuthUser $authUser, Event $event): bool
+    {
+        return $authUser->can('replicate_event');
+    }
+
+    public function reorder(AuthUser $authUser): bool
+    {
+        return $authUser->can('reorder_event');
+    }
+}

--- a/app-modules/panel-admin/src/Policies/ExternalIdentityPolicy.php
+++ b/app-modules/panel-admin/src/Policies/ExternalIdentityPolicy.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\PanelAdmin\Policies;
+
+use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Foundation\Auth\User as AuthUser;
+
+class ExternalIdentityPolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('view_any_external_identity');
+    }
+
+    public function view(AuthUser $authUser, ExternalIdentity $externalIdentity): bool
+    {
+        return $authUser->can('view_external_identity');
+    }
+
+    public function create(AuthUser $authUser): bool
+    {
+        return $authUser->can('create_external_identity');
+    }
+
+    public function update(AuthUser $authUser, ExternalIdentity $externalIdentity): bool
+    {
+        return $authUser->can('update_external_identity');
+    }
+
+    public function delete(AuthUser $authUser, ExternalIdentity $externalIdentity): bool
+    {
+        return $authUser->can('delete_external_identity');
+    }
+
+    public function deleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('delete_any_external_identity');
+    }
+
+    public function restore(AuthUser $authUser, ExternalIdentity $externalIdentity): bool
+    {
+        return $authUser->can('restore_external_identity');
+    }
+
+    public function forceDelete(AuthUser $authUser, ExternalIdentity $externalIdentity): bool
+    {
+        return $authUser->can('force_delete_external_identity');
+    }
+
+    public function forceDeleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('force_delete_any_external_identity');
+    }
+
+    public function restoreAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('restore_any_external_identity');
+    }
+
+    public function replicate(AuthUser $authUser, ExternalIdentity $externalIdentity): bool
+    {
+        return $authUser->can('replicate_external_identity');
+    }
+
+    public function reorder(AuthUser $authUser): bool
+    {
+        return $authUser->can('reorder_external_identity');
+    }
+}

--- a/app-modules/panel-admin/src/Policies/GithubRepositoryPolicy.php
+++ b/app-modules/panel-admin/src/Policies/GithubRepositoryPolicy.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\PanelAdmin\Policies;
+
+use He4rt\IntegrationGithub\Models\GithubRepository;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Foundation\Auth\User as AuthUser;
+
+class GithubRepositoryPolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('view_any_github_repository');
+    }
+
+    public function view(AuthUser $authUser, GithubRepository $githubRepository): bool
+    {
+        return $authUser->can('view_github_repository');
+    }
+
+    public function create(AuthUser $authUser): bool
+    {
+        return $authUser->can('create_github_repository');
+    }
+
+    public function update(AuthUser $authUser, GithubRepository $githubRepository): bool
+    {
+        return $authUser->can('update_github_repository');
+    }
+
+    public function delete(AuthUser $authUser, GithubRepository $githubRepository): bool
+    {
+        return $authUser->can('delete_github_repository');
+    }
+
+    public function deleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('delete_any_github_repository');
+    }
+
+    public function restore(AuthUser $authUser, GithubRepository $githubRepository): bool
+    {
+        return $authUser->can('restore_github_repository');
+    }
+
+    public function forceDelete(AuthUser $authUser, GithubRepository $githubRepository): bool
+    {
+        return $authUser->can('force_delete_github_repository');
+    }
+
+    public function forceDeleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('force_delete_any_github_repository');
+    }
+
+    public function restoreAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('restore_any_github_repository');
+    }
+
+    public function replicate(AuthUser $authUser, GithubRepository $githubRepository): bool
+    {
+        return $authUser->can('replicate_github_repository');
+    }
+
+    public function reorder(AuthUser $authUser): bool
+    {
+        return $authUser->can('reorder_github_repository');
+    }
+}

--- a/app-modules/panel-admin/src/Policies/ModerationAppealPolicy.php
+++ b/app-modules/panel-admin/src/Policies/ModerationAppealPolicy.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\PanelAdmin\Policies;
+
+use He4rt\Moderation\Appeals\ModerationAppeal;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Foundation\Auth\User as AuthUser;
+
+class ModerationAppealPolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('view_any_moderation_appeal');
+    }
+
+    public function view(AuthUser $authUser, ModerationAppeal $moderationAppeal): bool
+    {
+        return $authUser->can('view_moderation_appeal');
+    }
+
+    public function create(AuthUser $authUser): bool
+    {
+        return $authUser->can('create_moderation_appeal');
+    }
+
+    public function update(AuthUser $authUser, ModerationAppeal $moderationAppeal): bool
+    {
+        return $authUser->can('update_moderation_appeal');
+    }
+
+    public function delete(AuthUser $authUser, ModerationAppeal $moderationAppeal): bool
+    {
+        return $authUser->can('delete_moderation_appeal');
+    }
+
+    public function deleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('delete_any_moderation_appeal');
+    }
+
+    public function restore(AuthUser $authUser, ModerationAppeal $moderationAppeal): bool
+    {
+        return $authUser->can('restore_moderation_appeal');
+    }
+
+    public function forceDelete(AuthUser $authUser, ModerationAppeal $moderationAppeal): bool
+    {
+        return $authUser->can('force_delete_moderation_appeal');
+    }
+
+    public function forceDeleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('force_delete_any_moderation_appeal');
+    }
+
+    public function restoreAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('restore_any_moderation_appeal');
+    }
+
+    public function replicate(AuthUser $authUser, ModerationAppeal $moderationAppeal): bool
+    {
+        return $authUser->can('replicate_moderation_appeal');
+    }
+
+    public function reorder(AuthUser $authUser): bool
+    {
+        return $authUser->can('reorder_moderation_appeal');
+    }
+}

--- a/app-modules/panel-admin/src/Policies/ModerationCasePolicy.php
+++ b/app-modules/panel-admin/src/Policies/ModerationCasePolicy.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\PanelAdmin\Policies;
+
+use He4rt\Moderation\Cases\Models\ModerationCase;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Foundation\Auth\User as AuthUser;
+
+class ModerationCasePolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('view_any_moderation_case');
+    }
+
+    public function view(AuthUser $authUser, ModerationCase $moderationCase): bool
+    {
+        return $authUser->can('view_moderation_case');
+    }
+
+    public function create(AuthUser $authUser): bool
+    {
+        return $authUser->can('create_moderation_case');
+    }
+
+    public function update(AuthUser $authUser, ModerationCase $moderationCase): bool
+    {
+        return $authUser->can('update_moderation_case');
+    }
+
+    public function delete(AuthUser $authUser, ModerationCase $moderationCase): bool
+    {
+        return $authUser->can('delete_moderation_case');
+    }
+
+    public function deleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('delete_any_moderation_case');
+    }
+
+    public function restore(AuthUser $authUser, ModerationCase $moderationCase): bool
+    {
+        return $authUser->can('restore_moderation_case');
+    }
+
+    public function forceDelete(AuthUser $authUser, ModerationCase $moderationCase): bool
+    {
+        return $authUser->can('force_delete_moderation_case');
+    }
+
+    public function forceDeleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('force_delete_any_moderation_case');
+    }
+
+    public function restoreAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('restore_any_moderation_case');
+    }
+
+    public function replicate(AuthUser $authUser, ModerationCase $moderationCase): bool
+    {
+        return $authUser->can('replicate_moderation_case');
+    }
+
+    public function reorder(AuthUser $authUser): bool
+    {
+        return $authUser->can('reorder_moderation_case');
+    }
+}

--- a/app-modules/panel-admin/src/Policies/ModerationRulePolicy.php
+++ b/app-modules/panel-admin/src/Policies/ModerationRulePolicy.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\PanelAdmin\Policies;
+
+use He4rt\Moderation\Rules\ModerationRule;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Foundation\Auth\User as AuthUser;
+
+class ModerationRulePolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('view_any_moderation_rule');
+    }
+
+    public function view(AuthUser $authUser, ModerationRule $moderationRule): bool
+    {
+        return $authUser->can('view_moderation_rule');
+    }
+
+    public function create(AuthUser $authUser): bool
+    {
+        return $authUser->can('create_moderation_rule');
+    }
+
+    public function update(AuthUser $authUser, ModerationRule $moderationRule): bool
+    {
+        return $authUser->can('update_moderation_rule');
+    }
+
+    public function delete(AuthUser $authUser, ModerationRule $moderationRule): bool
+    {
+        return $authUser->can('delete_moderation_rule');
+    }
+
+    public function deleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('delete_any_moderation_rule');
+    }
+
+    public function restore(AuthUser $authUser, ModerationRule $moderationRule): bool
+    {
+        return $authUser->can('restore_moderation_rule');
+    }
+
+    public function forceDelete(AuthUser $authUser, ModerationRule $moderationRule): bool
+    {
+        return $authUser->can('force_delete_moderation_rule');
+    }
+
+    public function forceDeleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('force_delete_any_moderation_rule');
+    }
+
+    public function restoreAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('restore_any_moderation_rule');
+    }
+
+    public function replicate(AuthUser $authUser, ModerationRule $moderationRule): bool
+    {
+        return $authUser->can('replicate_moderation_rule');
+    }
+
+    public function reorder(AuthUser $authUser): bool
+    {
+        return $authUser->can('reorder_moderation_rule');
+    }
+}

--- a/app-modules/panel-admin/src/Policies/RolePolicy.php
+++ b/app-modules/panel-admin/src/Policies/RolePolicy.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\PanelAdmin\Policies;
+
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Foundation\Auth\User as AuthUser;
+use Spatie\Permission\Models\Role;
+
+class RolePolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('view_any_role');
+    }
+
+    public function view(AuthUser $authUser, Role $role): bool
+    {
+        return $authUser->can('view_role');
+    }
+
+    public function create(AuthUser $authUser): bool
+    {
+        return $authUser->can('create_role');
+    }
+
+    public function update(AuthUser $authUser, Role $role): bool
+    {
+        return $authUser->can('update_role');
+    }
+
+    public function delete(AuthUser $authUser, Role $role): bool
+    {
+        return $authUser->can('delete_role');
+    }
+
+    public function deleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('delete_any_role');
+    }
+
+    public function restore(AuthUser $authUser, Role $role): bool
+    {
+        return $authUser->can('restore_role');
+    }
+
+    public function forceDelete(AuthUser $authUser, Role $role): bool
+    {
+        return $authUser->can('force_delete_role');
+    }
+
+    public function forceDeleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('force_delete_any_role');
+    }
+
+    public function restoreAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('restore_any_role');
+    }
+
+    public function replicate(AuthUser $authUser, Role $role): bool
+    {
+        return $authUser->can('replicate_role');
+    }
+
+    public function reorder(AuthUser $authUser): bool
+    {
+        return $authUser->can('reorder_role');
+    }
+}

--- a/app-modules/panel-admin/src/Policies/ShortLinkPolicy.php
+++ b/app-modules/panel-admin/src/Policies/ShortLinkPolicy.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\PanelAdmin\Policies;
+
+use He4rt\Marketing\ShortLink\Models\ShortLink;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Foundation\Auth\User as AuthUser;
+
+class ShortLinkPolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('view_any_short_link');
+    }
+
+    public function view(AuthUser $authUser, ShortLink $shortLink): bool
+    {
+        return $authUser->can('view_short_link');
+    }
+
+    public function create(AuthUser $authUser): bool
+    {
+        return $authUser->can('create_short_link');
+    }
+
+    public function update(AuthUser $authUser, ShortLink $shortLink): bool
+    {
+        return $authUser->can('update_short_link');
+    }
+
+    public function delete(AuthUser $authUser, ShortLink $shortLink): bool
+    {
+        return $authUser->can('delete_short_link');
+    }
+
+    public function deleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('delete_any_short_link');
+    }
+
+    public function restore(AuthUser $authUser, ShortLink $shortLink): bool
+    {
+        return $authUser->can('restore_short_link');
+    }
+
+    public function forceDelete(AuthUser $authUser, ShortLink $shortLink): bool
+    {
+        return $authUser->can('force_delete_short_link');
+    }
+
+    public function forceDeleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('force_delete_any_short_link');
+    }
+
+    public function restoreAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('restore_any_short_link');
+    }
+
+    public function replicate(AuthUser $authUser, ShortLink $shortLink): bool
+    {
+        return $authUser->can('replicate_short_link');
+    }
+
+    public function reorder(AuthUser $authUser): bool
+    {
+        return $authUser->can('reorder_short_link');
+    }
+}

--- a/app-modules/panel-admin/src/Policies/TwitchEventLogPolicy.php
+++ b/app-modules/panel-admin/src/Policies/TwitchEventLogPolicy.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\PanelAdmin\Policies;
+
+use He4rt\IntegrationTwitch\Models\TwitchEventLog;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Foundation\Auth\User as AuthUser;
+
+class TwitchEventLogPolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('view_any_twitch_event_log');
+    }
+
+    public function view(AuthUser $authUser, TwitchEventLog $twitchEventLog): bool
+    {
+        return $authUser->can('view_twitch_event_log');
+    }
+
+    public function create(AuthUser $authUser): bool
+    {
+        return $authUser->can('create_twitch_event_log');
+    }
+
+    public function update(AuthUser $authUser, TwitchEventLog $twitchEventLog): bool
+    {
+        return $authUser->can('update_twitch_event_log');
+    }
+
+    public function delete(AuthUser $authUser, TwitchEventLog $twitchEventLog): bool
+    {
+        return $authUser->can('delete_twitch_event_log');
+    }
+
+    public function deleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('delete_any_twitch_event_log');
+    }
+
+    public function restore(AuthUser $authUser, TwitchEventLog $twitchEventLog): bool
+    {
+        return $authUser->can('restore_twitch_event_log');
+    }
+
+    public function forceDelete(AuthUser $authUser, TwitchEventLog $twitchEventLog): bool
+    {
+        return $authUser->can('force_delete_twitch_event_log');
+    }
+
+    public function forceDeleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('force_delete_any_twitch_event_log');
+    }
+
+    public function restoreAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('restore_any_twitch_event_log');
+    }
+
+    public function replicate(AuthUser $authUser, TwitchEventLog $twitchEventLog): bool
+    {
+        return $authUser->can('replicate_twitch_event_log');
+    }
+
+    public function reorder(AuthUser $authUser): bool
+    {
+        return $authUser->can('reorder_twitch_event_log');
+    }
+}

--- a/app-modules/panel-admin/src/Policies/TwitchSubscriptionPolicy.php
+++ b/app-modules/panel-admin/src/Policies/TwitchSubscriptionPolicy.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\PanelAdmin\Policies;
+
+use He4rt\IntegrationTwitch\Models\TwitchSubscription;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Foundation\Auth\User as AuthUser;
+
+class TwitchSubscriptionPolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('view_any_twitch_subscription');
+    }
+
+    public function view(AuthUser $authUser, TwitchSubscription $twitchSubscription): bool
+    {
+        return $authUser->can('view_twitch_subscription');
+    }
+
+    public function create(AuthUser $authUser): bool
+    {
+        return $authUser->can('create_twitch_subscription');
+    }
+
+    public function update(AuthUser $authUser, TwitchSubscription $twitchSubscription): bool
+    {
+        return $authUser->can('update_twitch_subscription');
+    }
+
+    public function delete(AuthUser $authUser, TwitchSubscription $twitchSubscription): bool
+    {
+        return $authUser->can('delete_twitch_subscription');
+    }
+
+    public function deleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('delete_any_twitch_subscription');
+    }
+
+    public function restore(AuthUser $authUser, TwitchSubscription $twitchSubscription): bool
+    {
+        return $authUser->can('restore_twitch_subscription');
+    }
+
+    public function forceDelete(AuthUser $authUser, TwitchSubscription $twitchSubscription): bool
+    {
+        return $authUser->can('force_delete_twitch_subscription');
+    }
+
+    public function forceDeleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('force_delete_any_twitch_subscription');
+    }
+
+    public function restoreAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('restore_any_twitch_subscription');
+    }
+
+    public function replicate(AuthUser $authUser, TwitchSubscription $twitchSubscription): bool
+    {
+        return $authUser->can('replicate_twitch_subscription');
+    }
+
+    public function reorder(AuthUser $authUser): bool
+    {
+        return $authUser->can('reorder_twitch_subscription');
+    }
+}

--- a/app-modules/panel-admin/tests/Feature/Access/AreaIsolationTest.php
+++ b/app-modules/panel-admin/tests/Feature/Access/AreaIsolationTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Facades\Filament;
+use He4rt\PanelAdmin\Marketing\Resources\ShortLinks\Pages\ListShortLinks;
+
+use function Pest\Livewire\livewire;
+
+/**
+ * Holding a permission for one area must not open another. These two cover both entry
+ * points, because a policy that only binds during an HTTP request would leave every
+ * Livewire component wide open.
+ */
+beforeEach(function (): void {
+    $this->actingAs(panelUserWith('view_any_moderation_case'));
+
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+});
+
+test('a permission from another area does not open a livewire page', function (): void {
+    livewire(ListShortLinks::class)->assertForbidden();
+});
+
+test('a permission from another area does not open the http route', function (): void {
+    $this->get('/admin/marketing/short-links')->assertForbidden();
+});
+
+test('the matching permission does open the page', function (): void {
+    $this->actingAs(panelUserWith('view_any_short_link'));
+
+    livewire(ListShortLinks::class)->assertSuccessful();
+});

--- a/app-modules/panel-admin/tests/Feature/Access/PolicyCoverageTest.php
+++ b/app-modules/panel-admin/tests/Feature/Access/PolicyCoverageTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Facades\Filament;
+use He4rt\Identity\User\Models\User;
+use Illuminate\Support\Facades\Gate;
+use Spatie\Permission\Models\Role;
+
+/**
+ * Every Resource exposed by the admin panel must be governed by a policy. Without this
+ * guard a Resource added later would reach the panel wide open, and nothing would say so.
+ */
+test('every admin panel resource is governed by a policy', function (): void {
+    $user = User::factory()->create();
+    $user->assignRole(Role::create(['name' => 'coverage:probe', 'guard_name' => 'web']));
+
+    $this->actingAs($user)->get('/admin')->assertOk();
+
+    $unguarded = collect(Filament::getPanel('admin')->getResources())
+        ->map(fn (string $resource): ?string => $resource::getModel())
+        ->filter()
+        ->reject(fn (string $model): bool => Gate::getPolicyFor($model) !== null)
+        ->values()
+        ->all();
+
+    expect($unguarded)->toBeEmpty();
+});

--- a/app-modules/panel-admin/tests/Feature/AdminPanelAccessTest.php
+++ b/app-modules/panel-admin/tests/Feature/AdminPanelAccessTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Filament\Facades\Filament;
 use He4rt\Identity\User\Models\User;
+use Spatie\Permission\Models\Role;
 
 test('unauthenticated user is redirected to login', function (): void {
     $this
@@ -17,10 +18,9 @@ test('admin login page renders', function (): void {
         ->assertOk();
 });
 
-test('authenticated admin can access admin panel', function (): void {
-    $user = User::factory()->create(['username' => 'danielhe4rt']);
-
-    config(['he4rt.admins' => 'danielhe4rt']);
+test('a user holding any role can access the admin panel', function (): void {
+    $user = User::factory()->create();
+    $user->assignRole(Role::create(['name' => 'github:viewer', 'guard_name' => 'web']));
 
     $this
         ->actingAs($user)
@@ -28,24 +28,24 @@ test('authenticated admin can access admin panel', function (): void {
         ->assertOk();
 });
 
-test('admin user can access panel via canAccessPanel', function (): void {
-    $user = User::factory()->create(['username' => 'danielhe4rt']);
-
-    config(['he4rt.admins' => 'danielhe4rt']);
-
-    $panel = Filament::getPanel('admin');
-
-    expect($user->canAccessPanel($panel))->toBeTrue();
-});
-
-test('non-admin user cannot access admin panel in production', function (): void {
-    $user = User::factory()->create(['username' => 'regular-user']);
-
-    config(['he4rt.admins' => 'danielhe4rt']);
-
-    app()->detectEnvironment(fn () => 'production');
+test('a user without any role cannot access the admin panel', function (): void {
+    $user = User::factory()->create();
 
     $panel = Filament::getPanel('admin');
 
     expect($user->canAccessPanel($panel))->toBeFalse();
+});
+
+test('the role gate applies outside production too', function (): void {
+    app()->detectEnvironment(fn (): string => 'local');
+
+    $user = User::factory()->create();
+
+    expect($user->canAccessPanel(Filament::getPanel('admin')))->toBeFalse();
+});
+
+test('a username alone no longer grants access', function (): void {
+    $user = User::factory()->create(['username' => 'danielhe4rt']);
+
+    expect($user->canAccessPanel(Filament::getPanel('admin')))->toBeFalse();
 });

--- a/app-modules/panel-admin/tests/Feature/Discord/DiscordClusterSmokeTest.php
+++ b/app-modules/panel-admin/tests/Feature/Discord/DiscordClusterSmokeTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Filament\Facades\Filament;
-use He4rt\Identity\User\Models\User;
 use He4rt\IntegrationDiscord\Models\DiscordChannel;
 use He4rt\IntegrationDiscord\Models\DiscordEventLog;
 use He4rt\IntegrationDiscord\Models\DiscordGuild;
@@ -30,9 +29,7 @@ use He4rt\PanelAdmin\Discord\Widgets\MemberGrowthChartWidget;
 use function Pest\Livewire\livewire;
 
 beforeEach(function (): void {
-    $user = User::factory()->create(['username' => 'danielhe4rt']);
-
-    config(['he4rt.admins' => 'danielhe4rt']);
+    $user = panelAdminUser();
 
     $this->actingAs($user);
 

--- a/app-modules/panel-admin/tests/Feature/Github/GithubRepositoryResourceTest.php
+++ b/app-modules/panel-admin/tests/Feature/Github/GithubRepositoryResourceTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use Filament\Actions\Testing\TestAction;
 use Filament\Facades\Filament;
-use He4rt\Identity\User\Models\User;
 use He4rt\IntegrationGithub\Backfill\Jobs\BackfillGithubRepository;
 use He4rt\IntegrationGithub\Models\GithubRepository;
 use He4rt\PanelAdmin\Github\Resources\GithubRepositoryResource\Pages\CreateGithubRepository;
@@ -14,9 +13,7 @@ use Illuminate\Support\Facades\Queue;
 use function Pest\Livewire\livewire;
 
 beforeEach(function (): void {
-    $user = User::factory()->create(['username' => 'danielhe4rt']);
-
-    config(['he4rt.admins' => 'danielhe4rt']);
+    $user = panelAdminUser();
 
     $this->actingAs($user);
 

--- a/app-modules/panel-admin/tests/Feature/Marketing/ShortLinkResourceTest.php
+++ b/app-modules/panel-admin/tests/Feature/Marketing/ShortLinkResourceTest.php
@@ -42,16 +42,18 @@ function chartClicks(ClicksOverTimeChart $chart): array
  */
 function admin(): User
 {
-    return User::query()->where('username', 'danielhe4rt')->sole();
+    /** @var User $user */
+    $user = auth()->user();
+
+    return $user;
 }
 
 beforeEach(function (): void {
     config([
-        'he4rt.admins' => 'danielhe4rt',
         'app.display_timezone' => 'America/Sao_Paulo',
     ]);
 
-    $this->actingAs(User::factory()->create(['username' => 'danielhe4rt']));
+    $this->actingAs(panelAdminUser());
 
     Filament::setCurrentPanel(Filament::getPanel('admin'));
 });

--- a/app-modules/panel-admin/tests/Feature/Moderation/AppealQueueTest.php
+++ b/app-modules/panel-admin/tests/Feature/Moderation/AppealQueueTest.php
@@ -12,9 +12,7 @@ use He4rt\PanelAdmin\Moderation\Livewire\AppealQueue;
 use function Pest\Livewire\livewire;
 
 beforeEach(function (): void {
-    $this->user = User::factory()->create(['username' => 'danielhe4rt']);
-
-    config(['he4rt.admins' => 'danielhe4rt']);
+    $this->user = panelAdminUser();
 
     $this->actingAs($this->user);
 

--- a/app-modules/panel-admin/tests/Feature/Moderation/ModerationDashboardTest.php
+++ b/app-modules/panel-admin/tests/Feature/Moderation/ModerationDashboardTest.php
@@ -13,9 +13,7 @@ use He4rt\PanelAdmin\Moderation\Pages\ModerationDashboard;
 use function Pest\Livewire\livewire;
 
 beforeEach(function (): void {
-    $user = User::factory()->create(['username' => 'danielhe4rt']);
-
-    config(['he4rt.admins' => 'danielhe4rt']);
+    $user = panelAdminUser();
 
     $this->actingAs($user);
 

--- a/app-modules/panel-admin/tests/Feature/Moderation/ModerationQueueTest.php
+++ b/app-modules/panel-admin/tests/Feature/Moderation/ModerationQueueTest.php
@@ -3,16 +3,13 @@
 declare(strict_types=1);
 
 use Filament\Facades\Filament;
-use He4rt\Identity\User\Models\User;
 use He4rt\Moderation\Cases\Models\ModerationCase;
 use He4rt\PanelAdmin\Moderation\Livewire\ModerationQueue;
 
 use function Pest\Livewire\livewire;
 
 beforeEach(function (): void {
-    $this->user = User::factory()->create(['username' => 'danielhe4rt']);
-
-    config(['he4rt.admins' => 'danielhe4rt']);
+    $this->user = panelAdminUser();
 
     $this->actingAs($this->user);
 

--- a/app-modules/panel-admin/tests/Feature/Moderation/TestRuleActionTest.php
+++ b/app-modules/panel-admin/tests/Feature/Moderation/TestRuleActionTest.php
@@ -3,16 +3,13 @@
 declare(strict_types=1);
 
 use Filament\Facades\Filament;
-use He4rt\Identity\User\Models\User;
 use He4rt\Moderation\Rules\ModerationRule;
 use He4rt\PanelAdmin\Moderation\Resources\ModerationRuleResource\Pages\EditModerationRule;
 
 use function Pest\Livewire\livewire;
 
 beforeEach(function (): void {
-    $user = User::factory()->create(['username' => 'danielhe4rt']);
-
-    config(['he4rt.admins' => 'danielhe4rt']);
+    $user = panelAdminUser();
 
     $this->actingAs($user);
 

--- a/app-modules/panel-admin/tests/Feature/Twitch/ConnectTwitchActionTest.php
+++ b/app-modules/panel-admin/tests/Feature/Twitch/ConnectTwitchActionTest.php
@@ -11,9 +11,7 @@ use He4rt\PanelAdmin\Twitch\Resources\TwitchSubscriptionResource\Pages\ListTwitc
 use function Pest\Livewire\livewire;
 
 beforeEach(function (): void {
-    $this->user = User::factory()->create(['username' => 'danielhe4rt']);
-
-    config(['he4rt.admins' => 'danielhe4rt']);
+    $this->user = panelAdminUser();
 
     $this->actingAs($this->user);
 

--- a/app-modules/panel-admin/tests/Feature/Twitch/RegisterSubscriptionsActionTest.php
+++ b/app-modules/panel-admin/tests/Feature/Twitch/RegisterSubscriptionsActionTest.php
@@ -3,15 +3,12 @@
 declare(strict_types=1);
 
 use Filament\Facades\Filament;
-use He4rt\Identity\User\Models\User;
 use He4rt\PanelAdmin\Twitch\Resources\TwitchSubscriptionResource\Pages\ListTwitchSubscriptions;
 
 use function Pest\Livewire\livewire;
 
 beforeEach(function (): void {
-    $user = User::factory()->create(['username' => 'danielhe4rt']);
-
-    config(['he4rt.admins' => 'danielhe4rt']);
+    $user = panelAdminUser();
 
     $this->actingAs($user);
 

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -7,6 +7,7 @@ namespace App\Providers\Filament;
 use App\Enums\FilamentPanel;
 use App\Filament\Pages\Login;
 use App\Http\Middleware\SetApplicationLocale;
+use BezhanSalleh\FilamentShield\FilamentShieldPlugin;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;
 use Filament\Http\Middleware\DisableBladeIconComponents;
@@ -59,6 +60,9 @@ class AdminPanelProvider extends PanelProvider
             ])
             ->pages([
                 Dashboard::class,
+            ])
+            ->plugins([
+                FilamentShieldPlugin::make(),
             ])
             ->authMiddleware([
                 Authenticate::class,

--- a/app/Providers/Tools/TelescopeServiceProvider.php
+++ b/app/Providers/Tools/TelescopeServiceProvider.php
@@ -43,7 +43,7 @@ class TelescopeServiceProvider extends TelescopeApplicationServiceProvider
      */
     protected function gate(): void
     {
-        Gate::define('viewTelescope', fn (User $user) => $user->isAdmin());
+        Gate::define('viewTelescope', fn (User $user) => $user->hasRole('super_admin'));
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     "require": {
         "php": "^8.4",
         "bacon/bacon-qr-code": "^2.0.8",
+        "bezhansalleh/filament-shield": "^4.3",
         "calebporzio/sushi": "^2.5.4",
         "dedoc/scramble": "^0.13.40",
         "filament/filament": "^5.7.6",
@@ -57,6 +58,7 @@
         "saloonphp/saloon": "^4.0",
         "spatie/laravel-backup": "^10.3.1",
         "spatie/laravel-medialibrary": "^11.23.5",
+        "spatie/laravel-permission": "^8.3",
         "symfony/dom-crawler": "^8.1.1",
         "symfony/yaml": "^8.1.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -84,6 +84,7 @@
     "autoload": {
         "psr-4": {
             "App\\": "app/",
+            "He4rt\\PanelAdmin\\": "app-modules/panel-admin/src/",
             "Database\\Factories\\": "database/factories/",
             "Database\\Seeders\\": "database/seeders/"
         },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c727200d90be2502d5887fe983f97e3c",
+    "content-hash": "8e9fbd9b99f2073816e5251ae898190f",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -124,6 +124,179 @@
                 "source": "https://github.com/Bacon/BaconQrCode/tree/2.0.8"
             },
             "time": "2022-12-07T17:46:57+00:00"
+        },
+        {
+            "name": "bezhansalleh/filament-plugin-essentials",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bezhanSalleh/filament-plugin-essentials.git",
+                "reference": "3ccec939e6e3fb51ce08cacf73c3cc3d3f59640c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bezhanSalleh/filament-plugin-essentials/zipball/3ccec939e6e3fb51ce08cacf73c3cc3d3f59640c",
+                "reference": "3ccec939e6e3fb51ce08cacf73c3cc3d3f59640c",
+                "shasum": ""
+            },
+            "require": {
+                "filament/filament": "^4.0|^5.0",
+                "illuminate/contracts": "^11.28|^12.0|^13.0",
+                "php": "^8.2|^8.3",
+                "spatie/laravel-package-tools": "^1.0"
+            },
+            "require-dev": {
+                "larastan/larastan": "^3.0",
+                "laravel/pint": "^1.14",
+                "nunomaduro/collision": "^7.10.0|^8.1.1",
+                "orchestra/testbench": "^9.0.0|^10.0.0|^11.0.0",
+                "pestphp/pest": "^3.0|^4.0",
+                "pestphp/pest-plugin-arch": "^3.0|^4.0",
+                "pestphp/pest-plugin-laravel": "^3.0|^4.0",
+                "pestphp/pest-plugin-type-coverage": "^3.5|^4.0",
+                "phpstan/extension-installer": "^1.3|^2.0",
+                "phpstan/phpstan-deprecation-rules": "^1.1|^2.0",
+                "phpstan/phpstan-phpunit": "^1.3|^2.0",
+                "rector/rector": "^2.1",
+                "spatie/laravel-ray": "^1.40"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "BezhanSalleh\\PluginEssentials\\PluginEssentialsServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "BezhanSalleh\\PluginEssentials\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bezhan Salleh",
+                    "email": "bezhan_salleh@yahoo.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A collection of essential traits that streamline Filament plugin development by taking care of the boilerplate, so you can focus on shipping real features faster",
+            "homepage": "https://github.com/bezhansalleh/filament-plugin-essentials",
+            "keywords": [
+                "Bezhan Salleh",
+                "filament-plugin-essentials",
+                "laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/bezhanSalleh/filament-plugin-essentials/issues",
+                "source": "https://github.com/bezhanSalleh/filament-plugin-essentials/tree/1.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/bezhanSalleh",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-07-25T02:30:23+00:00"
+        },
+        {
+            "name": "bezhansalleh/filament-shield",
+            "version": "4.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bezhanSalleh/filament-shield.git",
+                "reference": "1ff51f53985275f5bd37e9277cf810d391e7c3ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bezhanSalleh/filament-shield/zipball/1ff51f53985275f5bd37e9277cf810d391e7c3ca",
+                "reference": "1ff51f53985275f5bd37e9277cf810d391e7c3ca",
+                "shasum": ""
+            },
+            "require": {
+                "bezhansalleh/filament-plugin-essentials": "^1.0",
+                "filament/filament": "^4.0|^5.0",
+                "illuminate/contracts": "^11.28|^12.0|^13.0",
+                "illuminate/support": "^11.28|^12.0|^13.0",
+                "php": "^8.2|^8.3",
+                "spatie/laravel-package-tools": "^1.0",
+                "spatie/laravel-permission": "^6.0|^7.0|^8.0"
+            },
+            "require-dev": {
+                "larastan/larastan": "^3.0",
+                "laravel/pint": "^1.26",
+                "nunomaduro/collision": "^8.8",
+                "orchestra/testbench": "^9.0|^10.0|^11.0",
+                "pestphp/pest": "^3.8|^4.0",
+                "pestphp/pest-plugin-laravel": "^3.2|^4.0",
+                "pestphp/pest-plugin-livewire": "^3.0|^4.0",
+                "pestphp/pest-plugin-type-coverage": "^3.6|^4.0",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-deprecation-rules": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^11.0|^12.0",
+                "rector/jack": "^0.4.0",
+                "rector/rector": "^2.2",
+                "spatie/laravel-ray": "^1.43"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "FilamentShield": "BezhanSalleh\\FilamentShield\\Facades\\FilamentShield"
+                    },
+                    "providers": [
+                        "BezhanSalleh\\FilamentShield\\FilamentShieldServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "BezhanSalleh\\FilamentShield\\": "src",
+                    "BezhanSalleh\\FilamentShield\\Database\\Factories\\": "database/factories"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bezhan Salleh",
+                    "email": "bezhan_salleh@yahoo.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Filament support for `spatie/laravel-permission`.",
+            "homepage": "https://github.com/bezhansalleh/filament-shield",
+            "keywords": [
+                "acl",
+                "bezhanSalleh",
+                "filament",
+                "filament-shield",
+                "laravel",
+                "permission",
+                "permissions",
+                "rbac",
+                "roles",
+                "security"
+            ],
+            "support": {
+                "issues": "https://github.com/bezhanSalleh/filament-shield/issues",
+                "source": "https://github.com/bezhanSalleh/filament-shield/tree/4.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/bezhanSalleh",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-07-25T03:31:26+00:00"
         },
         {
             "name": "blade-ui-kit/blade-heroicons",
@@ -10767,6 +10940,94 @@
                 }
             ],
             "time": "2026-05-19T14:06:37+00:00"
+        },
+        {
+            "name": "spatie/laravel-permission",
+            "version": "8.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-permission.git",
+                "reference": "60e8ed5b2fbf043c2264433fc2680c76b8b66aa6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-permission/zipball/60e8ed5b2fbf043c2264433fc2680c76b8b66aa6",
+                "reference": "60e8ed5b2fbf043c2264433fc2680c76b8b66aa6",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/auth": "^12.0|^13.0",
+                "illuminate/container": "^12.0|^13.0",
+                "illuminate/contracts": "^12.0|^13.0",
+                "illuminate/database": "^12.0|^13.0",
+                "php": "^8.3",
+                "spatie/laravel-package-tools": "^1.0"
+            },
+            "require-dev": {
+                "larastan/larastan": "^3.9",
+                "laravel/octane": "^2.0",
+                "laravel/passport": "^13.0",
+                "laravel/pint": "^1.0",
+                "orchestra/testbench": "^10.0|^11.0",
+                "pestphp/pest": "^3.0|^4.0",
+                "pestphp/pest-plugin-laravel": "^3.0|^4.1",
+                "phpstan/phpstan": "^2.1"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Spatie\\Permission\\PermissionServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-main": "8.x-dev",
+                    "dev-master": "8.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Spatie\\Permission\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Permission handling for Laravel 12 and up",
+            "homepage": "https://github.com/spatie/laravel-permission",
+            "keywords": [
+                "acl",
+                "laravel",
+                "permission",
+                "permissions",
+                "rbac",
+                "roles",
+                "security",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-permission/issues",
+                "source": "https://github.com/spatie/laravel-permission/tree/8.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-07-03T15:36:01+00:00"
         },
         {
             "name": "spatie/laravel-signal-aware-command",

--- a/config/filament-shield.php
+++ b/config/filament-shield.php
@@ -1,0 +1,288 @@
+<?php
+
+declare(strict_types=1);
+use BezhanSalleh\FilamentShield\Resources\Roles\RoleResource;
+use Filament\Pages\Dashboard;
+use Filament\Widgets\AccountWidget;
+use Filament\Widgets\FilamentInfoWidget;
+use He4rt\Identity\User\Models\User;
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Shield Resource
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure the built-in role management resource. You can
+    | customize the URL, choose whether to show model paths, group it under
+    | a cluster, and decide which permission tabs to display.
+    |
+    */
+
+    'shield_resource' => [
+        'slug' => 'shield/roles',
+        'show_model_path' => true,
+        'cluster' => null,
+        'tabs' => [
+            'pages' => true,
+            'widgets' => true,
+            'resources' => true,
+            'custom_permissions' => false,
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Multi-Tenancy
+    |--------------------------------------------------------------------------
+    |
+    | When your application supports teams, Shield will automatically detect
+    | and configure the tenant model during setup. This enables tenant-scoped
+    | roles and permissions throughout your application.
+    |
+    */
+
+    'tenant_model' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | User Model
+    |--------------------------------------------------------------------------
+    |
+    | This value contains the class name of your user model. This model will
+    | be used for role assignments and must implement the HasRoles trait
+    | provided by the Spatie\Permission package.
+    |
+    */
+
+    'auth_provider_model' => User::class,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Super Admin
+    |--------------------------------------------------------------------------
+    |
+    | Here you may define a super admin that has unrestricted access to your
+    | application. You can choose to implement this via Laravel's gate system
+    | or as a traditional role with all permissions explicitly assigned.
+    |
+    */
+
+    'super_admin' => [
+        'enabled' => true,
+        'name' => 'super_admin',
+        'define_via_gate' => true,
+        'intercept_gate' => 'before',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Panel User
+    |--------------------------------------------------------------------------
+    |
+    | When enabled, Shield will create a basic panel user role that can be
+    | assigned to users who should have access to your Filament panels but
+    | don't need any specific permissions beyond basic authentication.
+    |
+    */
+
+    'panel_user' => [
+        'enabled' => true,
+        'name' => 'panel_user',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Permission Builder
+    |--------------------------------------------------------------------------
+    |
+    | You can customize how permission keys are generated to match your
+    | preferred naming convention and organizational standards. Shield uses
+    | these settings when creating permission names from your resources.
+    |
+    | Supported formats: snake, kebab, pascal, camel, upper_snake, lower_snake
+    |
+    | Note: The separator must not conflict with the case format's own
+    | delimiter. For example, `_` cannot be used with snake/lower_snake/
+    | upper_snake, and `-` cannot be used with kebab.
+    |
+    | When `format_custom_permission_keys` is true (default), custom
+    | permissions defined below will have their keys formatted according to
+    | the case setting. If your custom permissions come from external sources
+    | (e.g. Terraform, Keycloak) and must remain unchanged, set this to false.
+    | When using the separator in custom permission definitions, each segment
+    | will be formatted independently (e.g. 'view:system_log' with pascal
+    | case becomes 'View:SystemLog').
+    |
+    */
+
+    'permissions' => [
+        'separator' => '.',
+        'case' => 'snake',
+        'generate' => true,
+        'format_custom_permission_keys' => true,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Policies
+    |--------------------------------------------------------------------------
+    |
+    | Shield can automatically generate Laravel policies for your resources.
+    | Generated policies mirror each model's location: models under
+    | app/Models map into the path below (keeping their nesting), models in
+    | any other "Models" directory get a sibling "Policies" directory, and
+    | vendor models fall back to the path below. When merge is enabled, the
+    | methods below will be combined with any resource-specific methods you
+    | define in the resources section.
+    |
+    */
+
+    'policies' => [
+        'path' => base_path('app-modules/panel-admin/src/Policies'),
+        'merge' => true,
+        'generate' => true,
+        'methods' => [
+            'viewAny', 'view', 'create', 'update', 'delete', 'deleteAny', 'restore',
+            'forceDelete', 'forceDeleteAny', 'restoreAny', 'replicate', 'reorder',
+        ],
+        'single_parameter_methods' => [
+            'viewAny',
+            'create',
+            'deleteAny',
+            'forceDeleteAny',
+            'restoreAny',
+            'reorder',
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Localization
+    |--------------------------------------------------------------------------
+    |
+    | Shield supports multiple languages out of the box. When enabled, you
+    | can provide translated labels for permissions to create a more
+    | localized experience for your international users.
+    |
+    */
+
+    'localization' => [
+        'enabled' => false,
+        'key' => 'filament-shield::filament-shield.resource_permission_prefixes_labels',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Resources
+    |--------------------------------------------------------------------------
+    |
+    | Here you can fine-tune permissions for specific Filament resources.
+    | Use the 'manage' array to override the default policy methods for
+    | individual resources, giving you granular control over permissions.
+    |
+    */
+
+    'resources' => [
+        'subject' => 'model',
+        'manage' => [
+            RoleResource::class => [
+                'viewAny',
+                'view',
+                'create',
+                'update',
+                'delete',
+            ],
+        ],
+        'exclude' => [
+
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pages
+    |--------------------------------------------------------------------------
+    |
+    | Most Filament pages only require view permissions. Pages listed in the
+    | exclude array will be skipped during permission generation and won't
+    | appear in your role management interface.
+    |
+    */
+
+    'pages' => [
+        'subject' => 'class',
+        'prefix' => 'view',
+        'exclude' => [
+            Dashboard::class,
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Widgets
+    |--------------------------------------------------------------------------
+    |
+    | Like pages, widgets typically only need view permissions. Add widgets
+    | to the exclude array if you don't want them to appear in your role
+    | management interface.
+    |
+    */
+
+    'widgets' => [
+        'subject' => 'class',
+        'prefix' => 'view',
+        'exclude' => [
+            AccountWidget::class,
+            FilamentInfoWidget::class,
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Permissions
+    |--------------------------------------------------------------------------
+    |
+    | Sometimes you need permissions that don't map to resources, pages, or
+    | widgets. Define any custom permissions here and they'll be available
+    | when editing roles in your application.
+    |
+    | Keys are formatted per the Permission Builder settings above; set
+    | permissions.format_custom_permission_keys to false to use them as-is.
+    |
+    */
+
+    'custom_permissions' => [],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Entity Discovery
+    |--------------------------------------------------------------------------
+    |
+    | By default, Shield only looks for entities in your default Filament
+    | panel. Enable these options if you're using multiple panels and want
+    | Shield to discover entities across all of them.
+    |
+    */
+
+    'discovery' => [
+        'discover_all_resources' => false,
+        'discover_all_widgets' => false,
+        'discover_all_pages' => false,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Role Policy
+    |--------------------------------------------------------------------------
+    |
+    | Shield can automatically register a policy for role management itself.
+    | This lets you control who can manage roles using Laravel's built-in
+    | authorization system. Requires a RolePolicy class in your app.
+    |
+    */
+
+    'register_role_policy' => true,
+
+];

--- a/config/permission.php
+++ b/config/permission.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+use Spatie\Permission\DefaultTeamResolver;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+
+return [
+
+    'models' => [
+
+        /*
+         * When using the "HasPermissions" trait from this package, we need to know which
+         * Eloquent model should be used to retrieve your permissions. Of course, it
+         * is often just the "Permission" model but you may use whatever you like.
+         *
+         * The model you want to use as a Permission model needs to implement the
+         * `Spatie\Permission\Contracts\Permission` contract.
+         */
+
+        'permission' => Permission::class,
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * Eloquent model should be used to retrieve your roles. Of course, it
+         * is often just the "Role" model but you may use whatever you like.
+         *
+         * The model you want to use as a Role model needs to implement the
+         * `Spatie\Permission\Contracts\Role` contract.
+         */
+
+        'role' => Role::class,
+
+        /*
+         * When using the "Teams" feature from this package, we need to know which
+         * Eloquent model should be used to retrieve your teams. Of course, it
+         * is often just the "Team" model but you may use whatever you like.
+         */
+        'team' => null,
+
+        /*
+         * When using the "HasModels" trait and passing raw IDs to syncModels,
+         * attachModels, or detachModels, this model class will be used to
+         * resolve those IDs. If null, defaults to the guard's model.
+         */
+        'default_model' => null,
+    ],
+
+    'table_names' => [
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * table should be used to retrieve your roles. We have chosen a basic
+         * default value but you may easily change it to any table you like.
+         */
+
+        'roles' => 'roles',
+
+        /*
+         * When using the "HasPermissions" trait from this package, we need to know which
+         * table should be used to retrieve your permissions. We have chosen a basic
+         * default value but you may easily change it to any table you like.
+         */
+
+        'permissions' => 'permissions',
+
+        /*
+         * When using the "HasPermissions" trait from this package, we need to know which
+         * table should be used to retrieve your models permissions. We have chosen a
+         * basic default value but you may easily change it to any table you like.
+         */
+
+        'model_has_permissions' => 'model_has_permissions',
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * table should be used to retrieve your models roles. We have chosen a
+         * basic default value but you may easily change it to any table you like.
+         */
+
+        'model_has_roles' => 'model_has_roles',
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * table should be used to retrieve your roles permissions. We have chosen a
+         * basic default value but you may easily change it to any table you like.
+         */
+
+        'role_has_permissions' => 'role_has_permissions',
+    ],
+
+    'column_names' => [
+        /*
+         * Change this if you want to name the related pivots other than defaults
+         */
+        'role_pivot_key' => null, // default 'role_id',
+        'permission_pivot_key' => null, // default 'permission_id',
+
+        /*
+         * Change this if you want to name the related model primary key other than
+         * `model_id`.
+         *
+         * For example, this would be nice if your primary keys are all UUIDs. In
+         * that case, name this `model_uuid`.
+         */
+
+        'model_morph_key' => 'model_id',
+
+        /*
+         * Change this if you want to use the teams feature and your related model's
+         * foreign key is other than `team_id`.
+         */
+
+        'team_foreign_key' => 'team_id',
+    ],
+
+    /*
+     * When set to true, the method for checking permissions will be registered on the gate.
+     * Set this to false if you want to implement custom logic for checking permissions.
+     */
+
+    'register_permission_check_method' => true,
+
+    /*
+     * When set to true, Laravel\Octane\Events\OperationTerminated event listener will be registered
+     * this will refresh permissions on every TickTerminated, TaskTerminated and RequestTerminated
+     * NOTE: This should not be needed in most cases, but an Octane/Vapor combination benefited from it.
+     */
+    'register_octane_reset_listener' => false,
+
+    /*
+     * Events will fire when a role or permission is assigned/unassigned:
+     * \Spatie\Permission\Events\RoleAttachedEvent
+     * \Spatie\Permission\Events\RoleDetachedEvent
+     * \Spatie\Permission\Events\PermissionAttachedEvent
+     * \Spatie\Permission\Events\PermissionDetachedEvent
+     *
+     * To enable, set to true, and then create listeners to watch these events.
+     */
+    'events_enabled' => false,
+
+    /*
+     * Teams Feature.
+     * When set to true the package implements teams using the 'team_foreign_key'.
+     * If you want the migrations to register the 'team_foreign_key', you must
+     * set this to true before doing the migration.
+     * If you already did the migration then you must make a new migration to also
+     * add 'team_foreign_key' to 'roles', 'model_has_roles', and 'model_has_permissions'
+     * (view the latest version of this package's migration file)
+     */
+
+    'teams' => false,
+
+    /*
+     * The class to use to resolve the permissions team id
+     */
+    'team_resolver' => DefaultTeamResolver::class,
+
+    /*
+     * Passport Client Credentials Grant
+     * When set to true the package will use Passports Client to check permissions
+     */
+
+    'use_passport_client_credentials' => false,
+
+    /*
+     * When set to true, the required permission names are added to exception messages.
+     * This could be considered an information leak in some contexts, so the default
+     * setting is false here for optimum safety.
+     */
+
+    'display_permission_in_exception' => false,
+
+    /*
+     * When set to true, the required role names are added to exception messages.
+     * This could be considered an information leak in some contexts, so the default
+     * setting is false here for optimum safety.
+     */
+
+    'display_role_in_exception' => false,
+
+    /*
+     * By default wildcard permission lookups are disabled.
+     * See documentation to understand supported syntax.
+     */
+
+    'enable_wildcard_permission' => false,
+
+    /*
+     * The class to use for interpreting wildcard permissions.
+     * If you need to modify delimiters, override the class and specify its name here.
+     */
+    // 'wildcard_permission' => Spatie\Permission\WildcardPermission::class,
+
+    /* Cache-specific settings */
+
+    'cache' => [
+
+        /*
+         * By default all permissions are cached for 24 hours to speed up performance.
+         * When permissions or roles are updated the cache is flushed automatically.
+         */
+
+        'expiration_time' => DateInterval::createFromDateString('24 hours'),
+
+        /*
+         * The cache key used to store all permissions.
+         */
+
+        'key' => 'spatie.permission.cache',
+
+        /*
+         * You may optionally indicate a specific cache driver to use for permission and
+         * role caching using any of the `store` drivers listed in the cache.php config
+         * file. Using 'default' here means to use the `default` set in cache.php.
+         */
+
+        'store' => 'default',
+    ],
+];

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -22,5 +22,8 @@
     <php>
         <ini name="memory_limit" value="2G"/>
         <env name="APP_ENV" value="testing"/>
+        <!-- The Cloudflare proxy list is fetched over HTTP and cached forever. Tests ban
+             stray requests, so a cold cache turns every routed test into a 500. -->
+        <env name="LARAVEL_CLOUDFLARE_ENABLED" value="false"/>
     </php>
 </phpunit>

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
+use He4rt\Identity\User\Models\User;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
 use Tests\TestCase;
 
 /*
@@ -52,4 +55,44 @@ expect()->extend('toBeOne', fn () => $this->toBe(1));
 function something(): void
 {
     // ..
+}
+
+/*
+|--------------------------------------------------------------------------
+| Panel access
+|--------------------------------------------------------------------------
+|
+| Admin panel access is granted by roles, so a bare factory user is locked out.
+| This builds a user carrying exactly the permissions a test needs.
+|
+*/
+
+function panelUserWith(string ...$permissions): User
+{
+    $user = User::factory()->create();
+
+    $role = Role::query()->firstOrCreate([
+        'name' => 'test:'.md5(implode(',', $permissions)),
+        'guard_name' => 'web',
+    ]);
+
+    $role->syncPermissions(
+        collect($permissions)->map(fn (string $permission): Permission => Permission::query()->firstOrCreate([
+            'name' => $permission,
+            'guard_name' => 'web',
+        ]))
+    );
+
+    return $user->assignRole($role);
+}
+
+/**
+ * A super admin, for panel tests that are not about authorisation themselves.
+ * Shield intercepts the gate for this role, so no permissions need to exist.
+ */
+function panelAdminUser(): User
+{
+    return User::factory()->create()->assignRole(
+        Role::query()->firstOrCreate(['name' => 'super_admin', 'guard_name' => 'web'])
+    );
 }


### PR DESCRIPTION
## Contexto

O acesso ao painel admin era decidido por uma lista de usernames em `config/he4rt.php`. Quem estava na lista via tudo; quem não estava não via nada. Não havia meio-termo — nenhuma forma de dar a um moderador acesso só à moderação, ou a um responsável por marketing acesso só ao encurtador.

Este PR troca o allowlist por autorização de verdade: `spatie/laravel-permission` para o schema de roles/permissions e `filament-shield` para gerar as permissions a partir dos recursos do painel. Acessar o painel passa a significar possuir um role, e cada um dos 15 recursos é governado por uma policy.

**Ainda é draft** — o fluxo está funcional, mas faltam as pontas descritas em *Pendências* antes de mergear.

### Alterações

- **`identity`** — publica a migration do `spatie/laravel-permission` dentro do módulo, com dois ajustes que o stub publicado exige aqui: `model_morph_key` vira UUID (o `User` usa UUID como PK, então atribuir role falharia no insert, não no migrate) e `timestamps()` vira `timestampsTz()`. Adiciona `HasRoles` ao `User`.
- **`panel-admin`** — 15 policies geradas pelo Shield, uma por recurso. Elas vivem no módulo de apresentação, não ao lado de cada model de domínio, porque autorizar uma tela é uma preocupação de apresentação.
- **Registro via `Gate::guessPolicyNamesUsing()`** — registrar dentro de `Filament::serving()` só resolvia as policies durante um request HTTP. Um componente Livewire exercitado diretamente rodava sem policy nenhuma, então um usuário com permissão de moderação abria uma página de marketing e recebia 200.
- **Três acomodações que o Shield precisou** neste repositório: ele lê apenas o `composer.json` da raiz ao resolver PSR-4 (daí a declaração do namespace `He4rt\PanelAdmin` lá); ele rejeita o separador `_` junto de snake case (daí o separador placeholder na config e o builder próprio); e ele só procura um diretório `Policies` irmão quando o model está sob `Models`.
- **`isAdmin()` removido.** O gate do Telescope agora pede o role `super_admin`.
- **Testes** — os que dependiam do allowlist constroem um role de verdade. Dois helpers em `tests/Pest.php` carregam isso: `panelUserWith()` para permissions específicas e `panelAdminUser()` para o super admin. Novos: `PermissionTablesTest`, `PolicyCoverageTest` e `AreaIsolationTest` (este último cobrindo tanto componente Livewire quanto rota HTTP).
- **Sob phpunit**, desativa o lookup de proxy do Cloudflare: ele busca por HTTP e cacheia para sempre, então um cache frio virava 500 em todo teste roteado.

---

## Plano de Testes

- [ ] Executar `make check`
- [ ] Executar `make test`
- [ ] Verificar que um usuário sem role nenhum não acessa `/admin`
- [ ] Verificar que um usuário com permission só de moderação recebe 403 numa página de marketing
- [ ] Verificar que `super_admin` acessa todos os 15 recursos e o Telescope

---

## Pendências antes de sair do draft

- [ ] **Bootstrap de acesso** — não existe seeder nem command que crie o role `super_admin` e o atribua a alguém. O allowlist era o que cumpria esse papel; nada tomou o lugar dele, então após o deploy ninguém entra no painel.
- [ ] **Tela de Roles invisível** — o painel monta a sidebar manualmente via `NavigationBuilder`, e `defaultNavigation()` não inclui os itens do `RoleResource` do Shield. A rota existe, o link não.
- [ ] **Sem UI para vincular usuário a role** — não há `UserResource` no `panel-admin`. Dá para criar roles no Shield, mas o vínculo user↔role só via tinker. Candidato a PR separado.
- [ ] **Config morta** — `config/he4rt.php` ainda carrega `'admins' => env('HE4RT_ADMINS_USERNAMES', ...)`, que já não é lido por nada.
- [ ] Atualizar `docs/admin/en/users/authentication.md` e `roles.md`.

---

## Issues Relacionadas

<!-- Related to #___ -->
