### PR TITLE
fix(panel-app): exibe conexões e preview de perfil no mobile

### DIFF
--- a/app-modules/panel-app/resources/views/pages/profile.blade.php
+++ b/app-modules/panel-app/resources/views/pages/profile.blade.php
@@ -18,8 +18,8 @@
             {{ $this->form }}
         </div>
 
-        {{-- Preview card + connections (right, 1/3, sticky) --}}
-        <div class="hidden space-y-6 xl:sticky xl:top-4 xl:block">
+        {{-- Preview card + connections (right, 1/3, sticky no desktop) --}}
+        <div class="space-y-6 xl:sticky xl:top-4">
             @include ('panel-app::components.profile-preview-card',
                 [
                     'data' => $this->data,


### PR DESCRIPTION
Close #513 

## Summary
                                                                                                                                                                                                                     
  - A coluna direita da página de Profile (preview do perfil + `<livewire:connection-hub />`) usava `hidden xl:block` sem nenhum fallback para breakpoints menores, então abaixo de 1280px ela não renderizava — o card de       
  conexões não aparecia mesmo empilhado, simplesmente não existia no DOM.                                                                                                                                                        
  - Remove o `hidden`/`xl:block` e mantém `sticky`/`top-4` só a partir do `xl`, deixando a coluna sempre visível e empilhando naturalmente abaixo do formulário em telas menores.                                                
                                                                                                                                                                                                                                 
  Closes #513                                                                                                                                                                                                                    
                                                                                                                                                                                                                                 
  ## Test plan                                                                                                                                                                                                                   
  - [ ] Acessar `/profile` em viewport mobile/tablet (DevTools ou dispositivo real) e confirmar que o card de conexões aparece e é editável                                                                                      
  - [ ] Confirmar que o comportamento em desktop (≥1280px) permanece igual (coluna sticky ao lado do formulário)