### PR TITLE
fix(login): remove fundo do texto da divisória do login

### DIFF
--- a/app-modules/panel-app/resources/views/auth/login.blade.php
+++ b/app-modules/panel-app/resources/views/auth/login.blade.php
@@ -141,13 +141,10 @@
                 </div>
 
                 {{-- Divider --}}
-                <div class="relative my-6">
-                    <div class="absolute inset-0 flex items-center">
-                        <div class="w-full border-t border-zinc-800"></div>
-                    </div>
-                    <div class="relative flex justify-center text-xs uppercase">
-                        <span class="bg-white px-3 text-zinc-500 dark:bg-gray-950 dark:text-zinc-400">ou</span>
-                    </div>
+                <div class="flex items-center gap-3 my-6">
+                    <hr class="flex-1 border-t border-zinc-800">
+                    <span class="text-xs uppercase text-zinc-500 dark:text-zinc-400">ou</span>
+                    <hr class="flex-1 border-t border-zinc-800">
                 </div>
 
                 {{-- Filament email/password form --}}


### PR DESCRIPTION
## Descrição

Corrige a diferença de cor entre o fundo do texto da divisória ("ou") da
página de login e o fundo da página.

### Antes

O texto era centralizado sobre a linha com posicionamento absoluto e um
`span` com cor de fundo opaca para mascarar a linha por baixo dele:

- Light mode: `bg-white` → retângulo branco destacado sobre o fundo cinza
- Dark mode: `dark:bg-gray-950` → tom levemente diferente do restante

Perceptível principalmente ao abrir o DevTools (reportado em #517).

### Depois

A divisória foi reestruturada com flexbox: dois `<hr>` com `flex-1` nas
laterais e o texto centralizado **sem nenhuma classe de background**.
Sem cor de fundo no texto, não há como destoar do corpo da página — em
nenhum tema, mesmo que os tokens de cor mudem no futuro.

## Como testar

1. Acesse `/app/login`
2. Inspecione a divisória "ou" acima do formulário de email/senha
3. Confirme que o texto não possui mais `background-color`
4. Alterne entre light/dark mode e verifique que tudo acompanha o fundo

Closes #517
