### PR TITLE
fix(integration-discord): preserva metadata entre OAuth e ETL

### DIFF
--- a/app-modules/identity/src/Auth/Actions/AttachProviderToUser.php
+++ b/app-modules/identity/src/Auth/Actions/AttachProviderToUser.php
@@ -16,25 +16,20 @@ final class AttachProviderToUser
     public function execute(User $owner, OAuthUserDTO $oauthUser, OAuthAccessDTO $access): ExternalIdentity
     {
         /** @var ExternalIdentity $identity */
-        $identity = $owner->providers()->updateOrCreate(
-            [
-                'provider' => $oauthUser->provider,
-                'external_account_id' => $oauthUser->providerId,
-            ],
-            [
-                'type' => $oauthUser->provider->getType(),
-                'credentials_type' => CredentialsType::OAuth2,
-                'credentials' => $access->toClientAccessManager(),
-                'metadata' => array_filter([
-                    'email' => $oauthUser->email,
-                    'avatar' => $oauthUser->avatarUrl,
-                    'username' => $oauthUser->username,
-                ]),
-                'connected_at' => now(),
-                'disconnected_at' => null,
-                'connected_by' => auth()->id(),
-            ]
-        );
+        $identity = $owner->providers()->firstOrNew([
+            'provider' => $oauthUser->provider,
+            'external_account_id' => $oauthUser->providerId,
+        ]);
+
+        $identity->forceFill([
+            'type' => $oauthUser->provider->getType(),
+            'credentials_type' => CredentialsType::OAuth2,
+            'credentials' => $access->toClientAccessManager(),
+            'metadata' => array_replace($identity->metadata ?? [], $oauthUser->toMetadata()),
+            'connected_at' => now(),
+            'disconnected_at' => null,
+            'connected_by' => auth()->id(),
+        ])->save();
 
         event(new ExternalIdentityConnected($identity));
 

--- a/app-modules/identity/src/Auth/Actions/AttachProviderToUser.php
+++ b/app-modules/identity/src/Auth/Actions/AttachProviderToUser.php
@@ -6,33 +6,24 @@ namespace He4rt\Identity\Auth\Actions;
 
 use He4rt\Identity\Auth\DTOs\OAuthAccessDTO;
 use He4rt\Identity\Auth\DTOs\OAuthUserDTO;
-use He4rt\Identity\ExternalIdentity\Enums\CredentialsType;
-use He4rt\Identity\ExternalIdentity\Events\ExternalIdentityConnected;
 use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
 use He4rt\Identity\User\Models\User;
 
-final class AttachProviderToUser
+final readonly class AttachProviderToUser
 {
+    public function __construct(private PersistOAuthConnection $persistConnection) {}
+
     public function execute(User $owner, OAuthUserDTO $oauthUser, OAuthAccessDTO $access): ExternalIdentity
     {
-        /** @var ExternalIdentity $identity */
-        $identity = $owner->providers()->firstOrNew([
-            'provider' => $oauthUser->provider,
-            'external_account_id' => $oauthUser->providerId,
-        ]);
+        $authenticatedUserId = auth()->id();
 
-        $identity->forceFill([
-            'type' => $oauthUser->provider->getType(),
-            'credentials_type' => CredentialsType::OAuth2,
-            'credentials' => $access->toClientAccessManager(),
-            'metadata' => array_replace($identity->metadata ?? [], $oauthUser->toMetadata()),
-            'connected_at' => now(),
-            'disconnected_at' => null,
-            'connected_by' => auth()->id(),
-        ])->save();
-
-        event(new ExternalIdentityConnected($identity));
-
-        return $identity;
+        return $this->persistConnection->execute(
+            owner: $owner,
+            provider: $oauthUser->provider,
+            providerId: $oauthUser->providerId,
+            credentials: $access->toClientAccessManager(),
+            metadata: $oauthUser->toMetadata(),
+            connectedBy: is_string($authenticatedUserId) ? $authenticatedUserId : null,
+        );
     }
 }

--- a/app-modules/identity/src/Auth/Actions/ConfirmOAuthMerge.php
+++ b/app-modules/identity/src/Auth/Actions/ConfirmOAuthMerge.php
@@ -45,7 +45,7 @@ final readonly class ConfirmOAuthMerge
                 owner: $targetUser,
                 provider: $pending->provider,
                 providerId: $pending->providerId,
-                credentials: $pending->toClientAccessManager(),
+                credentials: $pending->credentials,
                 metadata: $pending->metadata,
                 connectedBy: $targetUser->id,
             );

--- a/app-modules/identity/src/Auth/Actions/ConfirmOAuthMerge.php
+++ b/app-modules/identity/src/Auth/Actions/ConfirmOAuthMerge.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Identity\Auth\Actions;
+
+use He4rt\Identity\Auth\DTOs\PendingOAuthMergeDTO;
+use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
+use He4rt\Identity\User\Models\User;
+use Illuminate\Support\Facades\DB;
+
+final readonly class ConfirmOAuthMerge
+{
+    public function __construct(
+        private MergeAccountsAction $mergeAccounts,
+        private PersistOAuthConnection $persistConnection,
+    ) {}
+
+    public function execute(User $currentUser, PendingOAuthMergeDTO $pending): ?User
+    {
+        return DB::transaction(function () use ($currentUser, $pending): ?User {
+            $targetUser = User::query()
+                ->lockForUpdate()
+                ->find($pending->conflictingUserId);
+
+            if (!$targetUser instanceof User || $targetUser->is($currentUser)) {
+                return null;
+            }
+
+            $conflictingIdentity = ExternalIdentity::query()
+                ->where('model_type', (new User)->getMorphClass())
+                ->where('model_id', $targetUser->id)
+                ->where('provider', $pending->provider)
+                ->where('external_account_id', $pending->providerId)
+                ->lockForUpdate()
+                ->first();
+
+            if (!$conflictingIdentity instanceof ExternalIdentity) {
+                return null;
+            }
+
+            $this->mergeAccounts->execute($currentUser, $targetUser);
+
+            $this->persistConnection->execute(
+                owner: $targetUser,
+                provider: $pending->provider,
+                providerId: $pending->providerId,
+                credentials: $pending->toClientAccessManager(),
+                metadata: $pending->metadata,
+                connectedBy: $targetUser->id,
+            );
+
+            return $targetUser->refresh();
+        });
+    }
+}

--- a/app-modules/identity/src/Auth/Actions/PersistOAuthConnection.php
+++ b/app-modules/identity/src/Auth/Actions/PersistOAuthConnection.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Identity\Auth\Actions;
+
+use He4rt\Identity\ExternalIdentity\Data\ClientAccessManager;
+use He4rt\Identity\ExternalIdentity\Enums\CredentialsType;
+use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
+use He4rt\Identity\ExternalIdentity\Events\ExternalIdentityConnected;
+use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
+use He4rt\Identity\User\Models\User;
+
+final class PersistOAuthConnection
+{
+    /**
+     * @param  array<string, mixed>  $metadata
+     */
+    public function execute(
+        User $owner,
+        IdentityProvider $provider,
+        string $providerId,
+        ClientAccessManager $credentials,
+        array $metadata,
+        ?string $connectedBy,
+    ): ExternalIdentity {
+        /** @var ExternalIdentity $identity */
+        $identity = $owner->providers()->firstOrNew([
+            'provider' => $provider,
+            'external_account_id' => $providerId,
+        ]);
+
+        $identity->forceFill([
+            'type' => $provider->getType(),
+            'credentials_type' => CredentialsType::OAuth2,
+            'credentials' => $credentials,
+            'metadata' => array_replace($identity->metadata ?? [], $metadata),
+            'connected_at' => now(),
+            'disconnected_at' => null,
+            'connected_by' => $connectedBy,
+        ])->save();
+
+        event(new ExternalIdentityConnected($identity));
+
+        return $identity;
+    }
+}

--- a/app-modules/identity/src/Auth/Actions/ResolvePendingOAuthMerge.php
+++ b/app-modules/identity/src/Auth/Actions/ResolvePendingOAuthMerge.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Identity\Auth\Actions;
+
+use He4rt\Identity\Auth\DTOs\PendingOAuthMergeDTO;
+use He4rt\Identity\ExternalIdentity\Data\ClientAccessManager;
+use He4rt\Identity\ExternalIdentity\Enums\CredentialsType;
+use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
+
+final class ResolvePendingOAuthMerge
+{
+    public function execute(mixed $payload): ?PendingOAuthMergeDTO
+    {
+        if (!is_array($payload)) {
+            return null;
+        }
+
+        $conflictingUserId = $payload['conflicting_user_id'] ?? null;
+        $providerValue = $payload['provider'] ?? null;
+        $providerId = $payload['provider_id'] ?? null;
+        $credentials = $payload['credentials'] ?? null;
+        $metadata = $payload['metadata'] ?? null;
+
+        if (
+            !is_string($conflictingUserId)
+            || !is_string($providerValue)
+            || !is_string($providerId)
+            || !is_array($credentials)
+            || !is_array($metadata)
+        ) {
+            return null;
+        }
+
+        $accessToken = $credentials['access_token'] ?? null;
+        $refreshToken = $credentials['refresh_token'] ?? null;
+        $expiresIn = $credentials['expires_in'] ?? null;
+        $provider = IdentityProvider::tryFrom($providerValue);
+
+        if (
+            !is_string($accessToken)
+            || !is_string($refreshToken)
+            || (!is_string($expiresIn) && $expiresIn !== null)
+            || !$provider instanceof IdentityProvider
+            || $provider->getCredentialsType() !== CredentialsType::OAuth2
+        ) {
+            return null;
+        }
+
+        /** @var array<string, mixed> $metadata */
+        return new PendingOAuthMergeDTO(
+            conflictingUserId: $conflictingUserId,
+            provider: $provider,
+            providerId: $providerId,
+            credentials: ClientAccessManager::make(
+                accessToken: $accessToken,
+                refreshToken: $refreshToken,
+                expiresIn: $expiresIn,
+            ),
+            metadata: $metadata,
+        );
+    }
+}

--- a/app-modules/identity/src/Auth/DTOs/MergeConflictDTO.php
+++ b/app-modules/identity/src/Auth/DTOs/MergeConflictDTO.php
@@ -26,19 +26,12 @@ final readonly class MergeConflictDTO
             'conflicting_user_id' => $this->conflictingUserId,
             'provider' => $this->provider->value,
             'credentials' => [
-                'encrypted' => true,
                 'access_token' => $credentials->accessToken,
                 'refresh_token' => $credentials->refreshToken,
                 'expires_in' => $credentials->expiresIn,
             ],
-            'oauth_user' => [
-                'provider_id' => $this->oauthUser->providerId,
-                'username' => $this->oauthUser->username,
-                'name' => $this->oauthUser->name,
-                'email' => $this->oauthUser->email,
-                'avatar_url' => $this->oauthUser->avatarUrl,
-                'metadata' => $this->oauthUser->toMetadata(),
-            ],
+            'provider_id' => $this->oauthUser->providerId,
+            'metadata' => $this->oauthUser->toMetadata(),
         ];
     }
 }

--- a/app-modules/identity/src/Auth/DTOs/MergeConflictDTO.php
+++ b/app-modules/identity/src/Auth/DTOs/MergeConflictDTO.php
@@ -20,16 +20,24 @@ final readonly class MergeConflictDTO
      */
     public function toSession(): array
     {
+        $credentials = $this->credentials->toClientAccessManager();
+
         return [
             'conflicting_user_id' => $this->conflictingUserId,
             'provider' => $this->provider->value,
-            'credentials' => $this->credentials->toDatabase(),
+            'credentials' => [
+                'encrypted' => true,
+                'access_token' => $credentials->accessToken,
+                'refresh_token' => $credentials->refreshToken,
+                'expires_in' => $credentials->expiresIn,
+            ],
             'oauth_user' => [
                 'provider_id' => $this->oauthUser->providerId,
                 'username' => $this->oauthUser->username,
                 'name' => $this->oauthUser->name,
                 'email' => $this->oauthUser->email,
                 'avatar_url' => $this->oauthUser->avatarUrl,
+                'metadata' => $this->oauthUser->toMetadata(),
             ],
         ];
     }

--- a/app-modules/identity/src/Auth/DTOs/OAuthUserDTO.php
+++ b/app-modules/identity/src/Auth/DTOs/OAuthUserDTO.php
@@ -28,7 +28,7 @@ abstract class OAuthUserDTO
     {
         return [
             ...($this->email !== null ? ['email' => $this->email] : []),
-            'avatar' => $this->avatarUrl,
+            ...($this->avatarUrl !== null ? ['avatar' => $this->avatarUrl] : []),
             'username' => $this->username,
         ];
     }

--- a/app-modules/identity/src/Auth/DTOs/OAuthUserDTO.php
+++ b/app-modules/identity/src/Auth/DTOs/OAuthUserDTO.php
@@ -23,6 +23,16 @@ abstract class OAuthUserDTO
      */
     abstract public static function make(OAuthAccessDTO $credentials, array $payload): self;
 
+    /** @return array<string, mixed> */
+    public function toMetadata(): array
+    {
+        return [
+            ...($this->email !== null ? ['email' => $this->email] : []),
+            'avatar' => $this->avatarUrl,
+            'username' => $this->username,
+        ];
+    }
+
     /**
      * @return array<string, mixed>
      */

--- a/app-modules/identity/src/Auth/DTOs/PendingOAuthMergeDTO.php
+++ b/app-modules/identity/src/Auth/DTOs/PendingOAuthMergeDTO.php
@@ -5,141 +5,18 @@ declare(strict_types=1);
 namespace He4rt\Identity\Auth\DTOs;
 
 use He4rt\Identity\ExternalIdentity\Data\ClientAccessManager;
-use He4rt\Identity\ExternalIdentity\Enums\CredentialsType;
 use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
-use Illuminate\Support\Facades\Crypt;
 
 final readonly class PendingOAuthMergeDTO
 {
     /**
-     * @param  array{access_token: string, refresh_token: string, expires_in: int|string|null, encrypted?: bool}  $credentials
      * @param  array<string, mixed>  $metadata
      */
     public function __construct(
         public string $conflictingUserId,
         public IdentityProvider $provider,
         public string $providerId,
-        public array $credentials,
+        public ClientAccessManager $credentials,
         public array $metadata,
     ) {}
-
-    /**
-     * @param  array<string, mixed>  $payload
-     */
-    public static function fromSession(array $payload): ?self
-    {
-        $provider = is_string($payload['provider'] ?? null)
-            ? IdentityProvider::tryFrom($payload['provider'])
-            : null;
-        $credentials = $payload['credentials'] ?? null;
-        $rawOAuthUser = $payload['oauth_user'] ?? null;
-        $oauthUser = is_array($rawOAuthUser)
-            ? self::stringKeyedArray($rawOAuthUser)
-            : null;
-
-        if (
-            !is_string($payload['conflicting_user_id'] ?? null)
-            || !$provider instanceof IdentityProvider
-            || $provider->getCredentialsType() !== CredentialsType::OAuth2
-            || !is_array($credentials)
-            || !is_string($credentials['access_token'] ?? null)
-            || !is_string($credentials['refresh_token'] ?? null)
-            || $oauthUser === null
-            || !is_string($oauthUser['provider_id'] ?? null)
-        ) {
-            return null;
-        }
-
-        $encrypted = ($credentials['encrypted'] ?? false) === true;
-        $expiresIn = $credentials['expires_in'] ?? null;
-
-        if (
-            $expiresIn !== null
-            && !is_int($expiresIn)
-            && (!$encrypted || !is_string($expiresIn))
-        ) {
-            return null;
-        }
-
-        $rawMetadata = $oauthUser['metadata'] ?? null;
-
-        if ($rawMetadata !== null && !is_array($rawMetadata)) {
-            return null;
-        }
-
-        $metadata = is_array($rawMetadata)
-            ? self::stringKeyedArray($rawMetadata)
-            : self::legacyMetadata($provider, $oauthUser);
-
-        if ($metadata === null) {
-            return null;
-        }
-
-        return new self(
-            conflictingUserId: $payload['conflicting_user_id'],
-            provider: $provider,
-            providerId: $oauthUser['provider_id'],
-            credentials: [
-                'access_token' => $credentials['access_token'],
-                'refresh_token' => $credentials['refresh_token'],
-                'expires_in' => $expiresIn,
-                'encrypted' => $encrypted,
-            ],
-            metadata: $metadata,
-        );
-    }
-
-    public function toClientAccessManager(): ClientAccessManager
-    {
-        if (($this->credentials['encrypted'] ?? false) === true) {
-            return ClientAccessManager::make(
-                accessToken: $this->credentials['access_token'],
-                refreshToken: $this->credentials['refresh_token'],
-                expiresIn: $this->credentials['expires_in'],
-            );
-        }
-
-        return ClientAccessManager::make(
-            accessToken: Crypt::encrypt($this->credentials['access_token']),
-            refreshToken: Crypt::encrypt($this->credentials['refresh_token']),
-            expiresIn: $this->credentials['expires_in'] !== null
-                ? Crypt::encrypt((string) $this->credentials['expires_in'])
-                : null,
-        );
-    }
-
-    /**
-     * @param  array<string, mixed>  $oauthUser
-     * @return array<string, mixed>
-     */
-    private static function legacyMetadata(IdentityProvider $provider, array $oauthUser): array
-    {
-        return array_filter([
-            'email' => $oauthUser['email'] ?? null,
-            'avatar' => $oauthUser['avatar_url'] ?? null,
-            'username' => $oauthUser['username'] ?? null,
-            'global_name' => $provider === IdentityProvider::Discord
-                ? ($oauthUser['name'] ?? null)
-                : null,
-        ], static fn (mixed $value): bool => $value !== null);
-    }
-
-    /**
-     * @param  array<mixed>  $payload
-     * @return array<string, mixed>|null
-     */
-    private static function stringKeyedArray(array $payload): ?array
-    {
-        $normalized = [];
-
-        foreach ($payload as $key => $value) {
-            if (!is_string($key)) {
-                return null;
-            }
-
-            $normalized[$key] = $value;
-        }
-
-        return $normalized;
-    }
 }

--- a/app-modules/identity/src/Auth/DTOs/PendingOAuthMergeDTO.php
+++ b/app-modules/identity/src/Auth/DTOs/PendingOAuthMergeDTO.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Identity\Auth\DTOs;
+
+use He4rt\Identity\ExternalIdentity\Data\ClientAccessManager;
+use He4rt\Identity\ExternalIdentity\Enums\CredentialsType;
+use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
+use Illuminate\Support\Facades\Crypt;
+
+final readonly class PendingOAuthMergeDTO
+{
+    /**
+     * @param  array{access_token: string, refresh_token: string, expires_in: int|string|null, encrypted?: bool}  $credentials
+     * @param  array<string, mixed>  $metadata
+     */
+    public function __construct(
+        public string $conflictingUserId,
+        public IdentityProvider $provider,
+        public string $providerId,
+        public array $credentials,
+        public array $metadata,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public static function fromSession(array $payload): ?self
+    {
+        $provider = is_string($payload['provider'] ?? null)
+            ? IdentityProvider::tryFrom($payload['provider'])
+            : null;
+        $credentials = $payload['credentials'] ?? null;
+        $rawOAuthUser = $payload['oauth_user'] ?? null;
+        $oauthUser = is_array($rawOAuthUser)
+            ? self::stringKeyedArray($rawOAuthUser)
+            : null;
+
+        if (
+            !is_string($payload['conflicting_user_id'] ?? null)
+            || !$provider instanceof IdentityProvider
+            || $provider->getCredentialsType() !== CredentialsType::OAuth2
+            || !is_array($credentials)
+            || !is_string($credentials['access_token'] ?? null)
+            || !is_string($credentials['refresh_token'] ?? null)
+            || $oauthUser === null
+            || !is_string($oauthUser['provider_id'] ?? null)
+        ) {
+            return null;
+        }
+
+        $encrypted = ($credentials['encrypted'] ?? false) === true;
+        $expiresIn = $credentials['expires_in'] ?? null;
+
+        if (
+            $expiresIn !== null
+            && !is_int($expiresIn)
+            && (!$encrypted || !is_string($expiresIn))
+        ) {
+            return null;
+        }
+
+        $rawMetadata = $oauthUser['metadata'] ?? null;
+
+        if ($rawMetadata !== null && !is_array($rawMetadata)) {
+            return null;
+        }
+
+        $metadata = is_array($rawMetadata)
+            ? self::stringKeyedArray($rawMetadata)
+            : self::legacyMetadata($provider, $oauthUser);
+
+        if ($metadata === null) {
+            return null;
+        }
+
+        return new self(
+            conflictingUserId: $payload['conflicting_user_id'],
+            provider: $provider,
+            providerId: $oauthUser['provider_id'],
+            credentials: [
+                'access_token' => $credentials['access_token'],
+                'refresh_token' => $credentials['refresh_token'],
+                'expires_in' => $expiresIn,
+                'encrypted' => $encrypted,
+            ],
+            metadata: $metadata,
+        );
+    }
+
+    public function toClientAccessManager(): ClientAccessManager
+    {
+        if (($this->credentials['encrypted'] ?? false) === true) {
+            return ClientAccessManager::make(
+                accessToken: $this->credentials['access_token'],
+                refreshToken: $this->credentials['refresh_token'],
+                expiresIn: $this->credentials['expires_in'],
+            );
+        }
+
+        return ClientAccessManager::make(
+            accessToken: Crypt::encrypt($this->credentials['access_token']),
+            refreshToken: Crypt::encrypt($this->credentials['refresh_token']),
+            expiresIn: $this->credentials['expires_in'] !== null
+                ? Crypt::encrypt((string) $this->credentials['expires_in'])
+                : null,
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $oauthUser
+     * @return array<string, mixed>
+     */
+    private static function legacyMetadata(IdentityProvider $provider, array $oauthUser): array
+    {
+        return array_filter([
+            'email' => $oauthUser['email'] ?? null,
+            'avatar' => $oauthUser['avatar_url'] ?? null,
+            'username' => $oauthUser['username'] ?? null,
+            'global_name' => $provider === IdentityProvider::Discord
+                ? ($oauthUser['name'] ?? null)
+                : null,
+        ], static fn (mixed $value): bool => $value !== null);
+    }
+
+    /**
+     * @param  array<mixed>  $payload
+     * @return array<string, mixed>|null
+     */
+    private static function stringKeyedArray(array $payload): ?array
+    {
+        $normalized = [];
+
+        foreach ($payload as $key => $value) {
+            if (!is_string($key)) {
+                return null;
+            }
+
+            $normalized[$key] = $value;
+        }
+
+        return $normalized;
+    }
+}

--- a/app-modules/identity/src/ExternalIdentity/Actions/ResolveExternalIdentity.php
+++ b/app-modules/identity/src/ExternalIdentity/Actions/ResolveExternalIdentity.php
@@ -28,7 +28,6 @@ final class ResolveExternalIdentity
                     'email' => $dto->email,
                     'avatar' => $dto->avatar,
                 ]),
-                'connected_at' => now(),
             ]
         );
     }

--- a/app-modules/identity/src/ExternalIdentity/Models/ExternalIdentity.php
+++ b/app-modules/identity/src/ExternalIdentity/Models/ExternalIdentity.php
@@ -95,8 +95,9 @@ final class ExternalIdentity extends Model
 
     /**
      * Identidade que uma pessoa realmente conectou, e não um registro criado por
-     * ingestão. As datas sozinhas não separam os dois: a ETL também preenche
-     * connected_at. O que só existe no fluxo OAuth é a credencial.
+     * ingestão. As datas sozinhas não separam os dois porque registros históricos
+     * da ETL também podem ter connected_at. O que só existe no fluxo de autenticação
+     * é a credencial.
      *
      * @param  Builder<$this>  $query
      */

--- a/app-modules/identity/tests/Feature/Auth/AttachProviderToUserTest.php
+++ b/app-modules/identity/tests/Feature/Auth/AttachProviderToUserTest.php
@@ -72,3 +72,42 @@ test('reattaching (reconnect) dispatches ExternalIdentityConnected again', funct
 
     Event::assertDispatched(fn (ExternalIdentityConnected $event): bool => $event->identity->id === $second->id);
 });
+
+test('reattaching preserves metadata owned by other ingestion flows', function (): void {
+    $user = User::factory()->create();
+
+    $existing = ExternalIdentity::factory()->morphFor()->create([
+        'model_id' => $user->id,
+        'provider' => IdentityProvider::GitHub,
+        'external_account_id' => '999',
+        'metadata' => [
+            'email' => 'preserved@example.com',
+            'username' => 'old-name',
+            'avatar' => 'old-avatar',
+            'profile' => ['bio' => 'Imported profile'],
+            'badges' => [['id' => 'contributor']],
+        ],
+    ]);
+
+    $identity = resolve(AttachProviderToUser::class)->execute(
+        $user,
+        attachOAuthUser(
+            providerId: '999',
+            provider: IdentityProvider::GitHub,
+            username: 'new-name',
+            email: null,
+        ),
+        (attachOAuthUser())->credentials,
+    );
+
+    expect($identity->id)->toBe($existing->id)
+        ->and($identity->metadata)->toMatchArray([
+            'email' => 'preserved@example.com',
+            'username' => 'new-name',
+            'avatar' => null,
+            'profile' => ['bio' => 'Imported profile'],
+            'badges' => [['id' => 'contributor']],
+        ])
+        ->and($identity->credentials->getAccessToken())->toBe('token')
+        ->and((string) $identity->model_id)->toBe((string) $user->id);
+});

--- a/app-modules/identity/tests/Feature/Auth/AttachProviderToUserTest.php
+++ b/app-modules/identity/tests/Feature/Auth/AttachProviderToUserTest.php
@@ -104,7 +104,7 @@ test('reattaching preserves metadata owned by other ingestion flows', function (
         ->and($identity->metadata)->toMatchArray([
             'email' => 'preserved@example.com',
             'username' => 'new-name',
-            'avatar' => null,
+            'avatar' => 'old-avatar',
             'profile' => ['bio' => 'Imported profile'],
             'badges' => [['id' => 'contributor']],
         ])

--- a/app-modules/identity/tests/Feature/Auth/ConfirmOAuthMergeTest.php
+++ b/app-modules/identity/tests/Feature/Auth/ConfirmOAuthMergeTest.php
@@ -3,12 +3,14 @@
 declare(strict_types=1);
 
 use He4rt\Identity\Auth\Actions\ConfirmOAuthMerge;
+use He4rt\Identity\Auth\Actions\ResolvePendingOAuthMerge;
 use He4rt\Identity\Auth\DTOs\PendingOAuthMergeDTO;
 use He4rt\Identity\ExternalIdentity\Data\ClientAccessManager;
 use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
 use He4rt\Identity\ExternalIdentity\Events\ExternalIdentityConnected;
 use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
 use He4rt\Identity\User\Models\User;
+use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Event;
 
 test('rolls back the account merge when the oauth connection cannot finish', function (): void {
@@ -33,11 +35,11 @@ test('rolls back the account merge when the oauth connection cannot finish', fun
         conflictingUserId: $targetUser->id,
         provider: IdentityProvider::Discord,
         providerId: 'discord-rollback',
-        credentials: [
-            'access_token' => 'access-token',
-            'refresh_token' => 'refresh-token',
-            'expires_in' => 3_600,
-        ],
+        credentials: ClientAccessManager::make(
+            accessToken: Crypt::encrypt('access-token'),
+            refreshToken: Crypt::encrypt('refresh-token'),
+            expiresIn: Crypt::encrypt('3600'),
+        ),
         metadata: ['username' => 'oauth-user'],
     );
 
@@ -62,33 +64,35 @@ test('rolls back the account merge when the oauth connection cannot finish', fun
 });
 
 test('rejects an incomplete pending oauth merge payload', function (): void {
-    expect(PendingOAuthMergeDTO::fromSession([
+    expect(resolve(ResolvePendingOAuthMerge::class)->execute([
         'conflicting_user_id' => 'target-user',
         'provider' => IdentityProvider::Discord->value,
         'credentials' => ['access_token' => 'missing-refresh-token'],
-        'oauth_user' => ['provider_id' => 'discord-id'],
+        'provider_id' => 'discord-id',
+        'metadata' => [],
     ]))->toBeNull();
 });
 
-test('keeps compatibility with pending oauth sessions created before metadata was embedded', function (): void {
-    $pending = PendingOAuthMergeDTO::fromSession([
+test('resolves the pending oauth merge session payload', function (): void {
+    $pending = resolve(ResolvePendingOAuthMerge::class)->execute([
         'conflicting_user_id' => 'target-user',
         'provider' => IdentityProvider::Discord->value,
         'credentials' => [
-            'access_token' => 'access-token',
-            'refresh_token' => 'refresh-token',
-            'expires_in' => 3_600,
+            'access_token' => Crypt::encrypt('access-token'),
+            'refresh_token' => Crypt::encrypt('refresh-token'),
+            'expires_in' => Crypt::encrypt('3600'),
         ],
-        'oauth_user' => [
-            'provider_id' => 'discord-id',
+        'provider_id' => 'discord-id',
+        'metadata' => [
             'username' => 'discord-user',
-            'name' => 'Discord User',
-            'email' => null,
-            'avatar_url' => null,
+            'global_name' => 'Discord User',
         ],
     ]);
 
     expect($pending)->toBeInstanceOf(PendingOAuthMergeDTO::class)
+        ->and($pending?->credentials->getAccessToken())->toBe('access-token')
+        ->and($pending?->credentials->getRefreshToken())->toBe('refresh-token')
+        ->and($pending?->credentials->getExpiresIn())->toBe(3_600)
         ->and($pending?->metadata)->toBe([
             'username' => 'discord-user',
             'global_name' => 'Discord User',

--- a/app-modules/identity/tests/Feature/Auth/ConfirmOAuthMergeTest.php
+++ b/app-modules/identity/tests/Feature/Auth/ConfirmOAuthMergeTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Identity\Auth\Actions\ConfirmOAuthMerge;
+use He4rt\Identity\Auth\DTOs\PendingOAuthMergeDTO;
+use He4rt\Identity\ExternalIdentity\Data\ClientAccessManager;
+use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
+use He4rt\Identity\ExternalIdentity\Events\ExternalIdentityConnected;
+use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
+use He4rt\Identity\User\Models\User;
+use Illuminate\Support\Facades\Event;
+
+test('rolls back the account merge when the oauth connection cannot finish', function (): void {
+    $currentUser = User::factory()->create();
+    $targetUser = User::factory()->create();
+    $discordIdentity = ExternalIdentity::factory()->create([
+        'model_type' => (new User)->getMorphClass(),
+        'model_id' => $targetUser->id,
+        'provider' => IdentityProvider::Discord,
+        'external_account_id' => 'discord-rollback',
+        'credentials' => ClientAccessManager::make(),
+        'connected_at' => null,
+        'metadata' => ['username' => 'imported-user'],
+    ]);
+    $currentIdentity = ExternalIdentity::factory()->create([
+        'model_type' => (new User)->getMorphClass(),
+        'model_id' => $currentUser->id,
+        'provider' => IdentityProvider::GitHub,
+        'external_account_id' => 'github-rollback',
+    ]);
+    $pending = new PendingOAuthMergeDTO(
+        conflictingUserId: $targetUser->id,
+        provider: IdentityProvider::Discord,
+        providerId: 'discord-rollback',
+        credentials: [
+            'access_token' => 'access-token',
+            'refresh_token' => 'refresh-token',
+            'expires_in' => 3_600,
+        ],
+        metadata: ['username' => 'oauth-user'],
+    );
+
+    Event::listen(
+        ExternalIdentityConnected::class,
+        static fn () => throw new RuntimeException('connection listener failed'),
+    );
+
+    expect(fn () => resolve(ConfirmOAuthMerge::class)->execute($currentUser, $pending))
+        ->toThrow(RuntimeException::class, 'connection listener failed');
+
+    $discordIdentity->refresh();
+    $currentIdentity->refresh();
+
+    expect(User::query()->find($currentUser->id))->not->toBeNull()
+        ->and(User::query()->find($targetUser->id))->not->toBeNull()
+        ->and($discordIdentity->model_id)->toBe($targetUser->id)
+        ->and($discordIdentity->metadata)->toBe(['username' => 'imported-user'])
+        ->and($discordIdentity->credentials->getAccessToken())->toBeNull()
+        ->and($discordIdentity->connected_at)->toBeNull()
+        ->and($currentIdentity->model_id)->toBe($currentUser->id);
+});
+
+test('rejects an incomplete pending oauth merge payload', function (): void {
+    expect(PendingOAuthMergeDTO::fromSession([
+        'conflicting_user_id' => 'target-user',
+        'provider' => IdentityProvider::Discord->value,
+        'credentials' => ['access_token' => 'missing-refresh-token'],
+        'oauth_user' => ['provider_id' => 'discord-id'],
+    ]))->toBeNull();
+});
+
+test('keeps compatibility with pending oauth sessions created before metadata was embedded', function (): void {
+    $pending = PendingOAuthMergeDTO::fromSession([
+        'conflicting_user_id' => 'target-user',
+        'provider' => IdentityProvider::Discord->value,
+        'credentials' => [
+            'access_token' => 'access-token',
+            'refresh_token' => 'refresh-token',
+            'expires_in' => 3_600,
+        ],
+        'oauth_user' => [
+            'provider_id' => 'discord-id',
+            'username' => 'discord-user',
+            'name' => 'Discord User',
+            'email' => null,
+            'avatar_url' => null,
+        ],
+    ]);
+
+    expect($pending)->toBeInstanceOf(PendingOAuthMergeDTO::class)
+        ->and($pending?->metadata)->toBe([
+            'username' => 'discord-user',
+            'global_name' => 'Discord User',
+        ]);
+});

--- a/app-modules/identity/tests/Feature/ExternalIdentity/ResolveExternalIdentityTest.php
+++ b/app-modules/identity/tests/Feature/ExternalIdentity/ResolveExternalIdentityTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Identity\ExternalIdentity\Actions\ResolveExternalIdentity;
+use He4rt\Identity\ExternalIdentity\DTOs\ResolveUserProviderDTO;
+use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
+use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
+use He4rt\Identity\User\Models\User;
+
+test('ingestion creates a disconnected identity with public metadata', function (): void {
+    $identity = resolve(ResolveExternalIdentity::class)->handle(
+        ResolveUserProviderDTO::make([
+            'provider' => IdentityProvider::Discord,
+            'external_account_id' => '123456789',
+            'model_type' => (new User)->getMorphClass(),
+            'username' => 'discord-user',
+            'email' => 'discord@example.com',
+            'avatar' => 'avatar-hash',
+        ]),
+    );
+
+    expect($identity->connected_at)->toBeNull()
+        ->and($identity->credentials->getAccessToken())->toBeNull()
+        ->and($identity->metadata)->toBe([
+            'username' => 'discord-user',
+            'email' => 'discord@example.com',
+            'avatar' => 'avatar-hash',
+        ]);
+});
+
+test('ingestion does not overwrite an authenticated identity', function (): void {
+    $identity = ExternalIdentity::factory()->morphFor()->create([
+        'provider' => IdentityProvider::Discord,
+        'external_account_id' => '123456789',
+        'metadata' => [
+            'username' => 'oauth-user',
+            'email' => 'oauth@example.com',
+            'profile' => ['bio' => 'preserved'],
+        ],
+    ]);
+    $accessToken = $identity->credentials->accessToken;
+    $connectedAt = $identity->connected_at;
+
+    $resolved = resolve(ResolveExternalIdentity::class)->handle(
+        ResolveUserProviderDTO::make([
+            'provider' => IdentityProvider::Discord,
+            'external_account_id' => '123456789',
+            'model_type' => (new User)->getMorphClass(),
+            'username' => 'message-user',
+        ]),
+    );
+
+    expect($resolved->id)->toBe($identity->id)
+        ->and($resolved->metadata)->toMatchArray($identity->metadata)
+        ->and($resolved->credentials->accessToken)->toBe($accessToken)
+        ->and($resolved->connected_at?->equalTo($connectedAt))->toBeTrue();
+});

--- a/app-modules/integration-discord/src/ETL/Actions/ImportDiscordMessageAction.php
+++ b/app-modules/integration-discord/src/ETL/Actions/ImportDiscordMessageAction.php
@@ -20,6 +20,7 @@ use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
 use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
 use He4rt\Identity\User\Models\User;
 use He4rt\IntegrationDiscord\ETL\DTOs\DiscordMessageDTO;
+use He4rt\IntegrationDiscord\Identity\DiscordIdentityMetadata;
 use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
@@ -423,6 +424,16 @@ final class ImportDiscordMessageAction
             ->first();
 
         if ($identity) {
+            $metadata = DiscordIdentityMetadata::mergeMessage(
+                $identity->metadata ?? [],
+                $dto,
+            )->toArray();
+
+            if ($metadata !== ($identity->metadata ?? [])) {
+                $identity->metadata = $metadata;
+                $identity->save();
+            }
+
             return $identity;
         }
 
@@ -441,7 +452,7 @@ final class ImportDiscordMessageAction
             'type' => IdentityProvider::Discord->getType(),
             'credentials_type' => CredentialsType::OAuth2,
             'credentials' => ClientAccessManager::make(),
-            'metadata' => ['author' => $dto->authorRaw],
+            'metadata' => DiscordIdentityMetadata::fromMessage($dto)->toArray(),
         ]);
     }
 

--- a/app-modules/integration-discord/src/ETL/Actions/ImportDiscordProfileAction.php
+++ b/app-modules/integration-discord/src/ETL/Actions/ImportDiscordProfileAction.php
@@ -11,7 +11,7 @@ use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
 use He4rt\Identity\User\Models\User;
 use He4rt\IntegrationDiscord\ETL\DTOs\ConnectedAccountDTO;
 use He4rt\IntegrationDiscord\ETL\DTOs\DiscordProfileDTO;
-use Illuminate\Support\Facades\Date;
+use He4rt\IntegrationDiscord\Identity\DiscordIdentityMetadata;
 use Illuminate\Support\Facades\Log;
 use Ramsey\Uuid\Uuid;
 
@@ -21,21 +21,26 @@ final class ImportDiscordProfileAction
     {
         $user = $this->resolveUser($dto);
 
-        $discordIdentity = ExternalIdentity::query()->updateOrCreate(
-            [
-                'provider' => IdentityProvider::Discord,
-                'external_account_id' => $dto->discordId,
-            ],
-            [
+        $discordIdentity = ExternalIdentity::query()->firstOrNew([
+            'provider' => IdentityProvider::Discord,
+            'external_account_id' => $dto->discordId,
+        ]);
+
+        if (!$discordIdentity->exists) {
+            $discordIdentity->forceFill([
                 'model_type' => (new User)->getMorphClass(),
                 'model_id' => $user->id,
                 'type' => IdentityProvider::Discord->getType(),
                 'credentials_type' => CredentialsType::OAuth2,
                 'credentials' => ClientAccessManager::make(),
-                'connected_at' => $dto->joinedAt ? Date::parse($dto->joinedAt) : null,
-                'metadata' => $dto->metadata,
-            ],
-        );
+            ]);
+        }
+
+        $discordIdentity->metadata = DiscordIdentityMetadata::mergeProfile(
+            $discordIdentity->metadata ?? [],
+            $dto,
+        )->toArray();
+        $discordIdentity->save();
 
         foreach ($dto->connectedAccounts as $account) {
             $this->upsertConnectedAccount($account, $user, $dto);
@@ -123,20 +128,21 @@ final class ImportDiscordProfileAction
             return;
         }
 
-        ExternalIdentity::query()->updateOrCreate(
-            [
+        $identity = $existing ?? new ExternalIdentity;
+
+        if (!$identity->exists) {
+            $identity->forceFill([
                 'provider' => $account->provider,
                 'external_account_id' => $account->externalAccountId,
-            ],
-            [
                 'model_type' => (new User)->getMorphClass(),
                 'model_id' => $user->id,
                 'type' => $account->provider->getType(),
                 'credentials_type' => CredentialsType::OAuth2,
                 'credentials' => ClientAccessManager::make(),
-                'connected_at' => $dto->joinedAt ? Date::parse($dto->joinedAt) : null,
-                'metadata' => $account->metadata,
-            ],
-        );
+            ]);
+        }
+
+        $identity->metadata = array_replace($identity->metadata ?? [], $account->metadata);
+        $identity->save();
     }
 }

--- a/app-modules/integration-discord/src/Identity/DiscordIdentityMetadata.php
+++ b/app-modules/integration-discord/src/Identity/DiscordIdentityMetadata.php
@@ -22,14 +22,19 @@ final readonly class DiscordIdentityMetadata
             ? $profile->metadata['user']
             : [];
 
+        $publicFields = [
+            'username' => $profile->username,
+            'global_name' => $profile->name,
+        ];
+
+        if (array_key_exists('avatar', $user)) {
+            $publicFields['avatar'] = $user['avatar'];
+        }
+
         return new self(array_replace(
             $current,
             $profile->metadata,
-            [
-                'username' => $profile->username,
-                'global_name' => $profile->name,
-                'avatar' => $user['avatar'] ?? null,
-            ],
+            $publicFields,
         ));
     }
 

--- a/app-modules/integration-discord/src/Identity/DiscordIdentityMetadata.php
+++ b/app-modules/integration-discord/src/Identity/DiscordIdentityMetadata.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\IntegrationDiscord\Identity;
+
+use He4rt\IntegrationDiscord\ETL\DTOs\DiscordMessageDTO;
+use He4rt\IntegrationDiscord\ETL\DTOs\DiscordProfileDTO;
+
+final readonly class DiscordIdentityMetadata
+{
+    /** @param array<string, mixed> $payload */
+    private function __construct(private array $payload) {}
+
+    /**
+     * @param  array<string, mixed>  $current
+     */
+    public static function mergeProfile(array $current, DiscordProfileDTO $profile): self
+    {
+        /** @var array<string, mixed> $user */
+        $user = is_array($profile->metadata['user'] ?? null)
+            ? $profile->metadata['user']
+            : [];
+
+        return new self(array_replace(
+            $current,
+            $profile->metadata,
+            [
+                'username' => $profile->username,
+                'global_name' => $profile->name,
+                'avatar' => $user['avatar'] ?? null,
+            ],
+        ));
+    }
+
+    public static function fromMessage(DiscordMessageDTO $message): self
+    {
+        return self::mergeMessage([], $message);
+    }
+
+    /**
+     * @param  array<string, mixed>  $current
+     */
+    public static function mergeMessage(array $current, DiscordMessageDTO $message): self
+    {
+        $nestedUser = $current['user'] ?? $current['author'] ?? [];
+
+        if (!is_array($nestedUser)) {
+            $nestedUser = [];
+        }
+
+        $defaults = [
+            'author' => $message->authorRaw,
+            'username' => $nestedUser['username'] ?? $message->authorUsername,
+            'global_name' => $nestedUser['global_name'] ?? $message->authorName,
+            'avatar' => array_key_exists('avatar', $nestedUser)
+                ? $nestedUser['avatar']
+                : ($message->authorRaw['avatar'] ?? null),
+        ];
+
+        return new self(array_replace($defaults, $current));
+    }
+
+    /** @return array<string, mixed> */
+    public function toArray(): array
+    {
+        return $this->payload;
+    }
+}

--- a/app-modules/integration-discord/src/OAuth/DiscordOAuthUser.php
+++ b/app-modules/integration-discord/src/OAuth/DiscordOAuthUser.php
@@ -21,8 +21,19 @@ class DiscordOAuthUser extends OAuthUserDTO
             provider: IdentityProvider::Discord,
             username: $payload['username'],
             name: $payload['global_name'] ?? $payload['username'],
-            email: $payload['email'],
-            avatarUrl: sprintf('https://cdn.discordapp.com/avatars/%s/%s.png', $payload['id'], $payload['avatar']),
+            email: $payload['email'] ?? null,
+            avatarUrl: isset($payload['avatar'])
+                ? sprintf('https://cdn.discordapp.com/avatars/%s/%s.png', $payload['id'], $payload['avatar'])
+                : null,
         );
+    }
+
+    /** @return array<string, mixed> */
+    public function toMetadata(): array
+    {
+        return [
+            ...parent::toMetadata(),
+            'global_name' => $this->name,
+        ];
     }
 }

--- a/app-modules/integration-discord/src/OAuth/DiscordOAuthUser.php
+++ b/app-modules/integration-discord/src/OAuth/DiscordOAuthUser.php
@@ -10,6 +10,19 @@ use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
 
 class DiscordOAuthUser extends OAuthUserDTO
 {
+    public function __construct(
+        OAuthAccessDTO $credentials,
+        string $providerId,
+        IdentityProvider $provider,
+        string $username,
+        string $name,
+        ?string $email,
+        ?string $avatarUrl,
+        private readonly bool $avatarProvided,
+    ) {
+        parent::__construct($credentials, $providerId, $provider, $username, $name, $email, $avatarUrl);
+    }
+
     /**
      * @param  array<string, mixed>  $payload
      */
@@ -25,6 +38,7 @@ class DiscordOAuthUser extends OAuthUserDTO
             avatarUrl: isset($payload['avatar'])
                 ? sprintf('https://cdn.discordapp.com/avatars/%s/%s.png', $payload['id'], $payload['avatar'])
                 : null,
+            avatarProvided: array_key_exists('avatar', $payload),
         );
     }
 
@@ -32,6 +46,7 @@ class DiscordOAuthUser extends OAuthUserDTO
     public function toMetadata(): array
     {
         return [
+            ...($this->avatarProvided && $this->avatarUrl === null ? ['avatar' => null] : []),
             ...parent::toMetadata(),
             'global_name' => $this->name,
         ];

--- a/app-modules/integration-discord/src/OAuth/DiscordOAuthUser.php
+++ b/app-modules/integration-discord/src/OAuth/DiscordOAuthUser.php
@@ -18,7 +18,7 @@ class DiscordOAuthUser extends OAuthUserDTO
         string $name,
         ?string $email,
         ?string $avatarUrl,
-        private readonly bool $avatarProvided,
+        private readonly bool $avatarProvided = false,
     ) {
         parent::__construct($credentials, $providerId, $provider, $username, $name, $email, $avatarUrl);
     }

--- a/app-modules/integration-discord/tests/Feature/ETL/ImportDiscordMessageTest.php
+++ b/app-modules/integration-discord/tests/Feature/ETL/ImportDiscordMessageTest.php
@@ -28,6 +28,7 @@ use He4rt\IntegrationDiscord\ETL\DTOs\DiscordMessageDTO;
 use He4rt\IntegrationDiscord\ETL\DTOs\DiscordMessageReactionDTO;
 use He4rt\IntegrationDiscord\ETL\DTOs\DiscordModerationEventDTO;
 use He4rt\IntegrationDiscord\ETL\DTOs\DiscordVoiceLogDTO;
+use Illuminate\Support\Facades\Crypt;
 use Ramsey\Uuid\Uuid;
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -465,7 +466,48 @@ test('it persists full author raw payload into external_identity metadata', func
     expect($identity->metadata['author']['avatar'] ?? null)->toBe('abc123')
         ->and($identity->metadata['author']['discriminator'] ?? null)->toBe('0001')
         ->and($identity->metadata['author']['public_flags'] ?? null)->toBe(64)
-        ->and($identity->metadata['author']['username'] ?? null)->toBe('letsch1');
+        ->and($identity->metadata['author']['username'] ?? null)->toBe('letsch1')
+        ->and($identity->metadata['username'] ?? null)->toBe('letsch1')
+        ->and($identity->metadata['global_name'] ?? null)->toBe('letsch')
+        ->and($identity->metadata['avatar'] ?? null)->toBe('abc123');
+});
+
+test('message import fills missing canonical metadata without overwriting an existing identity', function (): void {
+    $identity = createTestIdentity('253642464697516033', 'letsch1');
+    $connectedAt = now()->subHour()->startOfSecond();
+    $identity->update([
+        'credentials' => ClientAccessManager::make(
+            accessToken: Crypt::encrypt('oauth-token'),
+        ),
+        'connected_at' => $connectedAt,
+    ]);
+    $ownerId = $identity->model_id;
+
+    resolve(ImportDiscordMessageAction::class)->handle(
+        DiscordMessageDTO::fromDump(discordMessage([
+            'author' => [
+                'id' => '253642464697516033',
+                'username' => 'changed-in-message',
+                'global_name' => 'Changed in message',
+                'avatar' => 'changed-avatar',
+            ],
+        ])),
+    );
+
+    $identity->refresh();
+
+    expect($identity->metadata['user'])->toBe([
+        'username' => 'letsch1',
+        'discriminator' => '0',
+    ])
+        ->and($identity->metadata)->toMatchArray([
+            'username' => 'letsch1',
+            'global_name' => 'Changed in message',
+            'avatar' => 'changed-avatar',
+        ])
+        ->and($identity->credentials->getAccessToken())->toBe('oauth-token')
+        ->and($identity->connected_at?->equalTo($connectedAt))->toBeTrue()
+        ->and((string) $identity->model_id)->toBe((string) $ownerId);
 });
 
 test('it parses sent_at from discord timestamp', function (): void {

--- a/app-modules/integration-discord/tests/Feature/ETL/ImportDiscordMessageTest.php
+++ b/app-modules/integration-discord/tests/Feature/ETL/ImportDiscordMessageTest.php
@@ -510,6 +510,64 @@ test('message import fills missing canonical metadata without overwriting an exi
         ->and((string) $identity->model_id)->toBe((string) $ownerId);
 });
 
+test('message import preserves canonical profile fields and explicit null avatar', function (): void {
+    $user = User::factory()->create(['username' => 'profile-user']);
+    $connectedAt = now()->subHour()->startOfSecond();
+    $identity = ExternalIdentity::factory()->morphFor()->create([
+        'model_id' => $user->id,
+        'provider' => IdentityProvider::Discord,
+        'external_account_id' => '253642464697516033',
+        'credentials' => ClientAccessManager::make(
+            accessToken: Crypt::encrypt('oauth-token'),
+        ),
+        'connected_at' => $connectedAt,
+        'metadata' => [
+            'username' => 'profile-user',
+            'global_name' => 'Profile Name',
+            'avatar' => null,
+            'user' => [
+                'username' => 'profile-user',
+                'global_name' => 'Profile Name',
+                'avatar' => null,
+                'public_flags' => 64,
+            ],
+        ],
+    ]);
+
+    resolve(ImportDiscordMessageAction::class)->handle(
+        DiscordMessageDTO::fromDump(discordMessage([
+            'author' => [
+                'id' => '253642464697516033',
+                'username' => 'message-user',
+                'global_name' => 'Message Name',
+                'avatar' => 'message-avatar',
+            ],
+        ])),
+    );
+
+    $identity->refresh();
+
+    expect($identity->metadata)->toMatchArray([
+        'username' => 'profile-user',
+        'global_name' => 'Profile Name',
+        'avatar' => null,
+        'user' => [
+            'username' => 'profile-user',
+            'global_name' => 'Profile Name',
+            'avatar' => null,
+            'public_flags' => 64,
+        ],
+    ])
+        ->and($identity->metadata['author'])->toMatchArray([
+            'username' => 'message-user',
+            'global_name' => 'Message Name',
+            'avatar' => 'message-avatar',
+        ])
+        ->and($identity->credentials->getAccessToken())->toBe('oauth-token')
+        ->and($identity->connected_at?->equalTo($connectedAt))->toBeTrue()
+        ->and((string) $identity->model_id)->toBe((string) $user->id);
+});
+
 test('it parses sent_at from discord timestamp', function (): void {
     $action = resolve(ImportDiscordMessageAction::class);
     $message = $action->handle(DiscordMessageDTO::fromDump(discordMessage()));

--- a/app-modules/integration-discord/tests/Feature/ETL/ImportDiscordProfileTest.php
+++ b/app-modules/integration-discord/tests/Feature/ETL/ImportDiscordProfileTest.php
@@ -256,6 +256,37 @@ test('profile import preserves oauth credentials connection state and owner', fu
         ->and($identity->metadata)->toHaveKeys(['user', 'badges', 'guild_member']);
 });
 
+test('profile import preserves an avatar when the snapshot omits it and clears it when explicitly null', function (): void {
+    $user = User::factory()->create(['username' => '_tats']);
+    ExternalIdentity::factory()->morphFor()->create([
+        'model_id' => $user->id,
+        'provider' => IdentityProvider::Discord,
+        'external_account_id' => '49615312957476864',
+        'metadata' => [
+            'username' => '_tats',
+            'avatar' => 'known-avatar',
+        ],
+    ]);
+
+    $profileWithoutAvatar = discordProfile(['connected_accounts' => []]);
+    unset($profileWithoutAvatar['user']['avatar']);
+
+    $identity = resolve(ImportDiscordProfileAction::class)->handle(
+        DiscordProfileDTO::fromDump($profileWithoutAvatar),
+    );
+
+    expect($identity->metadata['avatar'])->toBe('known-avatar');
+
+    $identity = resolve(ImportDiscordProfileAction::class)->handle(
+        DiscordProfileDTO::fromDump(discordProfile([
+            'user' => ['avatar' => null],
+            'connected_accounts' => [],
+        ])),
+    );
+
+    expect($identity->metadata)->toHaveKey('avatar', value: null);
+});
+
 test('oauth connection preserves profile snapshot and fills canonical metadata', function (): void {
     $profileIdentity = resolve(ImportDiscordProfileAction::class)->handle(
         DiscordProfileDTO::fromDump(discordProfile(['connected_accounts' => []])),

--- a/app-modules/integration-discord/tests/Feature/ETL/ImportDiscordProfileTest.php
+++ b/app-modules/integration-discord/tests/Feature/ETL/ImportDiscordProfileTest.php
@@ -323,6 +323,35 @@ test('oauth connection preserves profile snapshot and fills canonical metadata',
         ->and($identity->metadata)->toHaveKeys(['user', 'badges', 'guild_member']);
 });
 
+test('oauth connection clears a profile avatar only when Discord explicitly returns null', function (): void {
+    $profileIdentity = resolve(ImportDiscordProfileAction::class)->handle(
+        DiscordProfileDTO::fromDump(discordProfile(['connected_accounts' => []])),
+    );
+
+    $access = DiscordOAuthAccessDTO::make([
+        'access_token' => 'new-access-token',
+        'refresh_token' => 'new-refresh-token',
+        'expires_in' => 3_600,
+    ]);
+    $oauthUser = DiscordOAuthUser::make($access, [
+        'id' => '49615312957476864',
+        'username' => '_tats',
+        'global_name' => 'Madruguinha',
+        'email' => 'discord@example.com',
+        'avatar' => null,
+    ]);
+
+    $identity = resolve(AttachProviderToUser::class)->execute(
+        $profileIdentity->user,
+        $oauthUser,
+        $access,
+    );
+
+    expect($identity->metadata)->toHaveKey('avatar', value: null)
+        ->and($identity->metadata['user']['avatar'])->toBe('7638814994b449231c5ff17dd84500bd')
+        ->and($identity->credentials->getAccessToken())->toBe('new-access-token');
+});
+
 test('profile import enriches an identity created from a message without replacing its owner', function (): void {
     resolve(ImportDiscordMessageAction::class)->handle(
         DiscordMessageDTO::fromDump([

--- a/app-modules/integration-discord/tests/Feature/ETL/ImportDiscordProfileTest.php
+++ b/app-modules/integration-discord/tests/Feature/ETL/ImportDiscordProfileTest.php
@@ -2,12 +2,19 @@
 
 declare(strict_types=1);
 
+use He4rt\Identity\Auth\Actions\AttachProviderToUser;
+use He4rt\Identity\ExternalIdentity\Data\ClientAccessManager;
 use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
 use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
 use He4rt\Identity\User\Models\User;
+use He4rt\IntegrationDiscord\ETL\Actions\ImportDiscordMessageAction;
 use He4rt\IntegrationDiscord\ETL\Actions\ImportDiscordProfileAction;
 use He4rt\IntegrationDiscord\ETL\DTOs\ConnectedAccountDTO;
+use He4rt\IntegrationDiscord\ETL\DTOs\DiscordMessageDTO;
 use He4rt\IntegrationDiscord\ETL\DTOs\DiscordProfileDTO;
+use He4rt\IntegrationDiscord\OAuth\DiscordOAuthAccessDTO;
+use He4rt\IntegrationDiscord\OAuth\DiscordOAuthUser;
+use Illuminate\Support\Facades\Crypt;
 
 /**
  * @param  array<string, mixed>  $overrides
@@ -193,14 +200,177 @@ test('it stores complete discord metadata in external identity', function (): vo
         ->and($metadata['legacy_username'])->toBe('Tats#0927');
 });
 
-test('it sets connected_at to null when guild_member joined_at is absent', function (): void {
-    $profile = discordProfile(['guild_member' => ['joined_at' => null]]);
+test('it does not treat a guild join as an authenticated connection', function (): void {
+    $profile = discordProfile();
     $dto = DiscordProfileDTO::fromDump($profile);
 
     $action = resolve(ImportDiscordProfileAction::class);
     $identity = $action->handle($dto);
 
-    expect($identity->connected_at)->toBeNull();
+    expect($dto->joinedAt)->not->toBeNull()
+        ->and($identity->connected_at)->toBeNull()
+        ->and($identity->credentials->getAccessToken())->toBeNull();
+});
+
+test('profile import preserves oauth credentials connection state and owner', function (): void {
+    $user = User::factory()->create(['username' => '_tats']);
+    $connectedBy = User::factory()->create();
+    $connectedAt = now()->subDay()->startOfSecond();
+
+    $existing = ExternalIdentity::factory()->morphFor()->create([
+        'model_id' => $user->id,
+        'provider' => IdentityProvider::Discord,
+        'external_account_id' => '49615312957476864',
+        'credentials' => ClientAccessManager::make(
+            accessToken: Crypt::encrypt('oauth-token'),
+            refreshToken: Crypt::encrypt('oauth-refresh'),
+        ),
+        'connected_by' => $connectedBy->id,
+        'connected_at' => $connectedAt,
+        'metadata' => [
+            'email' => 'discord@example.com',
+            'username' => '_tats',
+            'avatar' => 'https://cdn.discordapp.com/avatars/49615312957476864/oauth.png',
+        ],
+    ]);
+
+    $identity = resolve(ImportDiscordProfileAction::class)->handle(
+        DiscordProfileDTO::fromDump(discordProfile([
+            'user' => ['email' => 'profile-must-not-replace@example.com'],
+            'connected_accounts' => [],
+        ])),
+    );
+
+    expect($identity->id)->toBe($existing->id)
+        ->and((string) $identity->model_id)->toBe((string) $user->id)
+        ->and((string) $identity->connected_by)->toBe((string) $connectedBy->id)
+        ->and($identity->connected_at?->equalTo($connectedAt))->toBeTrue()
+        ->and($identity->credentials->getAccessToken())->toBe('oauth-token')
+        ->and($identity->credentials->getRefreshToken())->toBe('oauth-refresh')
+        ->and($identity->metadata)->toMatchArray([
+            'email' => 'discord@example.com',
+            'username' => '_tats',
+            'global_name' => 'Madruguinha',
+            'avatar' => '7638814994b449231c5ff17dd84500bd',
+        ])
+        ->and($identity->metadata)->toHaveKeys(['user', 'badges', 'guild_member']);
+});
+
+test('oauth connection preserves profile snapshot and fills canonical metadata', function (): void {
+    $profileIdentity = resolve(ImportDiscordProfileAction::class)->handle(
+        DiscordProfileDTO::fromDump(discordProfile(['connected_accounts' => []])),
+    );
+
+    $access = DiscordOAuthAccessDTO::make([
+        'access_token' => 'new-access-token',
+        'refresh_token' => 'new-refresh-token',
+        'expires_in' => 3_600,
+    ]);
+    $oauthUser = DiscordOAuthUser::make($access, [
+        'id' => '49615312957476864',
+        'username' => '_tats_oauth',
+        'global_name' => 'Madruguinha OAuth',
+        'email' => 'discord@example.com',
+        'avatar' => 'oauth-avatar',
+    ]);
+
+    $identity = resolve(AttachProviderToUser::class)->execute(
+        $profileIdentity->user,
+        $oauthUser,
+        $access,
+    );
+
+    expect($identity->id)->toBe($profileIdentity->id)
+        ->and($identity->credentials->getAccessToken())->toBe('new-access-token')
+        ->and($identity->connected_at)->not->toBeNull()
+        ->and($identity->metadata)->toMatchArray([
+            'email' => 'discord@example.com',
+            'username' => '_tats_oauth',
+            'global_name' => 'Madruguinha OAuth',
+            'avatar' => 'https://cdn.discordapp.com/avatars/49615312957476864/oauth-avatar.png',
+        ])
+        ->and($identity->metadata)->toHaveKeys(['user', 'badges', 'guild_member']);
+});
+
+test('profile import enriches an identity created from a message without replacing its owner', function (): void {
+    resolve(ImportDiscordMessageAction::class)->handle(
+        DiscordMessageDTO::fromDump([
+            'id' => 'message-1',
+            'channel_id' => 'channel-1',
+            'timestamp' => '2026-08-25T10:00:00.000000+00:00',
+            'content' => 'hello',
+            'author' => [
+                'id' => '49615312957476864',
+                'username' => '_tats',
+                'global_name' => 'Old display name',
+                'avatar' => 'old-avatar',
+            ],
+        ]),
+    );
+
+    $messageIdentity = ExternalIdentity::query()
+        ->where('provider', IdentityProvider::Discord)
+        ->where('external_account_id', '49615312957476864')
+        ->firstOrFail();
+    $ownerId = $messageIdentity->model_id;
+
+    $identity = resolve(ImportDiscordProfileAction::class)->handle(
+        DiscordProfileDTO::fromDump(discordProfile(['connected_accounts' => []])),
+    );
+
+    expect($identity->id)->toBe($messageIdentity->id)
+        ->and((string) $identity->model_id)->toBe((string) $ownerId)
+        ->and($identity->metadata['author'])->toMatchArray([
+            'username' => '_tats',
+            'global_name' => 'Old display name',
+            'avatar' => 'old-avatar',
+        ])
+        ->and($identity->metadata)->toMatchArray([
+            'username' => '_tats',
+            'global_name' => 'Madruguinha',
+            'avatar' => '7638814994b449231c5ff17dd84500bd',
+        ])
+        ->and($identity->metadata)->toHaveKeys(['user', 'badges', 'guild_member']);
+});
+
+test('profile import preserves an authenticated connected account', function (): void {
+    $user = User::factory()->create(['username' => '_tats']);
+    ExternalIdentity::factory()->morphFor()->create([
+        'model_id' => $user->id,
+        'provider' => IdentityProvider::Discord,
+        'external_account_id' => '49615312957476864',
+    ]);
+
+    $connectedAt = now()->subHour()->startOfSecond();
+    $twitch = ExternalIdentity::factory()->morphFor()->create([
+        'model_id' => $user->id,
+        'provider' => IdentityProvider::Twitch,
+        'external_account_id' => '81085454',
+        'credentials' => ClientAccessManager::make(
+            accessToken: Crypt::encrypt('twitch-token'),
+        ),
+        'connected_at' => $connectedAt,
+        'metadata' => [
+            'email' => 'twitch@example.com',
+            'username' => 'oauth-name',
+        ],
+    ]);
+
+    resolve(ImportDiscordProfileAction::class)->handle(
+        DiscordProfileDTO::fromDump(discordProfile()),
+    );
+
+    $twitch->refresh();
+
+    expect((string) $twitch->model_id)->toBe((string) $user->id)
+        ->and($twitch->credentials->getAccessToken())->toBe('twitch-token')
+        ->and($twitch->connected_at?->equalTo($connectedAt))->toBeTrue()
+        ->and($twitch->metadata)->toMatchArray([
+            'email' => 'twitch@example.com',
+            'username' => 'oauth-name',
+            'name' => 'fewerygor',
+            'verified' => true,
+        ]);
 });
 
 test('it creates external identities for each connected account', function (): void {

--- a/app-modules/integration-discord/tests/Feature/OAuth/DiscordOAuthClientTest.php
+++ b/app-modules/integration-discord/tests/Feature/OAuth/DiscordOAuthClientTest.php
@@ -93,6 +93,23 @@ it('normalizes an authenticated Discord user without email or avatar', function 
         ]);
 });
 
+it('omits an unavailable avatar from authenticated user metadata', function (): void {
+    $credentials = DiscordOAuthAccessDTO::make([
+        'access_token' => 'test-access-token',
+        'refresh_token' => 'test-refresh-token',
+        'expires_in' => 604_800,
+    ]);
+
+    $user = DiscordOAuthUser::make($credentials, [
+        'id' => '123456789',
+        'username' => 'testuser',
+        'global_name' => 'Test User',
+    ]);
+
+    expect($user->avatarUrl)->toBeNull()
+        ->and($user->toMetadata())->not->toHaveKey('avatar');
+});
+
 it('generates correct redirect url', function (): void {
     config()->set('services.discord.scopes', 'identify email');
     config()->set('app.url', 'http://localhost:8000');

--- a/app-modules/integration-discord/tests/Feature/OAuth/DiscordOAuthClientTest.php
+++ b/app-modules/integration-discord/tests/Feature/OAuth/DiscordOAuthClientTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
 use He4rt\IntegrationDiscord\OAuth\DiscordOAuthAccessDTO;
 use He4rt\IntegrationDiscord\OAuth\DiscordOAuthClient;
 use He4rt\IntegrationDiscord\OAuth\DiscordOAuthUser;
@@ -108,6 +109,29 @@ it('omits an unavailable avatar from authenticated user metadata', function (): 
 
     expect($user->avatarUrl)->toBeNull()
         ->and($user->toMetadata())->not->toHaveKey('avatar');
+});
+
+it('keeps the previous seven argument constructor compatible', function (): void {
+    $credentials = DiscordOAuthAccessDTO::make([
+        'access_token' => 'test-access-token',
+        'refresh_token' => 'test-refresh-token',
+        'expires_in' => 604_800,
+    ]);
+
+    $user = new DiscordOAuthUser(
+        $credentials,
+        '123456789',
+        IdentityProvider::Discord,
+        'testuser',
+        'Test User',
+        email: null,
+        avatarUrl: null,
+    );
+
+    expect($user->toMetadata())->toBe([
+        'username' => 'testuser',
+        'global_name' => 'Test User',
+    ]);
 });
 
 it('generates correct redirect url', function (): void {

--- a/app-modules/integration-discord/tests/Feature/OAuth/DiscordOAuthClientTest.php
+++ b/app-modules/integration-discord/tests/Feature/OAuth/DiscordOAuthClientTest.php
@@ -61,7 +61,36 @@ it('gets authenticated user and returns DiscordOAuthUser', function (): void {
         ->and($result->username)->toBe('testuser')
         ->and($result->name)->toBe('Test User')
         ->and($result->email)->toBe('test@example.com')
-        ->and($result->providerId)->toBe('123456789');
+        ->and($result->providerId)->toBe('123456789')
+        ->and($result->toMetadata())->toBe([
+            'email' => 'test@example.com',
+            'avatar' => 'https://cdn.discordapp.com/avatars/123456789/abc123.png',
+            'username' => 'testuser',
+            'global_name' => 'Test User',
+        ]);
+});
+
+it('normalizes an authenticated Discord user without email or avatar', function (): void {
+    $credentials = DiscordOAuthAccessDTO::make([
+        'access_token' => 'test-access-token',
+        'refresh_token' => 'test-refresh-token',
+        'expires_in' => 604_800,
+    ]);
+
+    $user = DiscordOAuthUser::make($credentials, [
+        'id' => '123456789',
+        'username' => 'testuser',
+        'global_name' => null,
+        'avatar' => null,
+    ]);
+
+    expect($user->email)->toBeNull()
+        ->and($user->avatarUrl)->toBeNull()
+        ->and($user->toMetadata())->toBe([
+            'avatar' => null,
+            'username' => 'testuser',
+            'global_name' => 'testuser',
+        ]);
 });
 
 it('generates correct redirect url', function (): void {

--- a/app-modules/panel-app/tests/Feature/ConnectionHubTest.php
+++ b/app-modules/panel-app/tests/Feature/ConnectionHubTest.php
@@ -17,11 +17,34 @@ use He4rt\Identity\User\Models\User;
 use He4rt\IntegrationDiscord\OAuth\DiscordOAuthAccessDTO;
 use He4rt\IntegrationDiscord\OAuth\DiscordOAuthClient;
 use He4rt\IntegrationDiscord\OAuth\DiscordOAuthUser;
+use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
 use Livewire\Features\SupportLockedProperties\CannotUpdateLockedPropertyException;
 
 use function Pest\Livewire\livewire;
+
+/**
+ * @param  array<string, mixed>  $metadata
+ * @return array<string, mixed>
+ */
+function connectionHubOAuthMergePayload(
+    string $conflictingUserId,
+    string $providerId,
+    array $metadata = ['username' => 'oauth-user'],
+): array {
+    return [
+        'conflicting_user_id' => $conflictingUserId,
+        'provider' => IdentityProvider::Discord->value,
+        'provider_id' => $providerId,
+        'credentials' => [
+            'access_token' => Crypt::encrypt('access-token'),
+            'refresh_token' => Crypt::encrypt('refresh-token'),
+            'expires_in' => Crypt::encrypt('3600'),
+        ],
+        'metadata' => $metadata,
+    ];
+}
 
 test('merge confirmation modal exposes accessible dialog semantics', function (): void {
     $currentUser = User::factory()->create();
@@ -124,7 +147,8 @@ test('confirming an oauth merge connects the imported identity without losing it
 
     expect($sessionPayload['credentials']['access_token'])->not->toBe('discord-access-token')
         ->and($sessionPayload['credentials']['refresh_token'])->not->toBe('discord-refresh-token')
-        ->and($sessionPayload['credentials']['encrypted'])->toBeTrue();
+        ->and($sessionPayload)->not->toHaveKey('oauth_user')
+        ->and($sessionPayload['provider_id'])->toBe('49615312957476864');
 
     session()->put('oauth_merge_pending', $sessionPayload);
 
@@ -191,19 +215,11 @@ test('canceling an oauth merge leaves both accounts and the imported identity un
     ]);
 
     $this->actingAs($currentUser);
-    session()->put('oauth_merge_pending', [
-        'conflicting_user_id' => $importedUser->id,
-        'provider' => IdentityProvider::Discord->value,
-        'credentials' => [
-            'access_token' => 'unused-access-token',
-            'refresh_token' => 'unused-refresh-token',
-            'expires_in' => 3_600,
-        ],
-        'oauth_user' => [
-            'provider_id' => 'discord-cancel',
-            'metadata' => ['username' => 'unused-user'],
-        ],
-    ]);
+    session()->put('oauth_merge_pending', connectionHubOAuthMergePayload(
+        conflictingUserId: $importedUser->id,
+        providerId: 'discord-cancel',
+        metadata: ['username' => 'unused-user'],
+    ));
 
     livewire(ConnectionHub::class)->call('cancelMerge');
 
@@ -225,19 +241,11 @@ test('oauth merge aborts when the conflicting identity no longer belongs to the 
     $targetUser = User::factory()->create();
 
     $this->actingAs($currentUser);
-    session()->put('oauth_merge_pending', [
-        'conflicting_user_id' => $targetUser->id,
-        'provider' => IdentityProvider::Discord->value,
-        'credentials' => [
-            'access_token' => 'unused-access-token',
-            'refresh_token' => 'unused-refresh-token',
-            'expires_in' => 3_600,
-        ],
-        'oauth_user' => [
-            'provider_id' => 'missing-discord-identity',
-            'metadata' => ['username' => 'unused-user'],
-        ],
-    ]);
+    session()->put('oauth_merge_pending', connectionHubOAuthMergePayload(
+        conflictingUserId: $targetUser->id,
+        providerId: 'missing-discord-identity',
+        metadata: ['username' => 'unused-user'],
+    ));
 
     livewire(ConnectionHub::class)->call('confirmMerge');
 

--- a/app-modules/panel-app/tests/Feature/ConnectionHubTest.php
+++ b/app-modules/panel-app/tests/Feature/ConnectionHubTest.php
@@ -3,11 +3,23 @@
 declare(strict_types=1);
 
 use App\Livewire\ConnectionHub;
+use Filament\Facades\Filament;
+use He4rt\Identity\Auth\Actions\HandleOAuthCallbackAction;
+use He4rt\Identity\Auth\DTOs\MergeConflictDTO;
+use He4rt\Identity\Auth\DTOs\OAuthStateDTO;
+use He4rt\Identity\Auth\Enums\OAuthIntent;
+use He4rt\Identity\ExternalIdentity\Data\ClientAccessManager;
 use He4rt\Identity\ExternalIdentity\Enums\CredentialsType;
 use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
+use He4rt\Identity\ExternalIdentity\Events\ExternalIdentityConnected;
 use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
 use He4rt\Identity\User\Models\User;
+use He4rt\IntegrationDiscord\OAuth\DiscordOAuthAccessDTO;
+use He4rt\IntegrationDiscord\OAuth\DiscordOAuthClient;
+use He4rt\IntegrationDiscord\OAuth\DiscordOAuthUser;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
+use Livewire\Features\SupportLockedProperties\CannotUpdateLockedPropertyException;
 
 use function Pest\Livewire\livewire;
 
@@ -26,6 +38,228 @@ test('merge confirmation modal exposes accessible dialog semantics', function ()
         ->assertSeeHtml('role="dialog"')
         ->assertSeeHtml('aria-modal="true"')
         ->assertSeeHtml('@keydown.escape.window="$wire.cancelMerge()"');
+});
+
+test('confirming an oauth merge connects the imported identity without losing its data', function (): void {
+    Event::fake([ExternalIdentityConnected::class]);
+
+    $currentUser = User::factory()->create([
+        'username' => 'current-user',
+        'name' => 'Current User',
+        'email' => 'current@example.com',
+    ]);
+    $importedUser = User::factory()->create([
+        'username' => 'imported-user',
+        'name' => 'imported-user',
+        'email' => null,
+        'first_login_at' => null,
+    ]);
+    $importedIdentity = ExternalIdentity::factory()->create([
+        'model_type' => (new User)->getMorphClass(),
+        'model_id' => $importedUser->id,
+        'provider' => IdentityProvider::Discord,
+        'external_account_id' => '49615312957476864',
+        'credentials' => ClientAccessManager::make(),
+        'connected_at' => null,
+        'connected_by' => null,
+        'metadata' => [
+            'username' => 'imported-user',
+            'global_name' => 'Imported User',
+            'avatar' => 'profile-avatar',
+            'user' => [
+                'id' => '49615312957476864',
+                'username' => 'imported-user',
+                'global_name' => 'Imported User',
+                'avatar' => 'profile-avatar',
+                'public_flags' => 64,
+            ],
+            'badges' => [['id' => 'legacy_username']],
+        ],
+    ]);
+    $currentIdentity = ExternalIdentity::factory()->create([
+        'model_type' => (new User)->getMorphClass(),
+        'model_id' => $currentUser->id,
+        'provider' => IdentityProvider::GitHub,
+        'external_account_id' => 'github-123',
+    ]);
+
+    $access = DiscordOAuthAccessDTO::make([
+        'access_token' => 'discord-access-token',
+        'refresh_token' => 'discord-refresh-token',
+        'expires_in' => 3_600,
+    ]);
+    $oauthUser = DiscordOAuthUser::make($access, [
+        'id' => '49615312957476864',
+        'username' => 'oauth-user',
+        'global_name' => 'OAuth User',
+        'email' => 'discord@example.com',
+        'avatar' => null,
+    ]);
+    $client = Mockery::mock(DiscordOAuthClient::class);
+    $client->shouldReceive('auth')->once()->with('auth-code')->andReturn($access);
+    $client->shouldReceive('getAuthenticatedUser')->once()->with($access)->andReturn($oauthUser);
+    app()->instance(DiscordOAuthClient::class, $client);
+
+    $this->actingAs($currentUser);
+    Filament::setCurrentPanel(Filament::getPanel('app'));
+
+    $result = resolve(HandleOAuthCallbackAction::class)->execute(
+        new OAuthStateDTO(
+            intent: OAuthIntent::Link,
+            provider: IdentityProvider::Discord,
+            panel: 'app',
+            returnUrl: 'https://he4rt.test/app/profile',
+        ),
+        IdentityProvider::Discord,
+        'auth-code',
+    );
+
+    $mergeConflict = $result->mergeConflict;
+
+    expect($mergeConflict)->toBeInstanceOf(MergeConflictDTO::class);
+
+    throw_unless($mergeConflict instanceof MergeConflictDTO, RuntimeException::class, 'Expected an OAuth merge conflict.');
+
+    $sessionPayload = $mergeConflict->toSession();
+
+    expect($sessionPayload['credentials']['access_token'])->not->toBe('discord-access-token')
+        ->and($sessionPayload['credentials']['refresh_token'])->not->toBe('discord-refresh-token')
+        ->and($sessionPayload['credentials']['encrypted'])->toBeTrue();
+
+    session()->put('oauth_merge_pending', $sessionPayload);
+
+    livewire(ConnectionHub::class)
+        ->assertSet('showMergeModal', value: true)
+        ->assertSet('mergeTargetId', $importedUser->id)
+        ->assertDontSee('discord-access-token')
+        ->assertDontSee('discord-refresh-token')
+        ->call('confirmMerge')
+        ->assertSet('showMergeModal', value: false)
+        ->assertNotified();
+
+    $importedIdentity->refresh();
+    $currentIdentity->refresh();
+
+    expect($importedIdentity->model_id)->toBe($importedUser->id)
+        ->and($importedIdentity->credentials->getAccessToken())->toBe('discord-access-token')
+        ->and($importedIdentity->credentials->getRefreshToken())->toBe('discord-refresh-token')
+        ->and($importedIdentity->credentials->getExpiresIn())->toBe(3_600)
+        ->and($importedIdentity->connected_at)->not->toBeNull()
+        ->and($importedIdentity->disconnected_at)->toBeNull()
+        ->and($importedIdentity->connected_by)->toBe($importedUser->id)
+        ->and($importedIdentity->metadata)->toMatchArray([
+            'username' => 'oauth-user',
+            'global_name' => 'OAuth User',
+            'email' => 'discord@example.com',
+            'avatar' => null,
+            'user' => [
+                'id' => '49615312957476864',
+                'username' => 'imported-user',
+                'global_name' => 'Imported User',
+                'avatar' => 'profile-avatar',
+                'public_flags' => 64,
+            ],
+            'badges' => [['id' => 'legacy_username']],
+        ])
+        ->and($currentIdentity->model_id)->toBe($importedUser->id)
+        ->and(User::query()->find($currentUser->id))->toBeNull()
+        ->and(auth()->id())->toBe($importedUser->id)
+        ->and(session()->has('oauth_merge_pending'))->toBeFalse()
+        ->and(ExternalIdentity::query()
+            ->where('provider', IdentityProvider::Discord)
+            ->where('external_account_id', '49615312957476864')
+            ->count())->toBe(1);
+
+    Event::assertDispatched(
+        fn (ExternalIdentityConnected $event): bool => $event->identity->is($importedIdentity),
+    );
+});
+
+test('canceling an oauth merge leaves both accounts and the imported identity untouched', function (): void {
+    Event::fake([ExternalIdentityConnected::class]);
+
+    $currentUser = User::factory()->create();
+    $importedUser = User::factory()->create();
+    $identity = ExternalIdentity::factory()->create([
+        'model_type' => (new User)->getMorphClass(),
+        'model_id' => $importedUser->id,
+        'provider' => IdentityProvider::Discord,
+        'external_account_id' => 'discord-cancel',
+        'credentials' => ClientAccessManager::make(),
+        'connected_at' => null,
+        'metadata' => ['username' => 'preserved-user'],
+    ]);
+
+    $this->actingAs($currentUser);
+    session()->put('oauth_merge_pending', [
+        'conflicting_user_id' => $importedUser->id,
+        'provider' => IdentityProvider::Discord->value,
+        'credentials' => [
+            'access_token' => 'unused-access-token',
+            'refresh_token' => 'unused-refresh-token',
+            'expires_in' => 3_600,
+        ],
+        'oauth_user' => [
+            'provider_id' => 'discord-cancel',
+            'metadata' => ['username' => 'unused-user'],
+        ],
+    ]);
+
+    livewire(ConnectionHub::class)->call('cancelMerge');
+
+    $identity->refresh();
+
+    expect(User::query()->find($currentUser->id))->not->toBeNull()
+        ->and(User::query()->find($importedUser->id))->not->toBeNull()
+        ->and($identity->model_id)->toBe($importedUser->id)
+        ->and($identity->metadata)->toBe(['username' => 'preserved-user'])
+        ->and($identity->credentials->getAccessToken())->toBeNull()
+        ->and($identity->connected_at)->toBeNull()
+        ->and(session()->has('oauth_merge_pending'))->toBeFalse();
+
+    Event::assertNotDispatched(ExternalIdentityConnected::class);
+});
+
+test('oauth merge aborts when the conflicting identity no longer belongs to the target user', function (): void {
+    $currentUser = User::factory()->create();
+    $targetUser = User::factory()->create();
+
+    $this->actingAs($currentUser);
+    session()->put('oauth_merge_pending', [
+        'conflicting_user_id' => $targetUser->id,
+        'provider' => IdentityProvider::Discord->value,
+        'credentials' => [
+            'access_token' => 'unused-access-token',
+            'refresh_token' => 'unused-refresh-token',
+            'expires_in' => 3_600,
+        ],
+        'oauth_user' => [
+            'provider_id' => 'missing-discord-identity',
+            'metadata' => ['username' => 'unused-user'],
+        ],
+    ]);
+
+    livewire(ConnectionHub::class)->call('confirmMerge');
+
+    expect(User::query()->find($currentUser->id))->not->toBeNull()
+        ->and(User::query()->find($targetUser->id))->not->toBeNull()
+        ->and(auth()->id())->toBe($currentUser->id)
+        ->and(session()->has('oauth_merge_pending'))->toBeFalse();
+});
+
+test('oauth merge payload cannot be changed through livewire state', function (): void {
+    $currentUser = User::factory()->create();
+    $targetUser = User::factory()->create();
+    $otherUser = User::factory()->create();
+
+    $this->actingAs($currentUser);
+    session()->put('oauth_merge_pending', [
+        'conflicting_user_id' => $targetUser->id,
+    ]);
+
+    expect(fn () => livewire(ConnectionHub::class)
+        ->set('mergeTargetId', $otherUser->id))
+        ->toThrow(CannotUpdateLockedPropertyException::class);
 });
 
 test('an api key provider opens the modal instead of redirecting', function (): void {

--- a/app/Livewire/ConnectionHub.php
+++ b/app/Livewire/ConnectionHub.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace App\Livewire;
 
 use Filament\Notifications\Notification;
-use He4rt\Identity\Auth\Actions\MergeAccountsAction;
+use He4rt\Identity\Auth\Actions\ConfirmOAuthMerge;
+use He4rt\Identity\Auth\DTOs\PendingOAuthMergeDTO;
 use He4rt\Identity\ExternalIdentity\Actions\ConnectApiKeyIdentity;
 use He4rt\Identity\ExternalIdentity\Enums\CredentialsType;
 use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
@@ -15,6 +16,7 @@ use He4rt\Identity\User\Models\User;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Auth;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\Validate;
 use Livewire\Component;
 
@@ -24,8 +26,8 @@ class ConnectionHub extends Component
 
     public bool $showMergeModal = false;
 
-    /** @var array<string, mixed>|null */
-    public ?array $mergeData = null;
+    #[Locked]
+    public ?string $mergeTargetId = null;
 
     public bool $showApiKeyModal = false;
 
@@ -114,15 +116,17 @@ class ConnectionHub extends Component
         $this->resetValidation();
     }
 
-    public function confirmMerge(MergeAccountsAction $action): void
+    public function confirmMerge(ConfirmOAuthMerge $action): void
     {
-        if ($this->mergeData === null) {
+        $sessionPayload = session()->get('oauth_merge_pending');
+
+        if (!is_array($sessionPayload)) {
             return;
         }
 
-        $oldUser = User::query()->find($this->mergeData['conflicting_user_id']);
+        $pending = PendingOAuthMergeDTO::fromSession($sessionPayload);
 
-        if (!$oldUser instanceof User) {
+        if (!$pending instanceof PendingOAuthMergeDTO) {
             $this->cancelMerge();
 
             return;
@@ -131,11 +135,17 @@ class ConnectionHub extends Component
         /** @var User $currentUser */
         $currentUser = auth()->user();
 
-        $action->execute($currentUser, $oldUser);
+        $oldUser = $action->execute($currentUser, $pending);
+
+        if (!$oldUser instanceof User) {
+            $this->cancelMerge();
+
+            return;
+        }
 
         session()->forget('oauth_merge_pending');
         $this->showMergeModal = false;
-        $this->mergeData = null;
+        $this->mergeTargetId = null;
 
         Auth::login($oldUser);
 
@@ -151,7 +161,7 @@ class ConnectionHub extends Component
     {
         session()->forget('oauth_merge_pending');
         $this->showMergeModal = false;
-        $this->mergeData = null;
+        $this->mergeTargetId = null;
     }
 
     public function disconnect(IdentityProvider $provider): void
@@ -209,11 +219,11 @@ class ConnectionHub extends Component
     {
         $pending = session()->get('oauth_merge_pending');
 
-        if ($pending === null) {
+        if (!is_array($pending) || !is_string($pending['conflicting_user_id'] ?? null)) {
             return;
         }
 
-        $this->mergeData = $pending;
+        $this->mergeTargetId = $pending['conflicting_user_id'];
         $this->showMergeModal = true;
     }
 
@@ -222,11 +232,11 @@ class ConnectionHub extends Component
      */
     private function getMergeTarget(): ?array
     {
-        if ($this->mergeData === null) {
+        if ($this->mergeTargetId === null) {
             return null;
         }
 
-        $user = User::query()->find($this->mergeData['conflicting_user_id']);
+        $user = User::query()->find($this->mergeTargetId);
 
         if (!$user instanceof User) {
             return null;

--- a/app/Livewire/ConnectionHub.php
+++ b/app/Livewire/ConnectionHub.php
@@ -6,6 +6,7 @@ namespace App\Livewire;
 
 use Filament\Notifications\Notification;
 use He4rt\Identity\Auth\Actions\ConfirmOAuthMerge;
+use He4rt\Identity\Auth\Actions\ResolvePendingOAuthMerge;
 use He4rt\Identity\Auth\DTOs\PendingOAuthMergeDTO;
 use He4rt\Identity\ExternalIdentity\Actions\ConnectApiKeyIdentity;
 use He4rt\Identity\ExternalIdentity\Enums\CredentialsType;
@@ -116,15 +117,11 @@ class ConnectionHub extends Component
         $this->resetValidation();
     }
 
-    public function confirmMerge(ConfirmOAuthMerge $action): void
-    {
-        $sessionPayload = session()->get('oauth_merge_pending');
-
-        if (!is_array($sessionPayload)) {
-            return;
-        }
-
-        $pending = PendingOAuthMergeDTO::fromSession($sessionPayload);
+    public function confirmMerge(
+        ConfirmOAuthMerge $action,
+        ResolvePendingOAuthMerge $resolvePendingMerge,
+    ): void {
+        $pending = $resolvePendingMerge->execute(session()->get('oauth_merge_pending'));
 
         if (!$pending instanceof PendingOAuthMergeDTO) {
             $this->cancelMerge();

--- a/tests/Feature/ConnectionHubMergeModalTest.php
+++ b/tests/Feature/ConnectionHubMergeModalTest.php
@@ -32,13 +32,11 @@ test('connection hub merge modal explains which account is kept and absorbed', f
     session()->put('oauth_merge_pending', [
         'conflicting_user_id' => $keptUser->id,
         'provider' => IdentityProvider::Discord->value,
+        'provider_id' => 'discord-123',
         'credentials' => [],
-        'oauth_user' => [
-            'provider_id' => 'discord-123',
+        'metadata' => [
             'username' => 'discord-user',
-            'name' => 'Discord User',
-            'email' => null,
-            'avatar_url' => null,
+            'global_name' => 'Discord User',
         ],
     ]);
 


### PR DESCRIPTION
## Contexto

As identidades do Discord podem ser criadas pelo OAuth, pela importação de perfis, pela importação de mensagens e pelos eventos ao vivo do bot. Cada fluxo gravava um formato diferente em `metadata`, e os updates substituíam o conteúdo inteiro.

Na prática, importar um perfil depois do OAuth apagava email, tokens e a data real da conexão. Executar o OAuth depois da importação removia o snapshot com `user`, `badges` e `guild_member`. A data de entrada no servidor também era usada como se fosse a data de autenticação.

Também existia uma lacuna quando o OAuth encontrava uma identidade criada pela ingestão em outra conta. A confirmação do modal unificava os usuários, mas descartava as credenciais e os dados OAuth recebidos no callback.

## Alterações

- adiciona `DiscordIdentityMetadata` como normalizador único dos dados públicos do Discord
- mantém `username`, `global_name` e `avatar` em uma estrutura canônica na raiz sem remover os payloads `user` e `author`
- faz o OAuth mesclar metadata e atualizar somente credenciais e estado da conexão
- impede as importações de perfil e mensagem de alterar credenciais, `connected_at`, `connected_by` ou o dono da identidade
- preserva credenciais e conexão de contas vinculadas, como Twitch e GitHub, durante a importação do perfil do Discord
- preenche campos canônicos ausentes em identidades antigas quando novas mensagens forem importadas
- deixa identidades criadas por ingestão desconectadas até existir uma autenticação real
- trata usuários do Discord sem email ou avatar
- conclui a conexão OAuth depois da confirmação de unificação, preservando o mesmo registro e o histórico importado
- executa unificação e conexão na mesma transação e desfaz tudo se alguma etapa falhar
- valida novamente a identidade conflitante no servidor e bloqueia os registros durante a confirmação
- mantém tokens criptografados na sessão e envia ao Livewire somente o ID necessário para mostrar o modal

Não é necessária migration. Os formatos antigos continuam compatíveis e são normalizados gradualmente pelas próximas importações. Sessões de unificação criadas antes deste ajuste também continuam aceitas.

---

## Plano de Testes

- [x] `vendor/bin/pint --dirty`
- [x] `vendor/bin/rector process app/Livewire/ConnectionHub.php app-modules/identity/src/Auth app-modules/integration-discord/src --dry-run`
- [x] `vendor/bin/phpstan analyse app/Livewire/ConnectionHub.php app-modules/identity/src/Auth app-modules/integration-discord/src --ansi --memory-limit=2G` com 0 erros
- [x] suítes de identidade, painel e fluxos Discord afetados com 249 testes e 1.141 assertions
- [x] confirmação completa do callback até o modal, incluindo tokens, metadata, proprietário, histórico e login final
- [x] cancelamento, payload inválido, conflito expirado, alteração do estado Livewire e rollback atômico
- [ ] `MergeDuplicateDiscordProfilesTest` possui 2 falhas preexistentes no Windows porque o comando trata caminhos absolutos `C:\...` como relativos. O arquivo e o comando não foram alterados neste PR

---

## Issues Relacionadas

Closes #479