### PR TITLE
feat(activity): analytics de conversas e refino visual do deck da retrô

### DIFF
--- a/app-modules/activity/src/Retrospective/DiscordSource.php
+++ b/app-modules/activity/src/Retrospective/DiscordSource.php
@@ -75,10 +75,11 @@ final class DiscordSource implements CuratableSource, MeasuresPerson, Retrospect
 
     public function collect(Period $period, SourceFilters $filters): SourceResult
     {
-        $totalMessages = $this->messages($period, $filters)->count();
-        $withReactions = $this->messages($period, $filters)->where('reactions_total', '>', 0)->count();
-        $pinned = $this->messages($period, $filters)->where('is_pinned', operator: true)->count();
+        $messageTotals = $this->messageTotals($period, $filters);
         $chatters = $this->topChatters($period, $filters);
+        $messageDays = $this->messagesByWeekday($period, $filters);
+        $messageHours = $this->messagesByHour($period, $filters);
+        $messagePeak = $this->peakMessageDay($period, $filters);
 
         $voiceTotals = $this->voiceTotals($period, $filters);
         $participants = $voiceTotals['participants'];
@@ -101,17 +102,18 @@ final class DiscordSource implements CuratableSource, MeasuresPerson, Retrospect
         return new SourceResult(
             key: $this->key(),
             label: $this->label(),
-            headline: $this->headline($totalMessages, $participants, $joins, $totalReactions),
+            headline: $this->headline($messageTotals['total'], $participants, $joins, $totalReactions),
             slides: $this->slides(
                 voiceTotals: $voiceTotals,
                 channels: $channels,
                 voicePeople: $voicePeople,
                 voiceHours: $voiceHours,
                 voicePeak: $voicePeak,
-                totalMessages: $totalMessages,
-                withReactions: $withReactions,
-                pinned: $pinned,
+                messageTotals: $messageTotals,
+                messagePeak: $messagePeak,
                 chatters: $chatters,
+                messageDays: $messageDays,
+                messageHours: $messageHours,
                 joins: $joins,
                 boosts: $boosts,
                 totalReactions: $totalReactions,
@@ -258,7 +260,11 @@ final class DiscordSource implements CuratableSource, MeasuresPerson, Retrospect
      * @param  list<array{name: string, xp: int, joins: int, channels: int}>  $voicePeople
      * @param  list<array{hour: int, joins: int}>  $voiceHours
      * @param  array{date: string, joins: int}|null  $voicePeak
-     * @param  list<array{name: string, messages: int}>  $chatters
+     * @param  array{total: int, with_reactions: int, pinned: int, people: int}  $messageTotals
+     * @param  array{date: string, messages: int}|null  $messagePeak
+     * @param  list<array{name: string, messages: int, xp: int, reactions: int}>  $chatters
+     * @param  list<array{weekday: int, messages: int}>  $messageDays
+     * @param  list<array{hour: int, messages: int}>  $messageHours
      * @param  list<array{name: string, count: int, custom: bool}>  $emojis
      * @param  list<array{content: string, author: string, reactions: int}>  $topMessages
      * @return list<Slide>
@@ -269,10 +275,11 @@ final class DiscordSource implements CuratableSource, MeasuresPerson, Retrospect
         array $voicePeople,
         array $voiceHours,
         ?array $voicePeak,
-        int $totalMessages,
-        int $withReactions,
-        int $pinned,
+        array $messageTotals,
+        ?array $messagePeak,
         array $chatters,
+        array $messageDays,
+        array $messageHours,
         int $joins,
         int $boosts,
         int $totalReactions,
@@ -294,8 +301,17 @@ final class DiscordSource implements CuratableSource, MeasuresPerson, Retrospect
             );
         }
 
-        if ($totalMessages > 0) {
-            $slides[] = new MessagesSlide($totalMessages, $withReactions, $pinned, $chatters);
+        if ($messageTotals['total'] > 0) {
+            $slides[] = new MessagesSlide(
+                total: $messageTotals['total'],
+                withReactions: $messageTotals['with_reactions'],
+                pinned: $messageTotals['pinned'],
+                people: $messageTotals['people'],
+                peak: $messagePeak,
+                chatters: $chatters,
+                days: $messageDays,
+                hours: $messageHours,
+            );
         }
 
         if ($joins > 0 || $boosts > 0) {
@@ -429,7 +445,110 @@ final class DiscordSource implements CuratableSource, MeasuresPerson, Retrospect
     }
 
     /**
-     * @return list<array{name: string, messages: int}>
+     * Números do topo do painel de conversas numa passada só — mesmo argumento
+     * do voiceTotals(): messages é a maior tabela do banco e cada agregado a
+     * mais seria outra varredura do mesmo recorte.
+     *
+     * @return array{total: int, with_reactions: int, pinned: int, people: int}
+     */
+    private function messageTotals(Period $period, SourceFilters $filters): array
+    {
+        $row = $this->messages($period, $filters)
+            ->toBase()
+            ->selectRaw('COUNT(*) AS total')
+            ->selectRaw('COUNT(*) FILTER (WHERE reactions_total > 0) AS with_reactions')
+            ->selectRaw('COUNT(*) FILTER (WHERE is_pinned) AS pinned')
+            ->selectRaw('COUNT(DISTINCT external_identity_id) AS people')
+            ->first();
+
+        return [
+            'total' => $this->countOf($row?->total),
+            'with_reactions' => $this->countOf($row?->with_reactions),
+            'pinned' => $this->countOf($row?->pinned),
+            'people' => $this->countOf($row?->people),
+        ];
+    }
+
+    /**
+     * O dia mais falante do recorte, agrupado no fuso de exibição — ver
+     * peakVoiceDay() para o porquê do fuso e do GROUP BY posicional.
+     *
+     * @return array{date: string, messages: int}|null
+     */
+    private function peakMessageDay(Period $period, SourceFilters $filters): ?array
+    {
+        $row = $this->messages($period, $filters)
+            ->toBase()
+            ->selectRaw('(sent_at AT TIME ZONE ?)::date AS day', [$this->displayTimezone()])
+            ->selectRaw('COUNT(*) AS messages')
+            ->groupByRaw('1')
+            ->orderByRaw('2 DESC')
+            ->first();
+
+        $messages = $this->countOf($row?->messages);
+        $day = $row?->day;
+
+        if ($messages === 0 || (!is_string($day) && !$day instanceof DateTimeInterface)) {
+            return null;
+        }
+
+        return [
+            'date' => CarbonImmutable::parse($day)->format('d/m'),
+            'messages' => $messages,
+        ];
+    }
+
+    /**
+     * Mensagens por dia da semana, no fuso de exibição, com as 7 posições
+     * sempre presentes (ISO: 1 = segunda) — dia sem papo é uma barra zerada,
+     * não uma barra ausente.
+     *
+     * @return list<array{weekday: int, messages: int}>
+     */
+    private function messagesByWeekday(Period $period, SourceFilters $filters): array
+    {
+        $counts = $this->messages($period, $filters)
+            ->toBase()
+            ->selectRaw('EXTRACT(ISODOW FROM sent_at AT TIME ZONE ?)::int AS weekday', [$this->displayTimezone()])
+            ->selectRaw('COUNT(*) AS messages')
+            // Ver peakVoiceDay(): agrupar pela posição evita o segundo placeholder.
+            ->groupByRaw('1')
+            ->pluck('messages', 'weekday');
+
+        return array_map(
+            static fn (int $weekday): array => ['weekday' => $weekday, 'messages' => (int) ($counts[$weekday] ?? 0)],
+            range(1, 7),
+        );
+    }
+
+    /**
+     * Mensagens por hora do dia, no fuso de exibição, com as 24 posições sempre
+     * presentes — o histograma é irmão do voiceByHour().
+     *
+     * @return list<array{hour: int, messages: int}>
+     */
+    private function messagesByHour(Period $period, SourceFilters $filters): array
+    {
+        $counts = $this->messages($period, $filters)
+            ->toBase()
+            ->selectRaw('EXTRACT(HOUR FROM sent_at AT TIME ZONE ?)::int AS hour', [$this->displayTimezone()])
+            ->selectRaw('COUNT(*) AS messages')
+            // Ver peakVoiceDay(): agrupar pela posição evita o segundo placeholder.
+            ->groupByRaw('1')
+            ->pluck('messages', 'hour');
+
+        return array_map(
+            static fn (int $hour): array => ['hour' => $hour, 'messages' => (int) ($counts[$hour] ?? 0)],
+            range(0, 23),
+        );
+    }
+
+    /**
+     * Quem mais conversou: mensagens, XP tirado delas e quanta reação o que a
+     * pessoa escreveu puxou. Só o topo resolve nome (uma query a mais para 8
+     * linhas).
+     *
+     * @return list<array{name: string, messages: int, xp: int, reactions: int}>
      */
     private function topChatters(Period $period, SourceFilters $filters): array
     {
@@ -437,7 +556,12 @@ final class DiscordSource implements CuratableSource, MeasuresPerson, Retrospect
             ->groupBy('external_identity_id')
             ->orderByRaw('COUNT(*) DESC')
             ->limit(8)
-            ->get(['external_identity_id', DB::raw('COUNT(*) AS messages')]);
+            ->get([
+                'external_identity_id',
+                DB::raw('COUNT(*) AS messages'),
+                DB::raw('COALESCE(SUM(obtained_experience), 0) AS xp'),
+                DB::raw('COALESCE(SUM(reactions_total), 0) AS reactions'),
+            ]);
 
         $names = $this->displayNames($this->identityIds($rows));
 
@@ -445,6 +569,8 @@ final class DiscordSource implements CuratableSource, MeasuresPerson, Retrospect
             $rows->map(fn (Message $row): array => [
                 'name' => $names[$row->external_identity_id] ?? 'Anônimo',
                 'messages' => (int) $row->getAttribute('messages'),
+                'xp' => (int) $row->getAttribute('xp'),
+                'reactions' => (int) $row->getAttribute('reactions'),
             ])->all(),
         );
     }

--- a/app-modules/activity/src/Retrospective/Slides/MessagesSlide.php
+++ b/app-modules/activity/src/Retrospective/Slides/MessagesSlide.php
@@ -7,20 +7,28 @@ namespace He4rt\Activity\Retrospective\Slides;
 use He4rt\Community\Retrospective\Contracts\Slide;
 
 /**
- * Panorama de mensagens: total no recorte, quantas renderam reação, quantas
- * foram fixadas, e o topo de quem mais conversou (nome resolvido em PHP só para
- * as N pessoas do ranking).
+ * Painel de conversas, o irmão de texto do VoiceBoardSlide: os totais do
+ * recorte, o ritmo da semana, quem mais conversou (nome resolvido em PHP só
+ * para as N pessoas do ranking) e o histograma de mensagens por hora.
  */
 final readonly class MessagesSlide implements Slide
 {
     /**
-     * @param  list<array{name: string, messages: int}>  $chatters
+     * @param  int  $people  pessoas distintas que mandaram mensagem
+     * @param  array{date: string, messages: int}|null  $peak  o dia mais falante
+     * @param  list<array{name: string, messages: int, xp: int, reactions: int}>  $chatters
+     * @param  list<array{weekday: int, messages: int}>  $days  sempre as 7 posições (ISO: 1 = segunda)
+     * @param  list<array{hour: int, messages: int}>  $hours  sempre as 24 posições
      */
     public function __construct(
         private int $total,
         private int $withReactions,
         private int $pinned,
+        private int $people,
+        private ?array $peak,
         private array $chatters,
+        private array $days,
+        private array $hours,
     ) {}
 
     public function kind(): string
@@ -29,7 +37,16 @@ final readonly class MessagesSlide implements Slide
     }
 
     /**
-     * @return array{total: int, with_reactions: int, pinned: int, chatters: list<array{name: string, messages: int}>}
+     * @return array{
+     *     total: int,
+     *     with_reactions: int,
+     *     pinned: int,
+     *     people: int,
+     *     peak: array{date: string, messages: int}|null,
+     *     chatters: list<array{name: string, messages: int, xp: int, reactions: int}>,
+     *     days: list<array{weekday: int, messages: int}>,
+     *     hours: list<array{hour: int, messages: int}>,
+     * }
      */
     public function toArray(): array
     {
@@ -37,7 +54,11 @@ final readonly class MessagesSlide implements Slide
             'total' => $this->total,
             'with_reactions' => $this->withReactions,
             'pinned' => $this->pinned,
+            'people' => $this->people,
+            'peak' => $this->peak,
             'chatters' => $this->chatters,
+            'days' => $this->days,
+            'hours' => $this->hours,
         ];
     }
 }

--- a/app-modules/activity/tests/Feature/Retrospective/DiscordSourceTest.php
+++ b/app-modules/activity/tests/Feature/Retrospective/DiscordSourceTest.php
@@ -127,6 +127,58 @@ it('destaca mensagens com reação e fixadas, e a mais reagida', function (): vo
         ->and($topMessage['messages'][0]['content'])->toBe('mensagem campeã');
 });
 
+it('conta as pessoas do papo e aponta o dia mais falante', function (): void {
+    $alice = dcIdentity('Alice');
+    $bob = dcIdentity('Bob');
+
+    Message::factory()->create(['external_identity_id' => $alice->id, 'sent_at' => '2026-06-02 15:00:00']);
+    Message::factory()->count(3)->create(['external_identity_id' => $bob->id, 'sent_at' => '2026-06-04 15:00:00']);
+
+    $messages = dcSlide(($this->collect)(), 'discord.messages');
+
+    expect($messages['people'])->toBe(2)
+        ->and($messages['peak'])->toMatchArray(['date' => '04/06', 'messages' => 3]);
+});
+
+it('devolve o ritmo da semana com as 7 posições, no fuso de exibição', function (): void {
+    $alice = dcIdentity('Alice');
+
+    // 15h UTC = 12h em São Paulo: terça segue terça (ISO 2).
+    Message::factory()->count(2)->create(['external_identity_id' => $alice->id, 'sent_at' => '2026-06-02 15:00:00']);
+    // 1h UTC da terça = 22h de segunda em São Paulo (ISO 1).
+    Message::factory()->create(['external_identity_id' => $alice->id, 'sent_at' => '2026-06-02 01:00:00']);
+
+    $messages = dcSlide(($this->collect)(), 'discord.messages');
+
+    expect($messages['days'])->toHaveCount(7)
+        ->and(array_column($messages['days'], 'weekday'))->toBe(range(1, 7))
+        ->and($messages['days'][0])->toMatchArray(['weekday' => 1, 'messages' => 1])
+        ->and($messages['days'][1])->toMatchArray(['weekday' => 2, 'messages' => 2]);
+});
+
+it('devolve as 24 horas do histograma de mensagens, inclusive as vazias', function (): void {
+    $alice = dcIdentity('Alice');
+
+    Message::factory()->create(['external_identity_id' => $alice->id, 'sent_at' => '2026-06-02 15:00:00']);
+
+    $messages = dcSlide(($this->collect)(), 'discord.messages');
+
+    expect($messages['hours'])->toHaveCount(24)
+        ->and(array_column($messages['hours'], 'hour'))->toBe(range(0, 23))
+        ->and(array_sum(array_column($messages['hours'], 'messages')))->toBe(1);
+});
+
+it('rankeia chatters com o XP e as reações que as mensagens puxaram', function (): void {
+    $alice = dcIdentity('Alice');
+
+    Message::factory()->create(['external_identity_id' => $alice->id, 'sent_at' => '2026-06-02', 'obtained_experience' => 10, 'reactions_total' => 3]);
+    Message::factory()->create(['external_identity_id' => $alice->id, 'sent_at' => '2026-06-03', 'obtained_experience' => 20, 'reactions_total' => 0]);
+
+    $messages = dcSlide(($this->collect)(), 'discord.messages');
+
+    expect($messages['chatters'][0])->toMatchArray(['name' => 'Alice', 'messages' => 2, 'xp' => 30, 'reactions' => 3]);
+});
+
 it('agrega o board de voz por participantes, XP e canais', function (): void {
     $alice = dcIdentity('Alice');
     $bob = dcIdentity('Bob');

--- a/app-modules/community/src/Retrospective/Actions/ComposePromotions.php
+++ b/app-modules/community/src/Retrospective/Actions/ComposePromotions.php
@@ -76,6 +76,7 @@ final readonly class ComposePromotions
                 stage: $entry->stage,
                 reason: $entry->reason,
                 groups: $this->groups($person, $period, $filters),
+                memberSince: $person->memberSince,
             );
         }
 

--- a/app-modules/community/src/Retrospective/Actions/ResolvePeople.php
+++ b/app-modules/community/src/Retrospective/Actions/ResolvePeople.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace He4rt\Community\Retrospective\Actions;
 
+use Carbon\CarbonImmutable;
+use Carbon\CarbonInterface;
+use He4rt\Community\Retrospective\Contracts\MembershipDates;
 use He4rt\Community\Retrospective\Contracts\PersonDirectory;
 use He4rt\Community\Retrospective\DTOs\PersonAccount;
 use He4rt\Community\Retrospective\DTOs\PersonIdentity;
+use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
 use He4rt\Identity\User\Models\User;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -23,6 +27,8 @@ use Illuminate\Database\Eloquent\Relations\Relation;
  */
 final readonly class ResolvePeople implements PersonDirectory
 {
+    public function __construct(private MembershipDates $membershipDates) {}
+
     /**
      * @param  list<string>  $userIds
      * @return array<string, PersonIdentity> id do usuário => pessoa
@@ -43,10 +49,17 @@ final readonly class ResolvePeople implements PersonDirectory
             ->whereIn('id', array_values(array_unique($userIds)))
             ->get();
 
+        $accountsByUser = [];
+
+        foreach ($users as $user) {
+            $accountsByUser[$user->id] = $this->accounts($user);
+        }
+
+        $joinedAt = $this->joinedAt($accountsByUser);
         $people = [];
 
         foreach ($users as $user) {
-            $accounts = $this->accounts($user);
+            $accounts = $accountsByUser[$user->id];
 
             $people[$user->id] = new PersonIdentity(
                 userId: $user->id,
@@ -54,6 +67,7 @@ final readonly class ResolvePeople implements PersonDirectory
                 username: $user->username,
                 avatar: $this->avatar($user, $accounts),
                 accounts: $accounts,
+                memberSince: $this->memberSince($user, $accounts, $joinedAt),
             );
         }
 
@@ -85,30 +99,89 @@ final readonly class ResolvePeople implements PersonDirectory
     }
 
     /**
-     * Cascata do mais próprio para o mais genérico: a foto que a pessoa subiu
-     * aqui, depois a das plataformas, e só então o fallback pelo username.
+     * GitHub primeiro, Discord depois, o do sistema por último.
      *
-     * O fallback é o último a entrar de propósito — `getFilamentAvatarUrl()` monta
-     * a URL do GitHub com o username DO SITE, que na maioria das contas não existe
-     * lá e devolve a imagem de erro.
+     * A URL `github.com/{username}.png` usa o username da conta VINCULADA, então
+     * sempre resolve para a foto real — diferente do fallback final, que monta a
+     * mesma URL com o username do site e costuma devolver a imagem de erro.
      *
      * @param  array<string, PersonAccount>  $accounts
      */
     private function avatar(User $user, array $accounts): string
     {
+        $github = $accounts[IdentityProvider::GitHub->value] ?? null;
+
+        if ($github?->username !== null) {
+            return sprintf('https://github.com/%s.png', $github->username);
+        }
+
+        $discord = $accounts[IdentityProvider::Discord->value] ?? null;
+
+        if ($discord?->avatar !== null && $discord->avatar !== '') {
+            return $discord->avatar;
+        }
+
         $uploaded = $user->getFirstMediaUrl('avatar');
 
         if ($uploaded !== '') {
             return $uploaded;
         }
 
-        foreach ($accounts as $account) {
-            if ($account->avatar !== null && $account->avatar !== '') {
-                return $account->avatar;
+        return sprintf('https://github.com/%s.png', $user->username);
+    }
+
+    /**
+     * Desde quando a pessoa está na comunidade: o que vier PRIMEIRO entre entrar
+     * no servidor do Discord e criar a conta no site. A conta do site costuma vir
+     * anos depois da chegada, então sem a data do Discord o "desde" mentiria.
+     *
+     * @param  array<string, PersonAccount>  $accounts
+     * @param  array<string, CarbonImmutable>  $joinedAt  id da identidade => entrada no Discord
+     */
+    private function memberSince(User $user, array $accounts, array $joinedAt): ?CarbonImmutable
+    {
+        $dates = [];
+
+        if ($user->created_at instanceof CarbonInterface) {
+            $dates[] = $user->created_at->toImmutable();
+        }
+
+        $discord = $accounts[IdentityProvider::Discord->value] ?? null;
+
+        if ($discord !== null && isset($joinedAt[$discord->identityId])) {
+            $dates[] = $joinedAt[$discord->identityId];
+        }
+
+        if ($dates === []) {
+            return null;
+        }
+
+        usort($dates, static fn (CarbonImmutable $a, CarbonImmutable $b): int => $a <=> $b);
+
+        return $dates[0];
+    }
+
+    /**
+     * Uma ida só à integração para o lote inteiro, pelo mesmo motivo do
+     * carregamento dos usuários: são poucos cartões, mas perguntar pessoa a
+     * pessoa custaria uma query por cartão.
+     *
+     * @param  array<string, array<string, PersonAccount>>  $accountsByUser
+     * @return array<string, CarbonImmutable>
+     */
+    private function joinedAt(array $accountsByUser): array
+    {
+        $identityIds = [];
+
+        foreach ($accountsByUser as $accounts) {
+            $discord = $accounts[IdentityProvider::Discord->value] ?? null;
+
+            if ($discord !== null) {
+                $identityIds[] = $discord->identityId;
             }
         }
 
-        return sprintf('https://github.com/%s.png', $user->username);
+        return $this->membershipDates->execute($identityIds);
     }
 
     private function stringOrNull(mixed $value): ?string

--- a/app-modules/community/src/Retrospective/Contracts/MembershipDates.php
+++ b/app-modules/community/src/Retrospective/Contracts/MembershipDates.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Community\Retrospective\Contracts;
+
+use Carbon\CarbonImmutable;
+
+/**
+ * Quem sabe dizer quando cada conta chegou à comunidade na plataforma dela.
+ *
+ * É contrato pelo mesmo motivo do PersonDirectory: a data de entrada mora num
+ * modelo de integração (o servidor do Discord conhece o `joined_at` de cada
+ * membro), e o domínio não importa integração. A integração implementa e o
+ * container costura.
+ */
+interface MembershipDates
+{
+    /**
+     * @param  list<string>  $identityIds
+     * @return array<string, CarbonImmutable> id da identidade => quando entrou
+     */
+    public function execute(array $identityIds): array;
+}

--- a/app-modules/community/src/Retrospective/DTOs/PersonIdentity.php
+++ b/app-modules/community/src/Retrospective/DTOs/PersonIdentity.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace He4rt\Community\Retrospective\DTOs;
 
+use Carbon\CarbonImmutable;
+
 /**
  * Uma pessoa do deck em termos que TODA fonte entende: quem ela é para exibição
  * mais as contas que ela tem em cada plataforma.
@@ -18,6 +20,7 @@ final readonly class PersonIdentity
 {
     /**
      * @param  array<string, PersonAccount>  $accounts  provider => conta
+     * @param  CarbonImmutable|null  $memberSince  o mais antigo entre entrar no Discord e criar a conta no site
      */
     public function __construct(
         public string $userId,
@@ -25,6 +28,7 @@ final readonly class PersonIdentity
         public string $username,
         public string $avatar,
         public array $accounts = [],
+        public ?CarbonImmutable $memberSince = null,
     ) {}
 
     public function account(string $provider): ?PersonAccount

--- a/app-modules/community/src/Retrospective/DTOs/PromotionCard.php
+++ b/app-modules/community/src/Retrospective/DTOs/PromotionCard.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace He4rt\Community\Retrospective\DTOs;
 
+use Carbon\CarbonImmutable;
 use He4rt\Community\Retrospective\Enums\PromotionStage;
 
 /**
@@ -28,6 +29,7 @@ final readonly class PromotionCard
         public PromotionStage $stage,
         public ?string $reason = null,
         public array $groups = [],
+        public ?CarbonImmutable $memberSince = null,
     ) {}
 
     /**
@@ -43,6 +45,7 @@ final readonly class PromotionCard
         }
 
         $reason = $payload['reason'] ?? null;
+        $memberSince = $payload['member_since'] ?? null;
 
         return new self(
             userId: $userId,
@@ -52,6 +55,9 @@ final readonly class PromotionCard
             stage: $stage,
             reason: is_string($reason) && $reason !== '' ? $reason : null,
             groups: self::groups($payload['groups'] ?? []),
+            memberSince: is_string($memberSince) && $memberSince !== ''
+                ? CarbonImmutable::parse($memberSince)
+                : null,
         );
     }
 
@@ -67,6 +73,7 @@ final readonly class PromotionCard
             'avatar' => $this->avatar,
             'stage' => $this->stage->value,
             'reason' => $this->reason,
+            'member_since' => $this->memberSince?->toIso8601String(),
             'groups' => array_map(
                 fn (PromotionMetricGroup $group): array => [
                     'source_key' => $group->sourceKey,

--- a/app-modules/community/tests/Feature/Retrospective/ResolvePeopleAvatarTest.php
+++ b/app-modules/community/tests/Feature/Retrospective/ResolvePeopleAvatarTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Community\Retrospective\Actions\ResolvePeople;
+use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
+use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
+use He4rt\Identity\User\Models\User;
+
+function linkIdentity(User $user, IdentityProvider $provider, array $metadata): ExternalIdentity
+{
+    return ExternalIdentity::factory()->create([
+        'model_type' => $user->getMorphClass(),
+        'model_id' => $user->id,
+        'provider' => $provider,
+        'metadata' => $metadata,
+    ]);
+}
+
+it('usa o username da conta GitHub vinculada antes de qualquer outra fonte', function (): void {
+    $user = User::factory()->create();
+    linkIdentity($user, IdentityProvider::GitHub, ['username' => 'danielhe4rt']);
+    linkIdentity($user, IdentityProvider::Discord, ['avatar' => 'https://cdn.discordapp.com/avatars/1/abc.png']);
+
+    $person = resolve(ResolvePeople::class)->execute([$user->id])[$user->id];
+
+    expect($person->avatar)->toBe('https://github.com/danielhe4rt.png');
+});
+
+it('cai para o avatar do Discord quando não há conta GitHub', function (): void {
+    $user = User::factory()->create();
+    linkIdentity($user, IdentityProvider::Discord, ['avatar' => 'https://cdn.discordapp.com/avatars/1/abc.png']);
+
+    $person = resolve(ResolvePeople::class)->execute([$user->id])[$user->id];
+
+    expect($person->avatar)->toBe('https://cdn.discordapp.com/avatars/1/abc.png');
+});
+
+it('cai para o avatar do sistema quando não há GitHub nem Discord com avatar', function (): void {
+    $user = User::factory()->create(['username' => 'fulana']);
+
+    $person = resolve(ResolvePeople::class)->execute([$user->id])[$user->id];
+
+    expect($person->avatar)->toBe('https://github.com/fulana.png');
+});

--- a/app-modules/community/tests/Feature/Retrospective/ResolvePeopleMemberSinceTest.php
+++ b/app-modules/community/tests/Feature/Retrospective/ResolvePeopleMemberSinceTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+use Carbon\CarbonImmutable;
+use He4rt\Community\Retrospective\Actions\ResolvePeople;
+use He4rt\Community\Retrospective\Contracts\MembershipDates;
+use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
+use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
+use He4rt\Identity\User\Models\User;
+
+/**
+ * @param  array<string, CarbonImmutable>  $dates
+ */
+function fakeMembershipDates(array $dates): void
+{
+    app()->instance(MembershipDates::class, new readonly class($dates) implements MembershipDates
+    {
+        /**
+         * @param  array<string, CarbonImmutable>  $dates
+         */
+        public function __construct(private array $dates) {}
+
+        public function execute(array $identityIds): array
+        {
+            return array_intersect_key($this->dates, array_flip($identityIds));
+        }
+    });
+}
+
+function linkDiscord(User $user): ExternalIdentity
+{
+    return ExternalIdentity::factory()->create([
+        'model_type' => $user->getMorphClass(),
+        'model_id' => $user->id,
+        'provider' => IdentityProvider::Discord,
+    ]);
+}
+
+it('usa a entrada no Discord quando ela é mais antiga que a conta do site', function (): void {
+    $user = User::factory()->create(['created_at' => '2024-05-10 12:00:00']);
+    $identity = linkDiscord($user);
+
+    fakeMembershipDates([$identity->id => CarbonImmutable::parse('2020-03-01 00:00:00')]);
+
+    $person = resolve(ResolvePeople::class)->execute([$user->id])[$user->id];
+
+    expect($person->memberSince?->toDateString())->toBe('2020-03-01');
+});
+
+it('cai para o created_at do usuário quando ele é anterior ao Discord', function (): void {
+    $user = User::factory()->create(['created_at' => '2019-01-15 12:00:00']);
+    $identity = linkDiscord($user);
+
+    fakeMembershipDates([$identity->id => CarbonImmutable::parse('2022-08-01 00:00:00')]);
+
+    $person = resolve(ResolvePeople::class)->execute([$user->id])[$user->id];
+
+    expect($person->memberSince?->toDateString())->toBe('2019-01-15');
+});
+
+it('sem data do Discord, o created_at responde sozinho', function (): void {
+    $user = User::factory()->create(['created_at' => '2023-11-02 12:00:00']);
+    linkDiscord($user);
+
+    fakeMembershipDates([]);
+
+    $person = resolve(ResolvePeople::class)->execute([$user->id])[$user->id];
+
+    expect($person->memberSince?->toDateString())->toBe('2023-11-02');
+});

--- a/app-modules/community/tests/Unit/Retrospective/RetrospectiveSnapshotTest.php
+++ b/app-modules/community/tests/Unit/Retrospective/RetrospectiveSnapshotTest.php
@@ -2,11 +2,14 @@
 
 declare(strict_types=1);
 
+use Carbon\CarbonImmutable;
 use He4rt\Community\Retrospective\DTOs\HeadlineMetrics;
 use He4rt\Community\Retrospective\DTOs\Metric;
+use He4rt\Community\Retrospective\DTOs\PromotionCard;
 use He4rt\Community\Retrospective\DTOs\RetrospectiveSnapshot;
 use He4rt\Community\Retrospective\DTOs\SourceFilters;
 use He4rt\Community\Retrospective\DTOs\SourceResult;
+use He4rt\Community\Retrospective\Enums\PromotionStage;
 use He4rt\Community\Retrospective\Slides\FrozenSlide;
 
 it('faz round-trip e reidrata slides como FrozenSlide', function (): void {
@@ -76,4 +79,30 @@ it('assume os filtros padrão em snapshot antigo, sem a chave', function (): voi
 
     expect($restored->filters->hideBots)->toBeTrue()
         ->and($restored->filters->exclusions)->toBeEmpty();
+});
+
+it('congela e reidrata o member_since dos cartões da tag', function (): void {
+    $card = new PromotionCard(
+        userId: 'u1',
+        name: 'Fulana',
+        username: 'fulana',
+        avatar: 'a.png',
+        stage: PromotionStage::Promoted,
+        memberSince: CarbonImmutable::parse('2020-03-01T00:00:00+00:00'),
+    );
+
+    $payload = $card->toArray();
+    $hydrated = PromotionCard::makeFromPayload($payload);
+
+    expect($payload['member_since'])->toBe('2020-03-01T00:00:00+00:00')
+        ->and($hydrated?->memberSince?->toIso8601String())->toBe('2020-03-01T00:00:00+00:00');
+});
+
+it('cartão congelado antes do member_since reidrata sem a data', function (): void {
+    $hydrated = PromotionCard::makeFromPayload([
+        'user_id' => 'u1',
+        'stage' => 'promoted',
+    ]);
+
+    expect($hydrated?->memberSince)->toBeNull();
 });

--- a/app-modules/integration-discord/src/IntegrationDiscordServiceProvider.php
+++ b/app-modules/integration-discord/src/IntegrationDiscordServiceProvider.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace He4rt\IntegrationDiscord;
 
+use He4rt\Community\Retrospective\Contracts\MembershipDates;
 use He4rt\IntegrationDiscord\ETL\Console\BackfillVoiceLogsCommand;
 use He4rt\IntegrationDiscord\ETL\Console\ImportDiscordMessagesCommand;
 use He4rt\IntegrationDiscord\ETL\Console\ImportDiscordProfilesCommand;
 use He4rt\IntegrationDiscord\ETL\Console\MergeDuplicateDiscordProfilesCommand;
 use He4rt\IntegrationDiscord\Models\DiscordEventLog;
+use He4rt\IntegrationDiscord\Retrospective\DiscordMembershipDates;
 use He4rt\IntegrationDiscord\Sync\Console\PurgeUnusedInvitesCommand;
 use He4rt\IntegrationDiscord\Sync\Console\SyncDiscordGuildCommand;
 use He4rt\IntegrationDiscord\Sync\Observers\DiscordEventLogObserver;
@@ -20,6 +22,10 @@ class IntegrationDiscordServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
+        // Quem responde "desde quando essa pessoa está na comunidade" para o
+        // slide da tag: a data mora em discord_members, então o dono dela é aqui.
+        $this->app->bind(MembershipDates::class, DiscordMembershipDates::class);
+
         $this->app->singleton(DiscordConnector::class, fn (): DiscordConnector => new DiscordConnector(
             botToken: config()->string('discord.token'),
         ));

--- a/app-modules/integration-discord/src/Retrospective/DiscordMembershipDates.php
+++ b/app-modules/integration-discord/src/Retrospective/DiscordMembershipDates.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\IntegrationDiscord\Retrospective;
+
+use Carbon\CarbonImmutable;
+use He4rt\Community\Retrospective\Contracts\MembershipDates;
+use He4rt\IntegrationDiscord\Models\DiscordMember;
+
+/**
+ * A resposta do Discord para "desde quando essa pessoa está aqui": o menor
+ * `joined_at` entre os servidores onde a conta aparece.
+ *
+ * O mínimo importa porque sair e voltar reseta o `joined_at` de um servidor —
+ * a guilda mais antiga é a memória que sobrou da chegada de verdade.
+ */
+final readonly class DiscordMembershipDates implements MembershipDates
+{
+    public function execute(array $identityIds): array
+    {
+        if ($identityIds === []) {
+            return [];
+        }
+
+        $rows = DiscordMember::query()
+            ->whereIn('external_identity_id', $identityIds)
+            ->whereNotNull('joined_at')
+            ->groupBy('external_identity_id')
+            ->selectRaw('external_identity_id, min(joined_at) as first_joined_at')
+            ->toBase()
+            ->get();
+
+        $dates = [];
+
+        foreach ($rows as $row) {
+            $identityId = $row->external_identity_id;
+            $joinedAt = $row->first_joined_at;
+
+            if (is_string($identityId) && is_string($joinedAt)) {
+                $dates[$identityId] = CarbonImmutable::parse($joinedAt);
+            }
+        }
+
+        return $dates;
+    }
+}

--- a/app-modules/integration-discord/tests/Feature/Retrospective/DiscordMembershipDatesTest.php
+++ b/app-modules/integration-discord/tests/Feature/Retrospective/DiscordMembershipDatesTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
+use He4rt\IntegrationDiscord\Models\DiscordMember;
+use He4rt\IntegrationDiscord\Retrospective\DiscordMembershipDates;
+
+it('responde o joined_at mais antigo entre os servidores da conta', function (): void {
+    $identity = ExternalIdentity::factory()->create();
+
+    DiscordMember::factory()->create([
+        'external_identity_id' => $identity->id,
+        'joined_at' => '2022-06-01 10:00:00',
+    ]);
+    DiscordMember::factory()->create([
+        'external_identity_id' => $identity->id,
+        'joined_at' => '2019-02-14 08:30:00',
+    ]);
+
+    $dates = new DiscordMembershipDates()->execute([$identity->id]);
+
+    expect($dates[$identity->id]->toDateString())->toBe('2019-02-14');
+});
+
+it('ignora membros sem joined_at e contas fora da lista', function (): void {
+    $comData = ExternalIdentity::factory()->create();
+    $semData = ExternalIdentity::factory()->create();
+    $foraDaLista = ExternalIdentity::factory()->create();
+
+    DiscordMember::factory()->create([
+        'external_identity_id' => $comData->id,
+        'joined_at' => '2021-01-01 00:00:00',
+    ]);
+    DiscordMember::factory()->create([
+        'external_identity_id' => $semData->id,
+        'joined_at' => null,
+    ]);
+    DiscordMember::factory()->create([
+        'external_identity_id' => $foraDaLista->id,
+        'joined_at' => '2018-01-01 00:00:00',
+    ]);
+
+    $dates = new DiscordMembershipDates()->execute([$comData->id, $semData->id]);
+
+    expect($dates)->toHaveKeys([$comData->id])
+        ->and($dates)->not->toHaveKeys([$semData->id, $foraDaLista->id]);
+});
+
+it('lista vazia não vai ao banco', function (): void {
+    expect(new DiscordMembershipDates()->execute([]))->toBeEmpty();
+});

--- a/app-modules/integration-github/src/Retrospective/GithubSource.php
+++ b/app-modules/integration-github/src/Retrospective/GithubSource.php
@@ -93,6 +93,7 @@ final class GithubSource implements CuratableSource, MeasuresPerson, Retrospecti
             // Repos exibidos = só os com PR no recorte (mesmo universo dos cards).
             'repos' => count($repos),
             'total' => $contributions->count(),
+            'days' => max(1, (int) ceil($period->since->diffInDays($period->until))),
         ];
 
         return new SourceResult(
@@ -494,12 +495,23 @@ final class GithubSource implements CuratableSource, MeasuresPerson, Retrospecti
                         ->sortByDesc(fn (array $pr): int => $pr['additions'] + $pr['deletions'])
                         ->values()
                         ->all(),
+                    // Quem mais abriu PR primeiro; presença sem PR (review,
+                    // issue, comentário) fica no fim com métricas zeradas — o
+                    // trilho do slide separa os dois grupos por esse critério.
                     'people' => $items
                         ->groupBy('actor_login')
-                        ->map(fn (Collection $group, string $login): array => [
-                            'login' => $login,
-                            'avatar' => $this->avatar($login, $group->first()?->actor_id),
-                        ])
+                        ->map(function (Collection $group, string $login): array {
+                            $authored = $group->filter(fn (GithubContribution $contribution): bool => $contribution->type === ContributionType::Pr);
+
+                            return [
+                                'login' => $login,
+                                'avatar' => $this->avatar($login, $group->first()?->actor_id),
+                                'prs' => $authored->count(),
+                                'additions' => $this->sumMeta($authored, 'additions'),
+                                'deletions' => $this->sumMeta($authored, 'deletions'),
+                            ];
+                        })
+                        ->sort(fn (array $a, array $b): int => [$b['prs'], $b['additions'] + $b['deletions']] <=> [$a['prs'], $a['additions'] + $a['deletions']])
                         ->values()
                         ->all(),
                     'metrics' => [

--- a/app-modules/integration-github/tests/Feature/Retrospective/GithubSourceTest.php
+++ b/app-modules/integration-github/tests/Feature/Retrospective/GithubSourceTest.php
@@ -99,6 +99,7 @@ it('agrega contribuições por pessoa com contagem por tipo e total, ordenado de
 
     expect($meta['people'])->toBe(2)
         ->and($meta['total'])->toBe(3)
+        ->and($meta['days'])->toBe(7)
         ->and($people[0]['login'])->toBe('maria')
         ->and($people[0]['total'])->toBe(2)
         ->and($people[0]['prs'])->toBe(1)
@@ -217,6 +218,20 @@ it('agrupa PRs por repositório e lista destaques por linhas mudadas', function 
         ->and($highlights[0]['num'])->toBe(1)
         ->and($highlights[0]['additions'])->toBe(500)
         ->and($highlights[0]['repo'])->toBe('he4rt/heartdevs.com');
+});
+
+it('quebra as pessoas do repo por PRs e churn, autores antes de quem só esteve por perto', function (): void {
+    ghContribution(['actor_login' => 'joao', 'repo' => 'he4rt/x', 'type' => ContributionType::Pr, 'external_ref' => 'pr:2', 'occurred_at' => '2026-06-02', 'metadata' => ['state' => 'open', 'merged' => false, 'title' => 'pequeno', 'url' => 'u2', 'additions' => 10, 'deletions' => 2, 'changed_files' => 1]]);
+    ghContribution(['actor_login' => 'ana', 'repo' => 'he4rt/x', 'type' => ContributionType::Review, 'external_ref' => 'review:1', 'occurred_at' => '2026-06-02']);
+    ghContribution(['actor_login' => 'maria', 'repo' => 'he4rt/x', 'type' => ContributionType::Pr, 'external_ref' => 'pr:1', 'occurred_at' => '2026-06-02', 'metadata' => ['state' => 'merged', 'merged' => true, 'title' => 'grande', 'url' => 'u1', 'additions' => 500, 'deletions' => 100, 'changed_files' => 5]]);
+
+    $people = ghRepos(($this->collect)())[0]['people'];
+
+    expect(array_column($people, 'login'))->toBe(['maria', 'joao', 'ana'])
+        ->and($people[0]['prs'])->toBe(1)
+        ->and($people[0]['additions'])->toBe(500)
+        ->and($people[0]['deletions'])->toBe(100)
+        ->and($people[2]['prs'])->toBe(0);
 });
 
 it('esconde da lista repos sem PR no recorte mas mantém suas contribuições nas stats', function (): void {

--- a/app-modules/portal/resources/css/retrospective.css
+++ b/app-modules/portal/resources/css/retrospective.css
@@ -114,7 +114,8 @@
     --t-issue: #f6b73c;
     --t-commit: #b39bff;
     --t-review: #2dd4bf;
-    --t-comment: #62a6ff;
+    /* Azul mais escuro que o lilás de commit: separa o par sob protanopia (ΔE 12.2). */
+    --t-comment: #3f7ce0;
     --t-review-comment: #7c83ff;
     --st-merged: #a06bff;
     --st-open: #34d399;
@@ -502,6 +503,185 @@
     margin-top: 9px;
 }
 
+/* panorama do github */
+.retro .faint {
+    color: var(--faint);
+}
+.retro .pan-hero {
+    font-family: 'Fraunces', serif;
+    font-weight: 600;
+    font-size: clamp(4rem, 11cqw, 7.2rem);
+    line-height: 0.95;
+    letter-spacing: -0.02em;
+    color: var(--brand-soft);
+    margin-top: 0.18em;
+}
+.retro .pan-lead {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 1.02rem;
+    color: var(--muted);
+    margin: 14px 0 0;
+}
+.retro .pan-lead b {
+    color: var(--text);
+    font-weight: 600;
+}
+.retro .pan-grid {
+    display: grid;
+    grid-template-columns: 1.35fr 1fr;
+    gap: 18px 56px;
+    align-items: start;
+    margin-top: 8px;
+}
+.retro .pan-sec {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.76rem;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: var(--brand-soft);
+    margin: 30px 0 14px;
+}
+.retro .pan-sec::before,
+.retro .pan-sec::after {
+    content: '';
+    height: 1px;
+    background: var(--border);
+    width: 26px;
+}
+.retro .pan-sec::after {
+    flex: 0 1 90px;
+}
+.retro .pan-rows {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+.retro .pan-row {
+    display: grid;
+    grid-template-columns: 12.5rem 3.6rem minmax(0, 1fr);
+    align-items: center;
+    gap: 14px;
+}
+.retro .pan-row .lbl {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.96rem;
+    color: var(--muted);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.retro .pan-row .num {
+    font-family: 'JetBrains Mono', monospace;
+    font-variant-numeric: tabular-nums;
+    font-size: 1.02rem;
+    font-weight: 700;
+    color: var(--text);
+    text-align: right;
+}
+.retro .pan-bar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+    border-left: 1px solid var(--border);
+    padding-left: 1px;
+}
+.retro .pan-bar .pct {
+    font-family: 'JetBrains Mono', monospace;
+    font-variant-numeric: tabular-nums;
+    font-size: 0.88rem;
+    color: var(--faint);
+    white-space: nowrap;
+}
+.retro .pan-fill {
+    display: block;
+    height: 14px;
+    border-radius: 0 4px 4px 0;
+    flex-shrink: 0;
+}
+.retro .pan-prs-total {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.96rem;
+    color: var(--muted);
+    margin: 0 0 12px;
+}
+.retro .pan-prs-total b {
+    color: var(--text);
+    font-size: 1.08rem;
+}
+.retro .pan-stack {
+    height: 14px;
+    border-radius: 4px;
+    overflow: hidden;
+    display: flex;
+    gap: 2px;
+}
+.retro .pan-stack span {
+    height: 100%;
+}
+.retro .pan-states {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 18px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.96rem;
+    color: var(--muted);
+    margin: 12px 0 0;
+}
+.retro .pan-states .key {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    white-space: nowrap;
+}
+.retro .pan-states .key i {
+    width: 9px;
+    height: 9px;
+    border-radius: 3px;
+    flex-shrink: 0;
+}
+.retro .pan-states .key b {
+    color: var(--text);
+    font-variant-numeric: tabular-nums;
+}
+.retro .pan-diff {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: center;
+    margin-top: 16px;
+    font-size: 0.9rem;
+}
+.retro .pan-diff .bdg {
+    font-size: 0.92rem;
+    padding: 6px 13px;
+}
+.retro .pan-insight {
+    font-size: 1.18rem;
+    color: var(--muted);
+    max-width: 82ch;
+    margin: 34px 0 0;
+    padding-top: 18px;
+    border-top: 1px solid var(--border);
+}
+.retro .pan-insight b {
+    color: var(--text);
+}
+
+@media (max-width: 900px) {
+    .retro .pan-grid {
+        grid-template-columns: minmax(0, 1fr);
+        gap: 0;
+    }
+    .retro .pan-row {
+        grid-template-columns: 8.5rem 3rem minmax(0, 1fr) 2.6rem;
+        gap: 8px;
+    }
+}
+
 /* card */
 .retro .card {
     background: var(--surface);
@@ -533,7 +713,10 @@
 }
 .retro .pcar-track {
     display: flex;
-    align-items: flex-start;
+    /* stretch + régua pregada no rodapé (abaixo): com a anatomia fixa do card
+       (chips de PR + uma régua de contadores), esticar pela altura do maior é o
+       que alinha o fundo da fileira — flex-start deixava a borda serrilhada */
+    align-items: stretch;
     gap: 16px;
     overflow-x: auto;
     scroll-snap-type: x proximity;
@@ -569,6 +752,21 @@
 .retro .pslide {
     flex: 0 0 clamp(300px, 30%, 460px);
     scroll-snap-align: start;
+    display: flex;
+}
+.retro .pslide .card {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+.retro .pslide .card .acts {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+.retro .pslide .cstats.strip {
+    margin-top: auto;
+    padding-top: 14px;
 }
 .retro .pcar-arrow {
     position: absolute;
@@ -619,12 +817,23 @@
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
     gap: 14px;
-    /* start (não stretch): o card abraça o conteúdo em vez de esticar até a
-       altura do mais alto da linha — sem "vazião" embaixo dos cards leves */
-    align-items: start;
+    /* stretch: com a anatomia fixa (cabeçalho + barra + pills no rodapé), o que
+       alinha a linha é esticar pela altura do mais alto e pregar as pills
+       embaixo — start deixava o fundo da fileira serrilhado */
+    align-items: stretch;
+}
+.retro .pgrid > div {
+    display: flex;
 }
 .retro .pgrid .card {
     padding: 16px 17px 17px;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+.retro .pgrid .card .cstats {
+    margin-top: auto;
+    padding-top: 13px;
 }
 
 /* badges */
@@ -737,7 +946,152 @@
     display: inline-block;
 }
 
-/* repo */
+/* repo — trilho de identidade + grid de PRs.
+   A lista de PRs não tem teto (todo PR do recorte entra), então uma coluna só
+   vira um poço de rolagem com metade da tela vazia. O trilho fixa a identidade
+   do repo à esquerda enquanto os PRs correm em duas colunas; o conjunto sai da
+   caixa de 1120px pelo mesmo truque do carrossel de pessoas. */
+.retro .repo-layout {
+    display: grid;
+    grid-template-columns: 300px minmax(0, 1fr);
+    gap: 34px;
+    align-items: start;
+    width: min(96cqw, 1400px);
+    margin-left: 50%;
+    transform: translateX(-50%);
+}
+.retro .repo-rail {
+    position: sticky;
+    top: 84px;
+}
+.retro .repo-prs {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+    align-items: start;
+}
+/* repo pequeno (≤4 PRs): coluna única com cards ricos em vez de um grid manco;
+   estreita e centraliza pra não virar três réguas de borda a borda */
+.retro .repo-prs.is-hero {
+    grid-template-columns: minmax(0, 720px);
+    justify-content: center;
+    gap: 14px;
+    align-self: center;
+}
+.retro .tpr.is-hero {
+    padding: 20px 22px;
+    border-radius: 16px;
+}
+.retro .tpr.is-hero .d {
+    font-size: 1.14rem;
+    line-height: 1.35;
+}
+.retro .tpr.is-hero .rn {
+    font-size: 1rem;
+}
+.retro .st-label {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.74rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+@media (max-width: 980px) {
+    .retro .repo-layout {
+        grid-template-columns: minmax(0, 1fr);
+        gap: 22px;
+    }
+    .retro .repo-rail {
+        position: static;
+    }
+    .retro .repo-prs {
+        grid-template-columns: minmax(0, 1fr);
+    }
+}
+
+/* quem mexeu — quebra por pessoa no trilho. A barra escala pelo maior churn DO
+   REPO (não da pessoa), então largura é comparação real entre as linhas; dentro
+   dela o verde/vermelho divide adições e remoções. */
+.retro .rp-list {
+    margin-top: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 13px;
+}
+.retro .rp-title {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.68rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--faint);
+}
+.retro .rp-id {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+}
+.retro .rp-login {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.8rem;
+    color: var(--text);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.retro .rp-prs {
+    margin-left: auto;
+    flex: none;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.74rem;
+    font-weight: 700;
+    color: var(--brand-soft);
+}
+.retro .rp-meter {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 6px;
+    /* alinha com o texto: avatar de 24px + gap de 8px */
+    padding-left: 32px;
+}
+.retro .rp-bar {
+    height: 6px;
+    min-width: 8px;
+    border-radius: 999px;
+    overflow: hidden;
+    display: inline-flex;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+}
+.retro .rp-bar .a {
+    background: var(--add);
+    height: 100%;
+}
+.retro .rp-bar .d {
+    background: var(--del);
+    height: 100%;
+}
+.retro .rp-churn {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.72rem;
+    color: #7ef0a3;
+    flex: none;
+}
+.retro .rp-churn.is-del {
+    color: #ff9a9a;
+}
+.retro .rp-present {
+    margin-top: 18px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+.retro .rp-present-label {
+    font-size: 0.74rem;
+    color: var(--faint);
+}
+
 .retro .repo-ic {
     width: 54px;
     height: 54px;
@@ -775,6 +1129,21 @@
 }
 .retro .avstack .mini:first-child {
     margin-left: 0;
+}
+.retro .closing-wall {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 8px;
+    margin-top: 30px;
+}
+.retro .closing-wall .mini {
+    width: 46px;
+    height: 46px;
+    transition: transform 0.25s cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+.retro .closing-wall .mini:hover {
+    transform: scale(1.18);
 }
 
 /* pessoa */
@@ -949,6 +1318,19 @@
 }
 .retro .cstat-n {
     color: var(--text);
+}
+.retro .cstat-l {
+    margin-left: 5px;
+    font-weight: 400;
+    font-size: 0.72rem;
+    color: var(--muted);
+}
+/* régua de contadores do card cheio: fecha o card com uma linha só, no lugar
+   das linhas rotuladas por tipo (que faziam as alturas divergirem no trilho) */
+.retro .cstats.strip {
+    margin-top: 14px;
+    padding-top: 12px;
+    border-top: 1px solid var(--border);
 }
 
 /* navbar do deck */
@@ -1777,38 +2159,234 @@
     color: var(--muted);
 }
 
-/* Canais — cartão compacto com ícone, nome e domínio. */
-.retro .chan {
-    display: flex;
+/*
+ | Canais — constelação. As estrelas dividem a MESMA órbita, equidistantes do
+ | núcleo: a igualdade entre os canais é geométrica, não declarada. Posição de
+ | cada estrela (`--sx`/`--sy`) e ângulo de cada raio vêm da partial, calculados
+ | sobre o total de canais do config — a órbita se redistribui sozinha.
+ */
+.retro .join-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 440px);
+    gap: 56px;
     align-items: center;
-    gap: 13px;
-    text-decoration: none;
-    color: inherit;
 }
-.retro .chan-ic {
+.retro .const {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 1;
+}
+.retro .const-ring {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 82%;
+    height: 82%;
+    margin: -41% 0 0 -41%;
+    border: 1px dashed rgba(182, 155, 255, 0.22);
+    border-radius: 50%;
+}
+.retro .slide.active .const-ring {
+    animation: orb-spin 90s linear infinite;
+}
+.retro .const-spoke {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 41%;
+    height: 1px;
+    transform-origin: left center;
+    background: linear-gradient(90deg, rgba(120, 43, 241, 0.35), transparent 85%);
+}
+/* A faixa de energia do raio: invisível até a vez da estrela dele no ciclo. */
+.retro .const-spoke::after {
+    content: '';
+    position: absolute;
+    inset: -1px 0;
+    background: linear-gradient(90deg, var(--ac, var(--brand-2)), transparent 92%);
+    opacity: 0;
+}
+.retro .slide.active .const-spoke::after {
+    animation: const-feed calc(var(--n, 7) * 2.5s) linear infinite;
+    animation-delay: calc(var(--i, 0) * 2.5s);
+}
+.retro .const-core {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 104px;
+    height: 104px;
+    display: grid;
+    place-items: center;
+    border-radius: 50%;
+    background: radial-gradient(circle at 38% 30%, #2a2140, var(--surface));
+    border: 1px solid rgba(120, 43, 241, 0.55);
+    box-shadow: 0 0 34px -8px rgba(120, 43, 241, 0.6);
+    font-family: 'Fraunces', serif;
+    font-style: italic;
+    font-weight: 600;
+    font-size: 2rem;
+    color: var(--brand-soft);
+}
+.retro .slide.active .const-core {
+    animation: const-beat 2.4s ease-in-out infinite;
+}
+@keyframes const-beat {
+    0%,
+    42%,
+    100% {
+        box-shadow: 0 0 34px -8px rgba(120, 43, 241, 0.6);
+    }
+    16% {
+        box-shadow: 0 0 44px -6px rgba(196, 75, 255, 0.75);
+    }
+}
+.retro .const-star {
+    position: absolute;
+    top: var(--sy);
+    left: var(--sx);
+    transform: translate(-50%, -50%);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 7px;
+    width: 104px;
+    text-decoration: none;
+    color: var(--text);
+    text-align: center;
+}
+.retro .const-star-ic {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 38px;
-    height: 38px;
-    flex: none;
-    border-radius: 11px;
-    background: var(--surface-2);
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    background: var(--surface);
+    border: 1px solid var(--border);
     color: var(--brand-soft);
+    transition:
+        border-color 0.25s ease,
+        background 0.25s ease,
+        color 0.25s ease,
+        transform 0.25s ease,
+        box-shadow 0.25s ease;
 }
-.retro .chan-ic svg {
-    width: 19px;
-    height: 19px;
+.retro .const-star:hover .const-star-ic {
+    border-color: var(--ac, var(--brand));
+    background: var(--ac, var(--brand));
+    /* A cor do accent varia do blurple ao branco puro; o ícone assume a cor do
+       fundo do deck, que contrasta com qualquer uma delas. */
+    color: var(--bg);
+    transform: scale(1.12);
+    box-shadow: 0 0 34px -6px var(--ac, var(--brand));
 }
-.retro .chan-name {
+.retro .const-star-ic svg {
+    width: 23px;
+    height: 23px;
+}
+/*
+ | O ciclo de energia: a cada tique de 2,5s a estrela seguinte "recebe o hover"
+ | por conta própria — um anel sólido na cor do canal, sem desfoque, contorna o
+ | ícone enquanto o raio dela alimenta o núcleo. Realce por contraste, não por
+ | brilho: a forma continua nítida para quem enxerga pouco e não vira fonte de
+ | luz pulsante. O anel vive num pseudo-elemento para o :hover real, que anima
+ | as mesmas propriedades no ícone, continuar respondendo por cima.
+ */
+.retro .const-star-ic::after {
+    content: '';
+    position: absolute;
+    inset: -6px;
+    border-radius: 50%;
+    border: 2px solid var(--ac, var(--brand));
+    opacity: 0;
+}
+.retro .const-star-ic {
+    position: relative;
+}
+.retro .slide.active .const-star-ic::after {
+    animation: const-feed calc(var(--n, 7) * 2.5s) linear infinite;
+    animation-delay: calc(var(--i, 0) * 2.5s);
+}
+/* Janela de ~1/N do ciclo acesa (≈2,5s), com subida e descida suaves; o resto
+   do tempo a estrela espera a volta completar. */
+@keyframes const-feed {
+    0% {
+        opacity: 0;
+    }
+    6% {
+        opacity: 1;
+    }
+    16%,
+    100% {
+        opacity: 0;
+    }
+}
+/* Navegação por teclado recebe o mesmo realce do hover: a estrela focada não
+   pode depender do anel do ciclo para ser encontrada. */
+.retro .const-star:focus-visible {
+    outline: none;
+}
+.retro .const-star:focus-visible .const-star-ic {
+    border-color: var(--ac, var(--brand));
+    background: var(--ac, var(--brand));
+    color: var(--bg);
+    transform: scale(1.12);
+}
+.retro .const-star-name {
     display: block;
-    font-weight: 700;
+    font-weight: 600;
+    font-size: 0.82rem;
+    line-height: 1.2;
 }
-.retro .chan-host {
+.retro .const-star-host {
     display: block;
     font-family: 'JetBrains Mono', monospace;
-    font-size: 0.71rem;
+    font-size: 0.58rem;
     color: var(--muted);
+}
+
+@media (max-width: 900px) {
+    /* Sem largura para a órbita, a constelação vira lista: as estrelas voltam
+       ao fluxo como chips e núcleo, anel e raios — que só existem para desenhar
+       a geometria — saem junto. */
+    .retro .join-grid {
+        grid-template-columns: minmax(0, 1fr);
+        gap: 30px;
+    }
+    .retro .const {
+        aspect-ratio: auto;
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+        gap: 12px;
+    }
+    .retro .const-ring,
+    .retro .const-spoke,
+    .retro .const-core {
+        display: none;
+    }
+    .retro .const-star {
+        position: static;
+        transform: none;
+        flex-direction: row;
+        width: auto;
+        gap: 11px;
+        text-align: left;
+        border: 1px solid var(--border);
+        border-radius: 14px;
+        background: var(--surface);
+        padding: 10px 12px;
+    }
+    .retro .const-star-ic {
+        width: 38px;
+        height: 38px;
+        flex: none;
+    }
+    .retro .const-star-ic svg {
+        width: 18px;
+        height: 18px;
+    }
 }
 
 /* ── ritual da tag He4rt ────────────────────────────────────────────────────
@@ -1933,20 +2511,24 @@
     margin-inline: auto;
 }
 
-/* O palco da entrega: as pessoas entram lado a lado quando cabem e empilham
-   quando não cabem — duas é o caso real, mais que isso continua legível. */
+/* O palco da entrega: um viewport com profundidade. Os cards empilham na mesma
+   célula do grid (o mais alto define a altura) e vivem em planos de Z — quem
+   dita onde cada um está é a coreografia do dolly, mais abaixo. */
 .retro .promo-stage {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    align-items: flex-start;
-    gap: 34px;
+    display: grid;
+    place-items: start center;
     margin-top: 30px;
+    perspective: 1400px;
+    perspective-origin: 50% 40%;
 }
 
 .retro .promo-hero {
-    flex: 1 1 320px;
-    max-width: 460px;
+    grid-area: 1 / 1;
+    width: min(100%, 520px);
+}
+
+.retro .promo-finale {
+    display: none;
 }
 
 .retro .promo-hero-metrics {
@@ -1956,7 +2538,182 @@
     justify-content: center;
 }
 
+/* ── coreografia da entrega da tag: o dolly ─────────────────────────────────
+ |
+ | O deck só liga `.shown`; a encenação mora aqui. O palco tem profundidade e a
+ | câmera viaja: quem ainda não foi anunciado espera longe, fora de foco; no seu
+ | passo, o card chega ao plano focal (rack focus — o blur abre junto com a
+ | viagem); quando o próximo é anunciado, o anterior sai POR TRÁS da câmera. O
+ | passo final é o pull-back: todos voltam, lado a lado, para a foto oficial.
+ |
+ | "Quem já passou" e "é o finale" são lidos do próprio DOM via :has() — o deck
+ | não sabe de nada disso, continua só ligando `.shown` na ordem dos passos.
+ |
+ | A câmera transita nos DOIS sentidos (voltar um passo desfaz a viagem); os
+ | gestos internos do card transitam só no `.shown`, para o retorno ser limpo.
+ */
+.retro .promo-tag .promo-hero[data-reveal] {
+    opacity: 0;
+    transform: translateZ(-980px) translateY(12px);
+    filter: blur(12px);
+    transition:
+        opacity 1.1s cubic-bezier(0.72, 0.02, 0.18, 0.99),
+        transform 1.1s cubic-bezier(0.72, 0.02, 0.18, 0.99),
+        filter 1.1s cubic-bezier(0.72, 0.02, 0.18, 0.99);
+}
+.retro .promo-tag .promo-hero[data-reveal].shown {
+    opacity: 1;
+    transform: translateZ(0);
+    filter: blur(0);
+}
+
+/* Já apresentado: com o próximo em cena, o anterior ultrapassa a câmera. */
+.retro .promo-tag .promo-hero[data-reveal].shown:has(~ .promo-hero.shown) {
+    opacity: 0;
+    transform: translateZ(430px) translateY(-3%);
+    filter: blur(14px);
+    pointer-events: none;
+}
+
+/* O finale: a câmera recua e a fila inteira volta ao plano geral. `--shift`
+   (posição relativa ao centro) vem da view, que sabe quantos cards existem. */
+.retro .promo-tag:has(.promo-finale.shown) .promo-hero[data-reveal].shown,
+.retro .promo-tag:has(.promo-finale.shown) .promo-hero[data-reveal].shown:has(~ .promo-hero.shown) {
+    opacity: 1;
+    transform: translateZ(-300px) translateX(calc(var(--shift, 0) * min(42cqw, 480px))) scale(0.94);
+    filter: blur(0);
+    pointer-events: auto;
+}
+
+.retro .promo-tag .promo-avatar-ring {
+    position: relative;
+    display: inline-block;
+    border-radius: 50%;
+}
+.retro .promo-tag .promo-avatar-ring::after {
+    content: '';
+    position: absolute;
+    inset: -9px;
+    border-radius: 50%;
+    border: 2px solid var(--brand-2);
+    opacity: 0;
+    pointer-events: none;
+}
+.retro .promo-tag .promo-hero.shown .promo-avatar-ring::after {
+    animation: retro-ping 2.6s ease-out infinite;
+    animation-delay: 1.3s;
+}
+
+.retro .promo-tag .promo-hero .promo-avatar.big {
+    opacity: 0;
+    transform: scale(0.72) translateY(14px);
+    filter: blur(5px);
+}
+.retro .promo-tag .promo-hero.shown .promo-avatar.big {
+    opacity: 1;
+    transform: none;
+    filter: blur(0);
+    transition:
+        opacity 0.5s ease,
+        transform 0.6s cubic-bezier(0.16, 1.1, 0.3, 1.15),
+        filter 0.5s ease;
+    transition-delay: 0.45s;
+}
+
+.retro .promo-tag .promo-hero .promo-name.big,
+.retro .promo-tag .promo-hero .promo-handle,
+.retro .promo-tag .promo-hero .promo-since {
+    opacity: 0;
+    transform: translateY(14px);
+}
+.retro .promo-tag .promo-hero.shown .promo-name.big,
+.retro .promo-tag .promo-hero.shown .promo-handle,
+.retro .promo-tag .promo-hero.shown .promo-since {
+    opacity: 1;
+    transform: none;
+    transition:
+        opacity 0.5s ease,
+        transform 0.5s cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+.retro .promo-tag .promo-hero.shown .promo-name.big {
+    transition-delay: 0.6s;
+}
+.retro .promo-tag .promo-hero.shown .promo-handle {
+    transition-delay: 0.72s;
+}
+.retro .promo-tag .promo-hero.shown .promo-since {
+    transition-delay: 0.82s;
+}
+
+/* Os números: cada fonte entra na sua vez (`--promo-i` vem da view), e o valor
+   estoura um tique depois da faixa — o olho lê a plataforma antes do número. */
+.retro .promo-tag .promo-hero-metrics .promo-source {
+    opacity: 0;
+    transform: translateY(12px);
+}
+.retro .promo-tag .promo-hero-metrics.shown .promo-source {
+    opacity: 1;
+    transform: none;
+    transition:
+        opacity 0.45s ease,
+        transform 0.45s ease;
+    transition-delay: calc(var(--promo-i, 0) * 0.16s);
+}
+.retro .promo-tag .promo-hero-metrics .promo-metric b {
+    display: inline-block;
+    opacity: 0;
+    transform: scale(0.55);
+}
+.retro .promo-tag .promo-hero-metrics.shown .promo-metric b {
+    opacity: 1;
+    transform: none;
+    transition:
+        opacity 0.4s ease,
+        transform 0.5s cubic-bezier(0.2, 0.9, 0.3, 1.4);
+    transition-delay: calc(var(--promo-i, 0) * 0.16s + 0.14s);
+}
+
+.retro .promo-tag .promo-reason.big[data-reveal] {
+    transform: translateY(10px) scale(0.98);
+    letter-spacing: 0.02em;
+}
+.retro .promo-tag .promo-reason.big[data-reveal].shown {
+    transform: none;
+    letter-spacing: normal;
+    transition:
+        opacity 0.7s ease,
+        transform 0.7s ease,
+        letter-spacing 0.7s ease;
+}
+
+/* Desde quando a pessoa está aqui — a régua que dá peso ao resto do cartão. */
+.retro .promo-since {
+    margin-top: 9px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.74rem;
+    letter-spacing: 0.06em;
+    color: var(--muted);
+}
+.retro .promo-since b {
+    color: var(--brand-soft);
+    font-weight: 600;
+}
+
 @media (max-width: 900px) {
+    /* Sem largura para o plano geral, o finale abre mão do 3D e empilha os
+       cards — a foto oficial vira coluna, todo mundo continua na tela. */
+    .retro .promo-tag:has(.promo-finale.shown) .promo-stage {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 28px;
+        perspective: none;
+    }
+    .retro .promo-tag:has(.promo-finale.shown) .promo-hero[data-reveal].shown,
+    .retro .promo-tag:has(.promo-finale.shown) .promo-hero[data-reveal].shown:has(~ .promo-hero.shown) {
+        transform: none;
+    }
+
     /* Sem largura para a onda, a timeline vira lista — ano e texto já andam
        juntos na mesma coluna, então basta soltar a quebra e fechar o vão. */
     .retro .tl-line {

--- a/app-modules/portal/resources/views/community-retrospective.blade.php
+++ b/app-modules/portal/resources/views/community-retrospective.blade.php
@@ -6,7 +6,6 @@
         <x-portal::retro.slides.empty />
     @else
         <x-portal::retro.slides.cover
-            :sources="$sources"
             :since="$since"
             :until="$until"
             :coverTitle="$coverTitle ?? null"

--- a/app-modules/portal/resources/views/components/retro/activity-chips.blade.php
+++ b/app-modules/portal/resources/views/components/retro/activity-chips.blade.php
@@ -1,9 +1,24 @@
 @props (['person'])
-@php ($stateColor = fn($state) => [ 'merged' => 'var(--st-merged)', 'open' => 'var(--st-open)', 'closed' => 'var(--st-closed)' ][$state ?? ''] ?? 'var(--st-open)')
+{{--
+    A anatomia do card é fixa de propósito: chips só para PRs (a parte com
+    título, que merece leitura) e UMA régua de contadores para todo o resto.
+    Uma linha rotulada por tipo fazia o card do #1 ter o dobro da altura do #3
+    e quebrava a comparação lado a lado no trilho.
+
+    Só blocos PHP pareados neste arquivo (e nada de diretiva PHP inline, nem
+    citada em comentário): o compilador do Blade casa o primeiro abre com o
+    primeiro fecha ANTES de remover comentários, e qualquer mistura engole o
+    miolo do template como PHP cru.
+--}}
+@php
+    $stateColor = fn ($state) => ['merged' => 'var(--st-merged)', 'open' => 'var(--st-open)', 'closed' => 'var(--st-closed)'][$state ?? ''] ?? 'var(--st-open)';
+@endphp
 <div class="acts">
     @if (count($person['pr_refs']))
-        @php ($prShown = array_slice($person['pr_refs'], 0, 3))
-        @php ($prMore = count($person['pr_refs']) - count($prShown))
+        @php
+            $prShown = array_slice($person['pr_refs'], 0, 3);
+            $prMore = count($person['pr_refs']) - count($prShown);
+        @endphp
         <div class="act act-pr" style="--c: var(--t-pr)">
             <span class="act-h">Abriu PR</span>
             <span class="act-items">
@@ -23,57 +38,31 @@
             </span>
         </div>
     @endif
-    @if ($person['reviews'] > 0)
-        <div class="act act-review" style="--c: var(--t-review)">
-            <span class="act-h">Revisou</span
-            ><span class="act-items"
-                ><span class="ref"><span class="rn">{{ $person['reviews'] }}</span> reviews</span></span
-            >
-        </div>
-    @endif
-    @if (count($person['issue_refs']))
-        @php ($issueShown = array_slice($person['issue_refs'], 0, 3))
-        @php ($issueMore = count($person['issue_refs']) - count($issueShown))
-        <div class="act act-issue" style="--c: var(--t-issue)">
-            <span class="act-h">Abriu issue</span>
-            <span class="act-items">
-                @foreach ($issueShown as $ref)
-                    <a
-                        class="ref"
-                        @if ($ref['url']) href="{{ $ref['url'] }}" target="_blank" rel="noopener" @endif
-                        title="{{ $ref['title'] }}"
-                    >
-                        <span class="rn">#{{ $ref['num'] }}</span><span class="rt">{{ $ref['title'] }}</span></a
-                    >
-                @endforeach
-                @if ($issueMore > 0)
-                    <span class="ref more">mais {{ $issueMore }}…</span>
-                @endif
-            </span>
-        </div>
-    @endif
-    @if ($person['comments'] > 0)
-        <div class="act act-comment" style="--c: var(--t-comment)">
-            <span class="act-h">Comentou</span
-            ><span class="act-items"
-                ><span class="ref"><span class="rn">{{ $person['comments'] }}</span> comentários</span></span
-            >
-        </div>
-    @endif
-    @if ($person['review_comments'] > 0)
-        <div class="act act-review-comment" style="--c: var(--t-review-comment)">
-            <span class="act-h">Comentou em review</span
-            ><span class="act-items"
-                ><span class="ref"><span class="rn">{{ $person['review_comments'] }}</span> em reviews</span></span
-            >
-        </div>
-    @endif
-    @if ($person['commits'] > 0)
-        <div class="act act-commit" style="--c: var(--t-commit)">
-            <span class="act-h">Commitou</span
-            ><span class="act-items"
-                ><span class="ref"><span class="rn">{{ $person['commits'] }}</span> commits</span></span
-            >
+    @php
+        $stats = array_values(
+            array_filter(
+                [
+                    ['cls' => 'act-review', 'c' => '--t-review', 'n' => $person['reviews'], 'label' => 'reviews'],
+                    ['cls' => 'act-issue', 'c' => '--t-issue', 'n' => count($person['issue_refs']), 'label' => 'issues'],
+                    ['cls' => 'act-comment', 'c' => '--t-comment', 'n' => $person['comments'], 'label' => 'coment.'],
+                    ['cls' => 'act-review-comment', 'c' => '--t-review-comment', 'n' => $person['review_comments'], 'label' => 'em review'],
+                    ['cls' => 'act-commit', 'c' => '--t-commit', 'n' => $person['commits'], 'label' => 'commits'],
+                ],
+                fn (array $stat): bool => $stat['n'] > 0,
+            ),
+        );
+    @endphp
+    @if (count($stats))
+        <div class="cstats strip">
+            @foreach ($stats as $stat)
+                <span
+                    class="cstat {{ $stat['cls'] }}"
+                    style="--c: var({{ $stat['c'] }})"
+                    title="{{ $stat['n'] }} {{ $stat['label'] }}"
+                >
+                    <span class="cstat-n">{{ $stat['n'] }}</span><span class="cstat-l">{{ $stat['label'] }}</span>
+                </span>
+            @endforeach
         </div>
     @endif
 </div>

--- a/app-modules/portal/resources/views/components/retro/composition-bar.blade.php
+++ b/app-modules/portal/resources/views/components/retro/composition-bar.blade.php
@@ -1,4 +1,4 @@
-@props (['person'])
+@props (['person', 'maxTotal' => null])
 @php
     $segments = array_values(
         array_filter(
@@ -18,9 +18,13 @@
         ),
     );
     $sum = array_sum(array_column($segments, 'count')) ?: 1;
+
+    // Com maxTotal a LARGURA da barra vira comparação real entre cards: quem fez
+    // menos tem barra menor, em vez de todo mundo ocupar 100% só mudando as cores.
+    $scale = $maxTotal !== null && $maxTotal > 0 ? min(100, round(($sum / $maxTotal) * 100, 1)) : 100;
 @endphp
 @if (count($segments))
-    <div class="compbar" aria-hidden="true">
+    <div class="compbar" aria-hidden="true" style="width: {{ $scale }}%">
         @foreach ($segments as $segment)
             <span
                 class="seg"

--- a/app-modules/portal/resources/views/components/retro/deck.blade.php
+++ b/app-modules/portal/resources/views/components/retro/deck.blade.php
@@ -124,23 +124,27 @@
                     $dispatch('retro-moved', { index: this.active });
                 }
             },
+            // Método, não expressão inline: o Alpine compila atributo como
+            // `__self.result = <expressão>`, e um bloco multi-linha ali é
+            // SyntaxError silencioso — o teclado inteiro morre.
+            keyboard($event) {
+                // Embutido no builder, o deck divide o teclado com o inspector:
+                // setas dentro de um campo movem o cursor, não o deck.
+                if ($event.target.closest('input, textarea, select, [contenteditable]')) return;
+
+                if ($event.key === 'ArrowRight') {
+                    this.forward();
+                    $event.preventDefault();
+                } else if ($event.key === 'ArrowLeft') {
+                    this.back();
+                    $event.preventDefault();
+                }
+            },
         }"
         {{-- Navegação por fora do deck: o Deck Builder aponta o preview para o
              slide que o operador acabou de selecionar na coluna de estrutura. --}}
         x-on:retro-goto.window="go($event.detail.index, { silent: true })"
-        @keydown.window="
-            // Embutido no builder, o deck divide o teclado com o inspector: setas
-            // dentro de um campo movem o cursor, não o deck.
-            if ($event.target.closest('input, textarea, select, [contenteditable]')) return;
-
-            if ($event.key === 'ArrowRight') {
-                forward();
-                $event.preventDefault();
-            } else if ($event.key === 'ArrowLeft') {
-                back();
-                $event.preventDefault();
-            }
-        "
+        @keydown.window="keyboard($event)"
     >
         @unless ($bare)
             <div class="progress">

--- a/app-modules/portal/resources/views/components/retro/people-carousel.blade.php
+++ b/app-modules/portal/resources/views/components/retro/people-carousel.blade.php
@@ -1,4 +1,8 @@
 @props (['items', 'size' => 48, 'startRank' => null])
+@php
+    // O maior total do trilho vira a régua de todas as barras de composição.
+    $maxTotal = max([1, ...array_column($items, 'total')]);
+@endphp
 <div
     class="pcarousel"
     x-data="{
@@ -103,6 +107,7 @@
                     :person="$person"
                     :rank="$startRank !== null ? $startRank + $i : null"
                     :size="$size"
+                    :max-total="$maxTotal"
                 />
             </div>
         @endforeach

--- a/app-modules/portal/resources/views/components/retro/person-card.blade.php
+++ b/app-modules/portal/resources/views/components/retro/person-card.blade.php
@@ -1,4 +1,4 @@
-@props (['person', 'rank' => null, 'size' => 44, 'compact' => false])
+@props (['person', 'rank' => null, 'size' => 44, 'compact' => false, 'maxTotal' => null])
 @php ($ns = $size >= 80 ? '1.7rem' : '1.18rem')
 <div class="card">
     <div class="phead">
@@ -28,7 +28,7 @@
             <span class="total-pill">#{{ $rank }}</span>
         @endif
     </div>
-    <x-portal::retro.composition-bar :person="$person" />
+    <x-portal::retro.composition-bar :person="$person" :max-total="$maxTotal" />
     @if ($compact)
         <x-portal::retro.activity-icons :person="$person" />
     @else

--- a/app-modules/portal/resources/views/components/retro/pr-row.blade.php
+++ b/app-modules/portal/resources/views/components/retro/pr-row.blade.php
@@ -1,6 +1,7 @@
-@props (['pr'])
+@props (['pr', 'hero' => false])
 @php ($stateColor = ['merged' => 'var(--st-merged)', 'open' => 'var(--st-open)', 'closed' => 'var(--st-closed)'][ $pr['state'] ?? '' ] ?? 'var(--st-open)')
-<a class="tpr" @if ($pr['url']) href="{{ $pr['url'] }}" target="_blank" rel="noopener" @endif>
+@php ($stateLabel = ['merged' => 'merged', 'open' => 'aberto', 'closed' => 'fechado'][ $pr['state'] ?? '' ] ?? 'aberto')
+<a class="tpr {{ $hero ? 'is-hero' : '' }}" @if ($pr['url']) href="{{ $pr['url'] }}" target="_blank" rel="noopener" @endif>
     <span class="stdot" style="background: {{ $stateColor }}"></span>
     <span class="rn">#{{ $pr['num'] }}</span>
     <span style="flex: 1; min-width: 0">
@@ -11,7 +12,12 @@
         }}</span>
         <span style="display: flex; flex-wrap: wrap; gap: 8px; align-items: center; margin-top: 7px">
             <span class="by">{{ '@' . $pr['author_login'] }}</span>
-            <x-portal::retro.badges :additions="$pr['additions']" :deletions="$pr['deletions']" />
+            @if ($hero)
+                <span class="st-label" style="color: {{ $stateColor }}">{{ $stateLabel }}</span>
+                <x-portal::retro.badges :additions="$pr['additions']" :deletions="$pr['deletions']" :files="$pr['changed_files'] > 0 ? $pr['changed_files'] : null" />
+            @else
+                <x-portal::retro.badges :additions="$pr['additions']" :deletions="$pr['deletions']" />
+            @endif
         </span>
     </span>
 </a>

--- a/app-modules/portal/resources/views/components/retro/slides/about/join.blade.php
+++ b/app-modules/portal/resources/views/components/retro/slides/about/join.blade.php
@@ -3,54 +3,91 @@
     chegou de fora — daqui em diante o deck só fala em números, e eles já vão
     fazer sentido.
 
-    Os canais saem do config `he4rt.social_media`, a mesma fonte da página /redes:
-    um link novo aparece aqui sem ninguém lembrar de vir editar o deck. Os canais
-    que ESTE recorte mediu ganham selo, que é o que amarra a apresentação aos
-    slides seguintes em vez de deixar uma lista de links solta.
+    Constelação: os canais são estrelas na MESMA órbita, equidistantes do
+    coração da He4rt. Nenhum canal manda — a igualdade não é dita, é geométrica,
+    e "a He4rt não cabe num lugar só" vira literal: toda porta dá no mesmo
+    centro. Por isso não há CTA — o destino é o núcleo, as portas são todas.
+
+    Os canais saem do config `he4rt.social_media`, a mesma fonte da página
+    /redes: um link novo entra na órbita e as estrelas se redistribuem sozinhas,
+    sem ninguém lembrar de vir editar o deck.
 --}}
 @php
-    $measured = collect($sources)->pluck('key')->all();
     $links = \He4rt\Portal\SocialLinks\SocialLinksPage::links();
-    $discord = config()->string('he4rt.social_media.discord.url');
+    $count = max(count($links), 1);
+
+    /*
+     | Raio em % da caixa da constelação, não em px: a órbita escala com o slide
+     | e sobra borda para o rótulo de cada estrela não vazar do quadrado.
+     */
+    $radius = 41;
 @endphp
 <section class="slide" data-label="Onde entrar">
     <div class="slide-inner">
-        <span class="sec-tag" data-anim>Onde encontrar</span>
-        <h2 class="sec" data-anim>A He4rt não cabe num lugar só</h2>
-        <p class="sec-sub" data-anim>
-            O Discord é a sala de estar e o GitHub é a bancada. O resto é por onde a comunidade
-            aparece para quem ainda não chegou — sem processo seletivo, nível mínimo nem
-            linguagem certa.
-        </p>
+        <div class="join-grid">
+            <div>
+                <span class="sec-tag" data-anim>Onde encontrar</span>
+                <h2 class="sec" data-anim>Todos os caminhos dão no mesmo lugar</h2>
+                <p class="sec-sub" data-anim>
+                    Não existe porta principal. Cada canal é uma entrada com a mesma distância
+                    do centro — <b style="color: var(--text)">sem processo seletivo, nível mínimo
+                    nem linguagem certa</b>. Escolhe a tua e chega.
+                </p>
+                <p class="hint" data-anim>↗ cada estrela é clicável</p>
+            </div>
 
-        <div class="pgrid" data-anim style="margin-top: 26px">
-            @foreach ($links as $link)
-                <a class="card chan" href="{{ $link->url }}" target="_blank" rel="noopener">
-                    <span class="chan-ic">
-                        <x-filament::icon :icon="$link->icon" />
-                    </span>
+            {{--
+                `--n` dimensiona o ciclo de energia: a cada tique de 2,5s a
+                estrela seguinte acende e o raio dela alimenta o núcleo, dando a
+                volta completa em `$count` tiques. Estrela e raio compartilham o
+                mesmo `--i`, então os dois pulsam juntos.
+            --}}
+            <div class="const" data-anim style="--n: {{ $count }}">
+                <div class="const-ring" aria-hidden="true"></div>
 
-                    <span style="min-width: 0">
-                        <span class="chan-name">{{ $link->label }}</span>
-                        <span class="chan-host">
-                            {{ \Illuminate\Support\Str::of($link->url)->after('//')->before('/') }}
+                @foreach ($links as $position => $link)
+                    <span
+                        class="const-spoke"
+                        aria-hidden="true"
+                        style="
+                            transform: rotate({{ round(-90 + ($position * 360 / $count), 2) }}deg);
+                            --i: {{ $position }};
+                            --ac: {{ $link->accentDark ?? $link->accent }};
+                        "
+                    ></span>
+                @endforeach
+
+                <span class="const-core" aria-hidden="true">&lt;4</span>
+
+                @foreach ($links as $position => $link)
+                    @php
+                        $angle = deg2rad(-90 + ($position * 360 / $count));
+                    @endphp
+                    <a
+                        class="const-star"
+                        href="{{ $link->url }}"
+                        target="_blank"
+                        rel="noopener"
+                        style="
+                            --sx: {{ round(50 + $radius * cos($angle), 2) }}%;
+                            --sy: {{ round(50 + $radius * sin($angle), 2) }}%;
+                            --ac: {{ $link->accentDark ?? $link->accent }};
+                            --i: {{ $position }};
+                        "
+                    >
+                        <span class="const-star-ic">
+                            <x-filament::icon :icon="$link->icon" />
                         </span>
-                    </span>
 
-                    @if (in_array($link->key, $measured, strict: true))
-                        <span class="bdg neu" style="margin-inline-start: auto">medido aqui</span>
-                    @endif
-                </a>
-            @endforeach
-        </div>
-
-        <div data-anim style="text-align: center">
-            <a class="cta" href="{{ $discord }}" target="_blank" rel="noopener">
-                Entrar na He4rt
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true">
-                    <path d="M5 12h14M13 6l6 6-6 6" stroke-linecap="round" stroke-linejoin="round" />
-                </svg>
-            </a>
+                        <span class="const-star-label">
+                            <span class="const-star-name">{{ $link->label }}</span>
+                            <span class="const-star-host">
+                                {{ \Illuminate\Support\Str::of($link->url)->after('//')->before('/') }}
+                            </span>
+                        </span>
+                    </a>
+                @endforeach
+            </div>
         </div>
     </div>
 </section>

--- a/app-modules/portal/resources/views/components/retro/slides/closing.blade.php
+++ b/app-modules/portal/resources/views/components/retro/slides/closing.blade.php
@@ -3,7 +3,10 @@
     $fmt = fn ($d): string => $d instanceof \Carbon\CarbonInterface
         ? $d->timezone(config('app.display_timezone'))->format('d/m/Y')
         : (string) $d;
-    $labels = collect($sources)->map(fn ($source): string => $source->label)->implode(', ');
+    $people = collect($sources)
+        ->flatMap(fn ($source) => $source->slides)
+        ->first(fn ($slide): bool => $slide->kind() === 'github.core')
+        ?->toArray()['people'] ?? [];
 @endphp
 <section class="slide" data-label="Obrigado">
     <div class="slide-inner" style="text-align: center; max-width: 940px">
@@ -15,13 +18,22 @@
                 Cada PR, cada mensagem, cada call e cada reação manteve a He4rt viva.
             @endif
         </p>
-        <div data-anim style="display: flex; flex-wrap: wrap; gap: 12px; justify-content: center; margin-top: 30px">
-            @foreach ($sources as $source)
-                <span class="bdg neu" style="font-size: 1rem; padding: 8px 16px">{{ $source->label }}</span>
-            @endforeach
-        </div>
-        <p class="hint" data-anim style="margin-top: 30px">
-            gerado a partir de {{ $labels }} · {{ $fmt($since) }} — {{ $fmt($until) }}
-        </p>
+        @if (count($people))
+            <div class="closing-wall" data-anim>
+                @foreach ($people as $person)
+                    <img
+                        class="mini"
+                        src="{{ $person['avatar'] }}"
+                        onerror="this.onerror=null;this.src='https://github.com/{{ $person['login'] }}.png'"
+                        loading="lazy"
+                        width="46"
+                        height="46"
+                        alt="{{ $person['login'] }}"
+                        title="{{ $person['login'] }}"
+                    />
+                @endforeach
+            </div>
+        @endif
+        <p class="hint" data-anim style="margin-top: 30px">{{ $fmt($since) }} — {{ $fmt($until) }}</p>
     </div>
 </section>

--- a/app-modules/portal/resources/views/components/retro/slides/cover.blade.php
+++ b/app-modules/portal/resources/views/components/retro/slides/cover.blade.php
@@ -1,4 +1,4 @@
-@props(['sources', 'since', 'until', 'coverTitle' => null, 'coverIntro' => null])
+@props(['since', 'until', 'coverTitle' => null, 'coverIntro' => null])
 @php
     $fmt = fn ($d): string => $d instanceof \Carbon\CarbonInterface
         ? $d->timezone(config('app.display_timezone'))->format('d/m/Y')
@@ -29,24 +29,6 @@
                 Participação da comunidade <b>He4rt</b> em cada frente — <b>gente, código, conversa e presença</b>.
             @endif
         </p>
-        <div data-anim style="display: flex; flex-direction: column; gap: 18px; margin-top: 26px">
-            @foreach ($sources as $source)
-                <div>
-                    <div
-                        class="mono"
-                        style="font-size: 0.72rem; letter-spacing: 0.2em; text-transform: uppercase; color: var(--brand-soft); margin-bottom: 9px"
-                    >{{ $source->label }}</div>
-                    <div style="display: flex; flex-wrap: wrap; gap: 10px; justify-content: center">
-                        @foreach ($source->headline->metrics as $metric)
-                            <span class="bdg neu" style="font-size: 1rem; padding: 7px 14px">
-                                <b style="color: var(--text)">{{ number_format($metric->value, 0, ',', '.') }}</b>
-                                {{ $metric->label }}
-                            </span>
-                        @endforeach
-                    </div>
-                </div>
-            @endforeach
-        </div>
         <div class="hint" data-anim>navegue com <kbd>←</kbd> <kbd>→</kbd></div>
     </div>
 </section>

--- a/app-modules/portal/resources/views/retro/slides/discord/messages.blade.php
+++ b/app-modules/portal/resources/views/retro/slides/discord/messages.blade.php
@@ -1,29 +1,130 @@
+@php
+    /*
+     | Props vêm do MessagesSlide, mas um snapshot congelado antes deste painel
+     | existir só traz total/with_reactions/pinned/chatters — daí os defaults.
+     | O deck publicado continua abrindo; republicar preenche o resto.
+     */
+    $people ??= 0;
+    $peak ??= null;
+    $days ??= [];
+    $hours ??= [];
+
+    $fmt = fn (int $value): string => number_format($value, 0, ',', '.');
+
+    $weekdays = [1 => 'Segunda', 2 => 'Terça', 3 => 'Quarta', 4 => 'Quinta', 5 => 'Sexta', 6 => 'Sábado', 7 => 'Domingo'];
+
+    // Barra proporcional ao dia mais falante; o resto se mede contra ele.
+    $busiestDay = max(1, ...array_map(static fn (array $d): int => $d['messages'], $days ?: [['messages' => 0]]));
+    $busiestHour = max(1, ...array_map(static fn (array $h): int => $h['messages'], $hours ?: [['messages' => 0]]));
+    $peakHour = collect($hours)->sortByDesc('messages')->first();
+@endphp
+
 <section class="slide" data-label="Conversas">
-    <div class="slide-inner">
+    {{-- O painel é denso como o de voz: a variante compacta encolhe o padding
+         do slide e o tamanho do título para o conteúdo caber sem rolagem. --}}
+    <div class="slide-inner is-dense">
         <span class="sec-tag" data-anim>O papo</span>
         <h2 class="sec" data-anim>O que rolou no chat</h2>
-        <p class="sec-sub" data-anim>
-            <b style="color: var(--text)">{{ number_format($total, 0, ',', '.') }} mensagens</b> trocadas no período.
-        </p>
-        <div data-anim style="display: flex; flex-wrap: wrap; gap: 12px; margin-top: 18px">
-            <span class="bdg neu" style="font-size: 1rem; padding: 7px 14px"
-                >{{ number_format($with_reactions, 0, ',', '.') }} com reação</span
-            >
-            <span class="bdg neu" style="font-size: 1rem; padding: 7px 14px"
-                >{{ number_format($pinned, 0, ',', '.') }} fixadas</span
-            >
+
+        {{-- Sem linha de resumo aqui: ela repetiria o primeiro número. --}}
+        <div class="vb-totals" data-anim>
+            <div class="vb-total">
+                <b>{{ $fmt($total) }}</b>
+                <span>Mensagens</span>
+            </div>
+            @if ($people > 0)
+                <div class="vb-total">
+                    <b>{{ $fmt($people) }}</b>
+                    <span>Pessoas no papo</span>
+                </div>
+            @endif
+            <div class="vb-total">
+                <b>{{ $fmt($with_reactions) }}</b>
+                <span>Com reação</span>
+            </div>
+            <div class="vb-total">
+                <b>{{ $fmt($pinned) }}</b>
+                <span>Fixadas</span>
+            </div>
+            @if ($peak)
+                <div class="vb-total">
+                    <b>{{ $fmt($peak['messages']) }}</b>
+                    <span>Pico · {{ $peak['date'] }}</span>
+                </div>
+            @endif
         </div>
-        @if (count($chatters))
-            <div style="margin-top: 22px; display: flex; flex-direction: column; gap: 10px">
-                @foreach ($chatters as $i => $chatter)
-                    <div class="card" data-anim style="display: flex; align-items: center; gap: 12px">
-                        <span class="mono" style="color: var(--brand-soft); min-width: 28px">#{{ $i + 1 }}</span>
-                        <span style="color: var(--text); font-weight: 600">{{ $chatter['name'] }}</span>
-                        <span class="mono" style="margin-left: auto; color: var(--faint)"
-                            >{{ number_format($chatter['messages'], 0, ',', '.') }} msgs</span
-                        >
+
+        <div class="vb-cols" data-anim>
+            @if (count($days))
+                <div class="vb-panel">
+                    <span class="vb-title">O ritmo da semana</span>
+
+                    <ul class="vb-arenas">
+                        @foreach ($days as $day)
+                            <li class="vb-arena">
+                                <div class="vb-arena-head">
+                                    <span class="vb-arena-name">{{ $weekdays[$day['weekday']] }}</span>
+
+                                    <span class="vb-arena-joins"><b>{{ $fmt($day['messages']) }}</b> msgs</span>
+                                </div>
+
+                                <div class="vb-track">
+                                    <span class="vb-fill" style="width: {{ max(1.5, ($day['messages'] / $busiestDay) * 100) }}%"></span>
+                                </div>
+                            </li>
+                        @endforeach
+                    </ul>
+                </div>
+            @endif
+
+            @if (count($chatters))
+                <div class="vb-panel">
+                    <span class="vb-title">Quem segurou o papo</span>
+
+                    <div class="vb-rank-legend">
+                        <span></span><span></span><span>Msgs</span><span>Reações</span><span>XP</span>
                     </div>
-                @endforeach
+
+                    <ol class="vb-rank">
+                        @foreach ($chatters as $index => $chatter)
+                            <li class="vb-rank-row">
+                                <span class="vb-rank-n">{{ str_pad((string) ($index + 1), 2, '0', STR_PAD_LEFT) }}</span>
+                                <span class="vb-rank-name">{{ $chatter['name'] }}</span>
+                                <span class="vb-rank-xp">{{ $fmt($chatter['messages']) }}</span>
+                                <span class="vb-rank-meta">{{ $fmt($chatter['reactions'] ?? 0) }}</span>
+                                <span class="vb-rank-meta">{{ $fmt($chatter['xp'] ?? 0) }}</span>
+                            </li>
+                        @endforeach
+                    </ol>
+                </div>
+            @endif
+        </div>
+
+        @if (count($hours))
+            <div class="vb-panel vb-hours" data-anim>
+                <div class="vb-hours-head">
+                    <span class="vb-title">Mensagens por hora</span>
+                    @if ($peakHour)
+                        <span class="vb-hours-peak">
+                            pico {{ str_pad((string) $peakHour['hour'], 2, '0', STR_PAD_LEFT) }}h · {{ $fmt($peakHour['messages']) }}
+                        </span>
+                    @endif
+                </div>
+
+                <div class="vb-bars">
+                    @foreach ($hours as $slot)
+                        <span
+                            @class(['vb-bar', 'is-peak' => $peakHour && $slot['hour'] === $peakHour['hour']])
+                            style="height: {{ max(4, ($slot['messages'] / $busiestHour) * 100) }}%"
+                            title="{{ str_pad((string) $slot['hour'], 2, '0', STR_PAD_LEFT) }}h · {{ $fmt($slot['messages']) }} msgs"
+                        ></span>
+                    @endforeach
+                </div>
+
+                <div class="vb-hours-axis">
+                    <span>0h</span>
+                    <span>23h</span>
+                </div>
             </div>
         @endif
     </div>

--- a/app-modules/portal/resources/views/retro/slides/github/community.blade.php
+++ b/app-modules/portal/resources/views/retro/slides/github/community.blade.php
@@ -1,4 +1,5 @@
 @php ($tail = array_slice($people, 5))
+@php ($maxTotal = max([1, ...array_column($tail, 'total')]))
 <section class="slide" data-label="A comunidade">
     <div class="slide-inner">
         <span class="sec-tag" data-anim>A cauda que sustenta</span>
@@ -6,7 +7,7 @@
         <p class="sec-sub" data-anim>Mais {{ count($tail) }} {{ count($tail) === 1 ? 'pessoa entrou' : 'pessoas entraram' }} com reviews, issues, comentários e commits. Cada toque conta.</p>
         <div class="pgrid" style="margin-top: 22px">
             @foreach ($tail as $person)
-                <div data-anim><x-portal::retro.person-card :person="$person" :size="44" :compact="true" /></div>
+                <div data-anim><x-portal::retro.person-card :person="$person" :size="44" :compact="true" :max-total="$maxTotal" /></div>
             @endforeach
         </div>
     </div>

--- a/app-modules/portal/resources/views/retro/slides/github/panorama.blade.php
+++ b/app-modules/portal/resources/views/retro/slides/github/panorama.blade.php
@@ -1,51 +1,104 @@
+@php
+    $fmt = fn(int $n): string => number_format($n, 0, ',', '.');
+    $total = max(1, (int) $meta['total']);
+    $days = (int) ($meta['days'] ?? 0);
+    $types = collect([
+        ['label' => 'reviews', 'count' => (int) $meta['reviews'], 'color' => 'var(--t-review)'],
+        ['label' => 'commits', 'count' => (int) $meta['commits'], 'color' => 'var(--t-commit)'],
+        ['label' => 'comentários', 'count' => (int) $meta['comments'], 'color' => 'var(--t-comment)'],
+        ['label' => 'comentários de review', 'count' => (int) $meta['review_comments'], 'color' => 'var(--t-review-comment)'],
+        ['label' => 'PRs', 'count' => (int) $meta['prs'], 'color' => 'var(--t-pr)'],
+        ['label' => 'issues', 'count' => (int) $meta['issues'], 'color' => 'var(--t-issue)'],
+    ])
+        ->filter(fn(array $type): bool => $type['count'] > 0)
+        ->sortByDesc('count')
+        ->values();
+    $busiest = max(1, (int) ($types->max('count') ?? 1));
+    $prsOpen = max(0, (int) $meta['prs'] - (int) $meta['prs_merged'] - (int) $meta['prs_unmerged']);
+    $top = $types->first();
+@endphp
+
 <section class="slide" data-label="Panorama">
     <div class="slide-inner">
         <span class="sec-tag" data-anim>O panorama</span>
-        <h2 class="sec" data-anim>O que a comunidade entregou</h2>
-        <p class="sec-sub" data-anim>
-            <b style="color: var(--text)">{{ $meta['people'] }} pessoas</b> somaram
-            <b style="color: var(--text)">{{ $meta['total'] }} interações</b>
-            em {{ $meta['repos'] }} @choice('repositório|repositórios', $meta['repos']).
-        </p>
-        <div class="stats" data-anim style="margin-top: 24px">
-            <div class="stat">
-                <div class="v accent">{{ $meta['people'] }}</div>
-                <div class="l">Pessoas</div>
-            </div>
-            <div class="stat">
-                <div class="v">{{ $meta['prs'] }}</div>
-                <div class="l">Pull Requests</div>
-            </div>
-            <div class="stat">
-                <div class="v">{{ $meta['reviews'] }}</div>
-                <div class="l">Reviews</div>
-            </div>
-            <div class="stat">
-                <div class="v">{{ $meta['issues'] }}</div>
-                <div class="l">Issues</div>
-            </div>
-            <div class="stat">
-                <div class="v">{{ $meta['comments'] + $meta['review_comments'] }}</div>
-                <div class="l">Comentários</div>
-            </div>
-            <div class="stat">
-                <div class="v accent">{{ $meta['commits'] }}</div>
-                <div class="l">Commits</div>
-            </div>
+
+        <div data-anim>
+            <div class="pan-hero">{{ $fmt((int) $meta['total']) }}</div>
+            <p class="pan-lead">
+                contribuições humanas
+                @if ($days > 0)
+                    em <b>{{ $days }} @choice('dia|dias', $days)</b>
+                @endif
+                · <b>{{ $meta['people'] }} @choice('pessoa|pessoas', $meta['people'])</b>
+                · <b>{{ $meta['repos'] }} @choice('repositório|repositórios', $meta['repos'])</b>
+                · <span class="faint">bots ficaram de fora</span>
+            </p>
         </div>
-        <div data-anim style="display: flex; flex-wrap: wrap; gap: 12px; align-items: center; margin-top: 22px">
-            <span class="bdg add" style="font-size: 1rem; padding: 7px 14px"
-                >+{{ number_format($meta['additions'], 0, ',', '.') }} linhas</span
-            >
-            <span class="bdg del" style="font-size: 1rem; padding: 7px 14px"
-                >−{{ number_format($meta['deletions'], 0, ',', '.') }} linhas</span
-            >
-            <span class="bdg neu" style="font-size: 1rem; padding: 7px 14px"
-                >{{ number_format($meta['changed_files'], 0, ',', '.') }} arquivos</span
-            >
-            <span class="bdg neu" style="font-size: 1rem; padding: 7px 14px"
-                >{{ $meta['prs_merged'] }} merged · {{ $meta['prs_unmerged'] }} fechados</span
-            >
+
+        <div class="pan-grid">
+            @if ($types->isNotEmpty())
+                <div data-anim>
+                    <span class="pan-sec">Por tipo</span>
+                    <div class="pan-rows">
+                        @foreach ($types as $type)
+                            <div class="pan-row">
+                                <span class="lbl">{{ $type['label'] }}</span>
+                                <span class="num">{{ $fmt($type['count']) }}</span>
+                                <div class="pan-bar">
+                                    {{-- O maior tipo ocupa o vão todo menos o espaço reservado ao rótulo de %. --}}
+                                    <span
+                                        class="pan-fill"
+                                        style="width: calc((100% - 3.4rem) * {{ max(0.015, round($type['count'] / $busiest, 4)) }}); background: {{ $type['color'] }}"
+                                    ></span>
+                                    <span class="pct">{{ round(($type['count'] / $total) * 100) }}%</span>
+                                </div>
+                            </div>
+                        @endforeach
+                    </div>
+                </div>
+            @endif
+
+            @if ($meta['prs'] > 0)
+                <div data-anim>
+                    <span class="pan-sec">Pull Requests</span>
+                    <p class="pan-prs-total"><b>{{ $meta['prs'] }} PRs</b> no recorte</p>
+                    @php
+                        $states = array_values(array_filter([
+                            ['count' => (int) $meta['prs_merged'], 'color' => 'var(--st-merged)'],
+                            ['count' => $prsOpen, 'color' => 'var(--st-open)'],
+                            ['count' => (int) $meta['prs_unmerged'], 'color' => 'var(--st-closed)'],
+                        ], fn(array $state): bool => $state['count'] > 0));
+                    @endphp
+                    <div class="pan-stack">
+                        @foreach ($states as $state)
+                            <span style="width: {{ round(($state['count'] / $meta['prs']) * 100, 2) }}%; background: {{ $state['color'] }}"></span>
+                        @endforeach
+                    </div>
+                    <p class="pan-states">
+                        <span class="key"><i style="background: var(--st-merged)"></i><b>{{ $meta['prs_merged'] }}</b> merged</span>
+                        <span class="key"><i style="background: var(--st-open)"></i><b>{{ $prsOpen }}</b> @choice('aberto|abertos', $prsOpen)</span>
+                        <span class="key"><i style="background: var(--st-closed)"></i><b>{{ $meta['prs_unmerged'] }}</b> @choice('fechado|fechados', $meta['prs_unmerged']) sem merge</span>
+                    </p>
+                    <div class="pan-diff">
+                        <span class="bdg add">+{{ $fmt((int) $meta['additions']) }}</span>
+                        <span class="bdg del">−{{ $fmt((int) $meta['deletions']) }}</span>
+                        <span class="bdg neu">{{ $fmt((int) $meta['changed_files']) }} arquivos</span>
+                        <span class="faint">só metadata dos PRs</span>
+                    </div>
+                </div>
+            @endif
         </div>
+
+        @if ($top !== null)
+            <p class="pan-insight" data-anim>
+                → {{ $top['label'] }} @choice('é|são', $top['count'])
+                <b>{{ round(($top['count'] / $total) * 100) }}%</b> de tudo
+                ({{ $fmt($top['count']) }} de {{ $fmt((int) $meta['total']) }}
+                @choice('contribuição|contribuições', $meta['total'])).
+                @if ($days > 0)
+                    Média de <b>{{ number_format($meta['total'] / $days, 1, ',', '.') }}</b> contribuições por dia.
+                @endif
+            </p>
+        @endif
     </div>
 </section>

--- a/app-modules/portal/resources/views/retro/slides/github/repos.blade.php
+++ b/app-modules/portal/resources/views/retro/slides/github/repos.blade.php
@@ -1,51 +1,113 @@
 <section class="slide" data-label="{{ $repo['name'] }}">
     <div class="slide-inner">
-        <div style="display: flex; align-items: center; gap: 14px; flex-wrap: wrap" data-anim>
-            <span
-                class="mono"
-                style="font-size: 0.74rem; letter-spacing: 0.2em; text-transform: uppercase; color: var(--brand-soft)"
-                >Repositório {{ $index }}</span
-            >
-            <span class="avstack" style="margin-left: auto">
-                @foreach (array_slice($repo['people'], 0, 6) as $p)
-                    <img
-                        class="mini"
-                        src="{{ $p['avatar'] }}"
-                        onerror="this.onerror=null;this.src='https://github.com/{{ $p['login'] }}.png'"
-                        width="36"
-                        height="36"
-                        alt="{{ $p['login'] }}"
-                        style="width: 36px; height: 36px"
-                    />
+        {{-- Trilho de identidade à esquerda, PRs em duas colunas à direita: a
+             lista inteira de PRs numa coluna só deixava metade da tela vazia. --}}
+        <div class="repo-layout">
+            <aside class="repo-rail" data-anim>
+                <span
+                    class="mono"
+                    style="font-size: 0.74rem; letter-spacing: 0.2em; text-transform: uppercase; color: var(--brand-soft)"
+                    >Repositório {{ $index }}</span
+                >
+                <div style="display: flex; gap: 16px; align-items: center; margin-top: 14px">
+                    <div class="repo-ic">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="var(--brand-soft)" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
+                            <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
+                        </svg>
+                    </div>
+                    <div>
+                        <h2 class="repo-name">{{ $repo['name'] }}</h2>
+                        <div class="handle">{{ $repo['full_name'] }}</div>
+                    </div>
+                </div>
+                <div style="display: flex; flex-wrap: wrap; gap: 9px; margin-top: 18px">
+                    <span class="bdg neu">{{ $repo['metrics']['prs'] }} PRs</span>
+                    <span class="bdg neu">{{ number_format($repo['metrics']['changed_files'], 0, ',', '.') }} arquivos</span>
+                    @if ($repo['metrics']['additions'] > 0)
+                        <span class="bdg add">+{{ number_format($repo['metrics']['additions'], 0, ',', '.') }}</span>
+                    @endif
+                    @if ($repo['metrics']['deletions'] > 0)
+                        <span class="bdg del">−{{ number_format($repo['metrics']['deletions'], 0, ',', '.') }}</span>
+                    @endif
+                </div>
+                @php
+                    // Snapshot antigo não traz métricas por pessoa: todo mundo cai
+                    // no grupo de presença e o trilho degrada para a pilha de
+                    // avatares que existia antes.
+                    $authors = array_values(array_filter($repo['people'], fn (array $p): bool => ($p['prs'] ?? 0) > 0));
+                    $present = array_values(array_filter($repo['people'], fn (array $p): bool => ($p['prs'] ?? 0) === 0));
+                    $maxChurn = max([1, ...array_map(fn (array $p): int => $p['additions'] + $p['deletions'], $authors)]);
+                @endphp
+
+                @if ($authors !== [])
+                    <div class="rp-list">
+                        <span class="rp-title">Quem mexeu</span>
+                        @foreach (array_slice($authors, 0, 5) as $p)
+                            @php
+                                $churn = max(1, $p['additions'] + $p['deletions']);
+                            @endphp
+                            <div class="rp-row">
+                                <div class="rp-id">
+                                    <img
+                                        class="mini"
+                                        src="{{ $p['avatar'] }}"
+                                        onerror="this.onerror=null;this.src='https://github.com/{{ $p['login'] }}.png'"
+                                        width="24"
+                                        height="24"
+                                        alt="{{ $p['login'] }}"
+                                        style="width: 24px; height: 24px"
+                                    />
+                                    <span class="rp-login">{{ '@' . $p['login'] }}</span>
+                                    <span class="rp-prs">{{ $p['prs'] }} @choice('PR|PRs', $p['prs'])</span>
+                                </div>
+                                <div class="rp-meter">
+                                    <span class="rp-bar" style="width: {{ round(($churn / $maxChurn) * 100, 1) }}%">
+                                        <span class="a" style="width: {{ round(($p['additions'] / $churn) * 100, 1) }}%"></span>
+                                        <span class="d" style="width: {{ round(($p['deletions'] / $churn) * 100, 1) }}%"></span>
+                                    </span>
+                                    <span class="rp-churn">+{{ number_format($p['additions'], 0, ',', '.') }}</span>
+                                    @if ($p['deletions'] > 0)
+                                        <span class="rp-churn is-del">−{{ number_format($p['deletions'], 0, ',', '.') }}</span>
+                                    @endif
+                                </div>
+                            </div>
+                        @endforeach
+                    </div>
+                @endif
+
+                @if ($present !== [])
+                    <div class="rp-present">
+                        <span class="avstack">
+                            @foreach (array_slice($present, 0, 6) as $p)
+                                <img
+                                    class="mini"
+                                    src="{{ $p['avatar'] }}"
+                                    onerror="this.onerror=null;this.src='https://github.com/{{ $p['login'] }}.png'"
+                                    width="28"
+                                    height="28"
+                                    alt="{{ $p['login'] }}"
+                                    style="width: 28px; height: 28px"
+                                />
+                            @endforeach
+                        </span>
+                        @if ($authors !== [])
+                            <span class="rp-present-label">na revisão e por perto</span>
+                        @endif
+                    </div>
+                @endif
+            </aside>
+            @php
+                // Densidade adaptativa: o grid de duas colunas existe para caber
+                // 10+ PRs; com poucos ele deixa a segunda coluna manca. Repo
+                // pequeno troca quantidade por detalhe — coluna única, card rico.
+                $isHero = count($repo['prs']) <= 4;
+            @endphp
+            <div class="repo-prs {{ $isHero ? 'is-hero' : '' }}">
+                @foreach ($repo['prs'] as $pr)
+                    <div data-anim><x-portal::retro.pr-row :pr="$pr" :hero="$isHero" /></div>
                 @endforeach
-            </span>
-        </div>
-        <div style="display: flex; gap: 16px; align-items: center; margin-top: 14px" data-anim>
-            <div class="repo-ic">
-                <svg viewBox="0 0 24 24" fill="none" stroke="var(--brand-soft)" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
-                    <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
-                </svg>
             </div>
-            <div>
-                <h2 class="repo-name">{{ $repo['name'] }}</h2>
-                <div class="handle">{{ $repo['full_name'] }}</div>
-            </div>
-        </div>
-        <div style="display: flex; flex-wrap: wrap; gap: 9px; margin: 18px 0" data-anim>
-            <span class="bdg neu">{{ $repo['metrics']['prs'] }} PRs</span>
-            <span class="bdg neu">{{ number_format($repo['metrics']['changed_files'], 0, ',', '.') }} arquivos</span>
-            @if ($repo['metrics']['additions'] > 0)
-                <span class="bdg add">+{{ number_format($repo['metrics']['additions'], 0, ',', '.') }}</span>
-            @endif
-            @if ($repo['metrics']['deletions'] > 0)
-                <span class="bdg del">−{{ number_format($repo['metrics']['deletions'], 0, ',', '.') }}</span>
-            @endif
-        </div>
-        <div style="display: flex; flex-direction: column; gap: 10px">
-            @foreach ($repo['prs'] as $pr)
-                <div data-anim><x-portal::retro.pr-row :pr="$pr" /></div>
-            @endforeach
         </div>
     </div>
 </section>

--- a/app-modules/portal/resources/views/retro/slides/he4rt/tag.blade.php
+++ b/app-modules/portal/resources/views/retro/slides/he4rt/tag.blade.php
@@ -2,11 +2,17 @@
     O slide da entrega da tag. `data-steps` é o contrato que o deck lê: enquanto
     houver passo pendente, a seta direita revela em vez de trocar de slide.
 
-    A conta é 1 + 3 por pessoa — o passo 0 abre com a pergunta e a tela vazia, e
-    cada pessoa gasta três: quem é, o que fez, e por que a tag é dela. Quem
-    apresenta controla o tempo de cada uma dessas frases.
+    A conta é 2 + 3 por pessoa — o passo 0 abre com a pergunta e o palco vazio,
+    cada pessoa gasta três (quem é, o que fez, por que a tag é dela), e o passo
+    final recua a câmera para a foto oficial, com todo mundo lado a lado.
+
+    A encenação é um dolly: o palco tem profundidade (perspective no CSS) e cada
+    pessoa ocupa um plano — avançar não troca de card, viaja até ele. Quem já foi
+    apresentado sai por trás da câmera até o finale trazer todos de volta.
+    `--shift` é a posição de cada card nessa foto final, calculada aqui porque o
+    CSS não sabe quantos cards existem.
 --}}
-<section class="slide promo-tag" data-label="A tag He4rt" data-steps="{{ 1 + count($cards) * 3 }}">
+<section class="slide promo-tag" data-label="A tag He4rt" data-steps="{{ 2 + count($cards) * 3 }}">
     <div class="slide-inner" style="text-align: center">
         <span class="sec-tag" data-reveal="0" style="margin-inline: auto">O ritual</span>
         <h2 class="sec" data-reveal="0">A tag He4rt vai para…</h2>
@@ -14,21 +20,38 @@
         <div class="promo-stage">
             @foreach ($cards as $position => $card)
                 @php ($step = $position * 3 + 1)
-                <article class="promo-hero" data-reveal="{{ $step }}">
-                    <img
-                        class="promo-avatar big"
-                        src="{{ $card->avatar }}"
-                        width="112"
-                        height="112"
-                        alt="{{ $card->name }}"
-                    />
+                <article
+                    class="promo-hero"
+                    data-reveal="{{ $step }}"
+                    style="--shift: {{ $position - (count($cards) - 1) / 2 }}"
+                >
+                    <span class="promo-avatar-ring">
+                        <img
+                            class="promo-avatar big"
+                            src="{{ $card->avatar }}"
+                            width="112"
+                            height="112"
+                            alt="{{ $card->name }}"
+                        />
+                    </span>
 
                     <div class="promo-name big">{{ $card->name }}</div>
                     <div class="promo-handle">{{ '@' . $card->username }}</div>
 
+                    @if ($card->memberSince !== null)
+                        @php ($since = $card->memberSince->timezone(config('app.display_timezone')))
+                        @php ($years = (int) $since->diffInYears())
+                        <div class="promo-since">
+                            na comunidade desde <b>{{ $since->translatedFormat('F \d\e Y') }}</b>
+                            @if ($years >= 1)
+                                · {{ $years }} {{ $years === 1 ? 'ano' : 'anos' }} de He4rt
+                            @endif
+                        </div>
+                    @endif
+
                     <div class="promo-hero-metrics" data-reveal="{{ $step + 1 }}">
                         @foreach ($card->groups as $group)
-                            <div class="promo-source">
+                            <div class="promo-source" style="--promo-i: {{ $loop->index }}">
                                 <span class="promo-source-name">{{ $group->sourceLabel }}</span>
                                 <span class="promo-metrics">
                                     @foreach ($group->metrics as $metric)
@@ -47,6 +70,10 @@
                     @endif
                 </article>
             @endforeach
+
+            {{-- Marcador do finale: não desenha nada — quando o deck o marca
+                 `.shown`, o CSS recua a câmera e alinha todos os cards. --}}
+            <span class="promo-finale" data-reveal="{{ 1 + count($cards) * 3 }}" aria-hidden="true"></span>
         </div>
     </div>
 </section>

--- a/app-modules/portal/src/Retrospective/PromotionSlide.php
+++ b/app-modules/portal/src/Retrospective/PromotionSlide.php
@@ -50,13 +50,14 @@ final readonly class PromotionSlide
      * Quantos apertos de seta o slide consome antes de liberar a navegação.
      *
      * A revelação é granular — nome, números e motivo de cada pessoa, um passo
-     * por vez — mais o passo 0, que abre com a pergunta e ninguém na tela. O
+     * por vez — entre o passo 0, que abre com a pergunta e ninguém na tela, e o
+     * passo final, em que a câmera recua e revela todo mundo lado a lado. O
      * slide de destaques não revela nada: mostra a grade inteira de uma vez.
      */
     public function steps(): int
     {
         return $this->stage === PromotionStage::Promoted
-            ? 1 + (count($this->cards) * 3)
+            ? 2 + (count($this->cards) * 3)
             : 0;
     }
 }

--- a/app-modules/portal/tests/Feature/CommunityRetrospectivePageTest.php
+++ b/app-modules/portal/tests/Feature/CommunityRetrospectivePageTest.php
@@ -131,9 +131,12 @@ it('apresenta a He4rt entre a capa e os números', function (): void {
         ->assertSee('Reunião Semanal')
         ->assertSee('Spaces')
         ->assertSee('frequência de encontro')
-        // Canais: vêm do config, e o que este recorte mediu leva selo.
+        // Canais: constelação com todos em pé de igualdade — vêm do config,
+        // e nenhum leva selo nem CTA próprio.
+        ->assertSee('Todos os caminhos dão no mesmo lugar')
         ->assertSee('github.com')
-        ->assertSee('medido aqui');
+        ->assertSee('class="const-star"', escape: false)
+        ->assertDontSee('medido aqui');
 });
 
 it('não anuncia marco que ainda não tinha acontecido no recorte', function (): void {

--- a/app-modules/portal/tests/Feature/PromotionSectionTest.php
+++ b/app-modules/portal/tests/Feature/PromotionSectionTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Carbon\CarbonImmutable;
 use He4rt\Community\Retrospective\DTOs\DeckConfig;
 use He4rt\Community\Retrospective\DTOs\Metric;
 use He4rt\Community\Retrospective\DTOs\PromotionCard;
@@ -23,6 +24,7 @@ function promoCard(string $id, PromotionStage $stage, ?string $reason = 'segurou
             new PromotionMetricGroup('discord', 'Discord', [new Metric('Mensagens', 8_132)]),
             new PromotionMetricGroup('github', 'GitHub', [new Metric('PRs', 47)]),
         ],
+        memberSince: CarbonImmutable::parse('2021-03-10 12:00:00'),
     );
 }
 
@@ -51,7 +53,7 @@ it('não desenha slide sem ninguém e obedece o on/off da curadoria', function (
         ->and($slides[0]->kind)->toBe(PromotionSection::SPOTLIGHT);
 });
 
-it('conta um passo de abertura mais três por pessoa só no slide da tag', function (): void {
+it('conta abertura, três por pessoa e o finale só no slide da tag', function (): void {
     $slides = PromotionSection::slides(
         [
             promoCard('u1', PromotionStage::Spotlight),
@@ -62,7 +64,7 @@ it('conta um passo de abertura mais três por pessoa só no slide da tag', funct
     );
 
     expect($slides[0]->steps())->toBe(0)
-        ->and($slides[1]->steps())->toBe(7);
+        ->and($slides[1]->steps())->toBe(8);
 });
 
 it('a view da tag declara os passos e marca cada faixa da revelação', function (): void {
@@ -70,15 +72,19 @@ it('a view da tag declara os passos e marca cada faixa da revelação', function
 
     $html = Blade::render('@include("portal::retro.slides.he4rt.tag", ["cards" => $cards])', ['cards' => $cards]);
 
-    // 1 + 3 por pessoa; a primeira pessoa entra no passo 1 e a segunda no 4.
-    expect($html)->toContain('data-steps="7"')
+    // 2 + 3 por pessoa; a primeira pessoa entra no passo 1, a segunda no 4 e o
+    // finale — o marcador que recua a câmera — ocupa o último passo.
+    expect($html)->toContain('data-steps="8"')
         ->and($html)->toContain('data-reveal="0"')
         ->and($html)->toContain('data-reveal="1"')
         ->and($html)->toContain('data-reveal="2"')
         ->and($html)->toContain('data-reveal="3"')
         ->and($html)->toContain('data-reveal="4"')
+        ->and($html)->toContain('class="promo-finale" data-reveal="7"')
         ->and($html)->toContain('Fulana u1')
-        ->and($html)->toContain('8.132');
+        ->and($html)->toContain('8.132')
+        ->and($html)->toContain('na comunidade desde')
+        ->and($html)->toContain('2021');
 });
 
 it('o slide de destaques mostra todo mundo e não consome setas', function (): void {

--- a/app-modules/portal/tests/Feature/RetrospectiveSlidesTest.php
+++ b/app-modules/portal/tests/Feature/RetrospectiveSlidesTest.php
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+use Carbon\CarbonImmutable;
+use He4rt\Community\Retrospective\DTOs\HeadlineMetrics;
+use He4rt\Community\Retrospective\DTOs\SourceResult;
+use He4rt\Community\Retrospective\Slides\FrozenSlide;
 use Illuminate\Support\Facades\Blade;
 
 it('na view, mostra só os 3 primeiros refs e um chip "mais X…"', function (): void {
@@ -25,6 +29,40 @@ it('na view, mostra só os 3 primeiros refs e um chip "mais X…"', function ():
         ->and($html)->not->toContain('#7')
         ->and($html)->not->toContain('#6')
         ->and($html)->toContain('mais 2…');
+});
+
+it('no card cheio, os contadores fecham numa régua única e issues viram número', function (): void {
+    $person = [
+        'pr_refs' => [['num' => 1, 'title' => 'feat: a', 'url' => null, 'state' => 'merged']],
+        'issue_refs' => [
+            ['num' => 19, 'title' => 'chore: pnpm', 'url' => null],
+            ['num' => 18, 'title' => 'feat: sink', 'url' => null],
+        ],
+        'reviews' => 41,
+        'comments' => 8,
+        'review_comments' => 3,
+        'commits' => 42,
+    ];
+
+    $html = Blade::render('<x-portal::retro.activity-chips :person="$person" />', ['person' => $person]);
+
+    expect($html)->toContain('cstats strip')
+        ->and($html)->toContain('Abriu PR')
+        ->and($html)->not->toContain('Abriu issue')
+        ->and($html)->not->toContain('Revisou')
+        ->and(mb_substr_count($html, 'class="cstat '))->toBe(5)
+        ->and($html)->toContain('<span class="cstat-n">2</span><span class="cstat-l">issues</span>')
+        ->and($html)->toContain('<span class="cstat-n">41</span><span class="cstat-l">reviews</span>');
+});
+
+it('a barra de composição escala a largura pelo total do topo do trilho', function (): void {
+    $person = ['prs' => 10, 'reviews' => 30, 'issues' => 0, 'comments' => 0, 'review_comments' => 0, 'commits' => 10];
+
+    $scaled = Blade::render('<x-portal::retro.composition-bar :person="$person" :max-total="200" />', ['person' => $person]);
+    $full = Blade::render('<x-portal::retro.composition-bar :person="$person" />', ['person' => $person]);
+
+    expect($scaled)->toContain('width: 25%')
+        ->and($full)->toContain('width: 100%');
 });
 
 it('o card compacto da comunidade mostra só ícone + somatória dos tipos com contribuição', function (): void {
@@ -57,6 +95,209 @@ it('o panorama do github pluraliza repositórios conforme a contagem', function 
 
     expect($html)->toContain($expected);
 })->with([
-    'singular' => [1, 'em 1 repositório.'],
-    'plural' => [3, 'em 3 repositórios.'],
+    'singular' => [1, '1 repositório'],
+    'plural' => [3, '3 repositórios'],
 ]);
+
+it('o panorama do github quebra os totais por tipo e por estado de PR', function (): void {
+    $meta = [
+        'people' => 83, 'total' => 713, 'days' => 32,
+        'prs' => 35, 'prs_merged' => 28, 'prs_unmerged' => 0,
+        'reviews' => 357, 'issues' => 19, 'comments' => 118, 'review_comments' => 56, 'commits' => 128,
+        'additions' => 18_613, 'deletions' => 4_236, 'changed_files' => 389, 'repos' => 6,
+    ];
+
+    $html = view('portal::retro.slides.github.panorama', ['meta' => $meta])->render();
+
+    expect($html)->toContain('713')
+        ->and($html)->toContain('em <b>32 dias</b>')
+        ->and($html)->toContain('bots ficaram de fora')
+        ->and($html)->toContain('Por tipo')
+        ->and($html)->toContain('reviews')
+        ->and($html)->toContain('357')
+        ->and($html)->toContain('50%')
+        ->and($html)->toContain('<b>28</b> merged')
+        ->and($html)->toContain('<b>7</b> abertos')
+        ->and($html)->toContain('<b>0</b> fechados sem merge')
+        ->and($html)->toContain('+18.613')
+        ->and($html)->toContain('−4.236')
+        ->and($html)->toContain('389 arquivos')
+        ->and($html)->toContain('reviews são')
+        ->and($html)->toContain('<b>22,3</b> contribuições por dia');
+});
+
+/**
+ * @param  list<array{login: string, prs: int, additions: int, deletions: int}>  $people
+ * @param  list<array{num: int, author: string, additions: int, deletions: int, state?: string}>  $prs
+ * @return array<string, mixed>
+ */
+function repoFixture(array $people, array $prs): array
+{
+    return [
+        'name' => 'exemplo',
+        'full_name' => 'he4rt/exemplo',
+        'people' => array_map(fn (array $p): array => [...$p, 'avatar' => 'https://example.com/a.png'], $people),
+        'prs' => array_map(fn (array $pr): array => [
+            'num' => $pr['num'],
+            'title' => 'pr '.$pr['num'],
+            'url' => null,
+            'state' => $pr['state'] ?? 'merged',
+            'author_login' => $pr['author'],
+            'additions' => $pr['additions'],
+            'deletions' => $pr['deletions'],
+            'changed_files' => 2,
+        ], $prs),
+        'metrics' => [
+            'prs' => count($prs),
+            'additions' => array_sum(array_column($prs, 'additions')),
+            'deletions' => array_sum(array_column($prs, 'deletions')),
+            'changed_files' => 2 * count($prs),
+        ],
+    ];
+}
+
+it('repo pequeno vira cards hero e mantém a quebra por pessoa', function (): void {
+    $repo = repoFixture(
+        people: [
+            ['login' => 'maria', 'prs' => 1, 'additions' => 187, 'deletions' => 257],
+            ['login' => 'joao', 'prs' => 1, 'additions' => 41, 'deletions' => 0],
+        ],
+        prs: [
+            ['num' => 135, 'author' => 'maria', 'additions' => 187, 'deletions' => 257],
+            ['num' => 134, 'author' => 'joao', 'additions' => 41, 'deletions' => 0, 'state' => 'closed'],
+        ],
+    );
+
+    $html = view('portal::retro.slides.github.repos', ['repo' => $repo, 'index' => 3])->render();
+
+    expect($html)->toContain('is-hero')
+        ->and($html)->toContain('fechado')
+        ->and($html)->toContain('2 arq.')
+        ->and($html)->toContain('Quem mexeu')
+        ->and($html)->toContain('+187')
+        ->and($html)->toContain('−257');
+});
+
+it('repo com autor recorrente mostra a quebra com adições e remoções', function (): void {
+    $repo = repoFixture(
+        people: [
+            ['login' => 'maria', 'prs' => 4, 'additions' => 2_000, 'deletions' => 400],
+            ['login' => 'joao', 'prs' => 1, 'additions' => 41, 'deletions' => 0],
+            ['login' => 'ana', 'prs' => 0, 'additions' => 0, 'deletions' => 0],
+        ],
+        prs: array_map(fn (int $n): array => ['num' => $n, 'author' => 'maria', 'additions' => 500, 'deletions' => 100], [1, 2, 3, 4, 5]),
+    );
+
+    $html = view('portal::retro.slides.github.repos', ['repo' => $repo, 'index' => 1])->render();
+
+    expect($html)->toContain('Quem mexeu')
+        ->and($html)->toContain('4 PRs')
+        ->and($html)->toContain('+2.000')
+        ->and($html)->toContain('−400')
+        ->and($html)->toContain('na revisão e por perto')
+        ->and($html)->not->toContain('is-hero');
+});
+
+it('repo pequeno com snapshot antigo (people sem métricas) degrada para a pilha de avatares', function (): void {
+    $repo = repoFixture(
+        people: [],
+        prs: [['num' => 1, 'author' => 'maria', 'additions' => 10, 'deletions' => 2]],
+    );
+    $repo['people'] = [['login' => 'maria', 'avatar' => 'https://example.com/a.png']];
+
+    $html = view('portal::retro.slides.github.repos', ['repo' => $repo, 'index' => 1])->render();
+
+    expect($html)->toContain('avstack')
+        ->and($html)->not->toContain('Quem mexeu');
+});
+
+it('o panorama do github tolera decks congelados sem a chave days', function (): void {
+    $meta = [
+        'people' => 2, 'total' => 10,
+        'prs' => 3, 'prs_merged' => 2, 'prs_unmerged' => 1,
+        'reviews' => 5, 'issues' => 0, 'comments' => 2, 'review_comments' => 0, 'commits' => 0,
+        'additions' => 100, 'deletions' => 50, 'changed_files' => 4, 'repos' => 1,
+    ];
+
+    $html = view('portal::retro.slides.github.panorama', ['meta' => $meta])->render();
+
+    expect($html)->not->toContain('dias')
+        ->and($html)->not->toContain('contribuições por dia')
+        ->and($html)->toContain('<b>2</b> merged')
+        ->and($html)->toContain('<b>1</b> fechado sem merge');
+});
+
+it('o fechamento troca os badges de fonte pelo muro de avatares do github', function (): void {
+    $people = [
+        ['login' => 'maria', 'avatar' => 'https://avatars.githubusercontent.com/u/42?v=4'],
+        ['login' => 'joao', 'avatar' => 'https://avatars.githubusercontent.com/u/7?v=4'],
+    ];
+    $sources = [new SourceResult('github', 'GitHub', new HeadlineMetrics(), [
+        new FrozenSlide('github.panorama', ['meta' => []]),
+        new FrozenSlide('github.core', ['people' => $people]),
+    ])];
+
+    $html = Blade::render(
+        '<x-portal::retro.slides.closing :sources="$sources" :since="$since" :until="$until" />',
+        ['sources' => $sources, 'since' => CarbonImmutable::parse('2026-06-01'), 'until' => CarbonImmutable::parse('2026-06-30')],
+    );
+
+    expect($html)->toContain('closing-wall')
+        ->and($html)->toContain('avatars.githubusercontent.com/u/42')
+        ->and($html)->toContain('alt="joao"')
+        ->and($html)->not->toContain('gerado a partir de')
+        ->and($html)->not->toContain('bdg neu');
+});
+
+it('o fechamento fica sem muro quando nenhuma fonte trouxe o núcleo do github', function (): void {
+    $sources = [new SourceResult('discord', 'Discord', new HeadlineMetrics(), [])];
+
+    $html = Blade::render(
+        '<x-portal::retro.slides.closing :sources="$sources" :since="$since" :until="$until" />',
+        ['sources' => $sources, 'since' => CarbonImmutable::parse('2026-06-01'), 'until' => CarbonImmutable::parse('2026-06-30')],
+    );
+
+    expect($html)->not->toContain('closing-wall')
+        ->and($html)->toContain('31/05/2026');
+});
+
+it('o painel de conversas abre com um snapshot congelado antes dos campos novos', function (): void {
+    $html = view('portal::retro.slides.discord.messages', [
+        'total' => 120,
+        'with_reactions' => 30,
+        'pinned' => 2,
+        'chatters' => [['name' => 'Alice', 'messages' => 50]],
+    ])->render();
+
+    expect($html)->toContain('vb-totals')
+        ->and($html)->toContain('<b>120</b>')
+        ->and($html)->toContain('Alice')
+        ->and($html)->not->toContain('Pessoas no papo')
+        ->and($html)->not->toContain('Pico ·')
+        ->and($html)->not->toContain('vb-bars');
+});
+
+it('o painel de conversas completo mostra totais, ritmo da semana, ranking e horas', function (): void {
+    $hours = array_map(fn (int $hour): array => ['hour' => $hour, 'messages' => $hour === 21 ? 40 : 1], range(0, 23));
+    $days = array_map(fn (int $weekday): array => ['weekday' => $weekday, 'messages' => $weekday * 10], range(1, 7));
+
+    $html = view('portal::retro.slides.discord.messages', [
+        'total' => 1_200,
+        'with_reactions' => 300,
+        'pinned' => 4,
+        'people' => 85,
+        'peak' => ['date' => '04/06', 'messages' => 210],
+        'chatters' => [['name' => 'Alice', 'messages' => 50, 'xp' => 300, 'reactions' => 12]],
+        'days' => $days,
+        'hours' => $hours,
+    ])->render();
+
+    expect($html)->toContain('Pessoas no papo')
+        ->and($html)->toContain('Pico · 04/06')
+        ->and($html)->toContain('O ritmo da semana')
+        ->and($html)->toContain('Domingo')
+        ->and($html)->toContain('Quem segurou o papo')
+        ->and($html)->toContain('pico 21h · 40')
+        ->and(mb_substr_count($html, 'class="vb-bar"'))->toBe(23)
+        ->and(mb_substr_count($html, 'vb-bar is-peak'))->toBe(1);
+});


### PR DESCRIPTION
## Contexto

O deck da retrospectiva já contava a história da comunidade, mas o painel de conversas do Discord era raso (três números soltos) e o trilho de repositórios do GitHub mostrava as pessoas sem contexto nenhum: só avatar, sem dizer quem de fato meteu PR. Este PR aprofunda os dois painéis e fecha alguns detalhes de narrativa que ficaram pendentes do #516.

O impacto pro usuário: os slides de mensagens e de repos passam a responder "quando a comunidade conversa?" e "quem construiu o quê?", e o slide de promoções ganha o fecho que faltava, com todo mundo lado a lado na tela.

### Alterações

- `DiscordSource`: totais do painel de mensagens numa varredura só da tabela de `messages` (total, com reação, fixadas, pessoas únicas), mais pico do dia, distribuição por dia da semana e por hora. Mesmo argumento do `voiceTotals()`: messages é a maior tabela do banco, cada agregado a mais seria outra varredura do mesmo recorte.
- `MessagesSlide` e a view `discord/messages`: o slide renderiza os novos dados (pico, dias, horas, pessoas).
- `GithubSource`: cada pessoa no trilho de repos carrega suas métricas (PRs, adições, remoções); quem abriu PR aparece primeiro, presença sem PR (review, issue, comentário) vai pro fim.
- Contrato `MembershipDates` no módulo `community` com implementação `DiscordMembershipDates`: alimenta o "na He4rt desde" dos cards de pessoa.
- `ResolvePeople`: resolução de avatares das pessoas do deck.
- `PromotionSlide`: passo final de revelação, a câmera recua e mostra todas as promoções lado a lado.
- Polimento visual geral do deck: `retrospective.css`, slides de capa, join, tag, panorama, repos e closing.

---

## Plano de Testes

- [x] `vendor/bin/pint --dirty` (via lint-staged no commit, com rector)
- [x] Suíte de retrô direcionada via pest: `DiscordSourceTest`, `GithubSourceTest`, `ResolvePeopleAvatarTest`, `ResolvePeopleMemberSinceTest`, `RetrospectiveSnapshotTest`, `DiscordMembershipDatesTest`, `CommunityRetrospectivePageTest`, `PromotionSectionTest`, `RetrospectiveSlidesTest` (111 testes, 418 assertions, tudo verde)

---

## Evidências

Mudança majoritariamente de dados + CSS dos slides. Pra conferir visualmente, abrir `/retrospectiva` e navegar até os slides de mensagens do Discord, repos do GitHub e promoções.

---

## Issues Relacionadas

Continuação do trabalho mergeado em #516.