### PR TITLE
fix(profile): corrige upload de capa e avatar (#458)

### DIFF
--- a/app-modules/identity/src/User/Concerns/HasProfileImages.php
+++ b/app-modules/identity/src/User/Concerns/HasProfileImages.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Identity\User\Concerns;
+
+use He4rt\Identity\User\Enums\ProfileImage;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Str;
+use Spatie\Image\Enums\Fit;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+/**
+ * Avatar e capa do perfil: como são guardados, convertidos e enquadrados.
+ *
+ * As dimensões e limites moram no enum ProfileImage; aqui fica só o que
+ * acontece com o arquivo.
+ */
+trait HasProfileImages
+{
+    /**
+     * Chamado pelo `registerMediaCollections()` do model: o media library
+     * também define esse método, e dois traits com o mesmo nome colidem.
+     */
+    public function registerProfileImageCollections(): void
+    {
+        foreach (ProfileImage::cases() as $image) {
+            $this->addMediaCollection($image->value)
+                ->singleFile()
+                ->useDisk('public')
+                ->acceptsMimeTypes(ProfileImage::mimeTypes())
+                ->registerMediaConversions(function (?Media $media = null) use ($image): void {
+                    // O que é servido inteiro não passa por aqui: converter
+                    // acharia o primeiro quadro de um GIF e mataria a animação.
+                    // O enquadramento desses fica por conta do object-cover.
+                    if (in_array($media?->mime_type, ProfileImage::unconvertedMimeTypes(), strict: true)) {
+                        return;
+                    }
+
+                    // Para o resto, o front recebe sempre a mesma dimensão e o
+                    // mesmo formato, independente do arquivo enviado. Aqui
+                    // também é onde o upscale acontece, quando necessário.
+                    $this->addMediaConversion($image->value)
+                        ->nonQueued()
+                        ->fit(Fit::Crop, $image->width(), $image->height())
+                        ->format('webp');
+                });
+        }
+    }
+
+    public function putImage(ProfileImage $image, UploadedFile $file): void
+    {
+        $this->refreshMediaRelation();
+
+        // A collection é singleFile: o media library troca a imagem anterior.
+        $this->addMedia($file)
+            ->usingFileName(Str::uuid()->toString().'.'.$this->extensionOf($file))
+            ->toMediaCollection($image->value);
+    }
+
+    public function removeImage(ProfileImage $image): void
+    {
+        $this->refreshMediaRelation();
+
+        $this->clearMediaCollection($image->value);
+    }
+
+    /**
+     * URL da conversão normalizada, caindo no original quando não existe
+     * conversão: mídia antiga, ou formato que é servido como chega.
+     */
+    public function imageUrl(ProfileImage $image): ?string
+    {
+        $media = $this->getFirstMedia($image->value);
+
+        if (!$media instanceof Media) {
+            return null;
+        }
+
+        return $media->hasGeneratedConversion($image->value)
+            ? $media->getUrl($image->value)
+            : $media->getUrl();
+    }
+
+    /**
+     * Imagem servida inteira, sem conversão, depende do enquadramento para
+     * decidir o que aparece no recorte da tela.
+     */
+    public function imageNeedsFraming(ProfileImage $image): bool
+    {
+        $media = $this->getFirstMedia($image->value);
+
+        return $media instanceof Media && !$media->hasGeneratedConversion($image->value);
+    }
+
+    /**
+     * Faixa vertical da imagem que aparece no recorte da tela, em porcentagem.
+     */
+    public function imageFocalY(ProfileImage $image): int
+    {
+        $focalY = $this->getFirstMedia($image->value)?->getCustomProperty('focal_y');
+
+        return is_numeric($focalY) ? (int) $focalY : ProfileImage::DEFAULT_FOCAL_Y;
+    }
+
+    public function setImageFocalY(ProfileImage $image, int $focalY): void
+    {
+        $media = $this->getFirstMedia($image->value);
+
+        if (!$media instanceof Media) {
+            return;
+        }
+
+        $media->setCustomProperty('focal_y', max(0, min(100, $focalY)));
+        $media->save();
+    }
+
+    /**
+     * O media library resolve `singleFile` lendo a relação já carregada. Numa
+     * requisição Livewire ela foi carregada na renderização, antes do upload,
+     * então sem descartar o cache a imagem anterior não é encontrada e fica
+     * órfã no disco.
+     */
+    private function refreshMediaRelation(): void
+    {
+        $this->unsetRelation('media');
+    }
+
+    private function extensionOf(UploadedFile $file): string
+    {
+        return $file->getClientOriginalExtension() ?: $file->guessExtension() ?: 'jpg';
+    }
+}

--- a/app-modules/identity/src/User/Enums/ProfileImage.php
+++ b/app-modules/identity/src/User/Enums/ProfileImage.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Identity\User\Enums;
+
+/**
+ * Fonte única de configuração das imagens de perfil: nome da collection no
+ * media library, dimensão servida ao front, piso aceito no upload, proporção
+ * e limite de tamanho.
+ *
+ * Variação de imagem aqui é dado, não subclasse: uma imagem nova entra como
+ * mais um case e já nasce com upload, recorte, validação e conversão.
+ *
+ * Altura é sempre derivada da proporção, nunca armazenada, senão largura e
+ * altura divergem e o recorte deixa de ser previsível.
+ */
+enum ProfileImage: string
+{
+    case Avatar = 'avatar';
+    case Cover = 'cover';
+
+    /** Centro da imagem: o recorte pega a faixa do meio. */
+    public const int DEFAULT_FOCAL_Y = 50;
+
+    /**
+     * @return list<string>
+     */
+    public static function mimeTypes(): array
+    {
+        return ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+    }
+
+    /**
+     * Formatos servidos exatamente como chegam, sem conversão.
+     *
+     * @return list<string>
+     */
+    public static function unconvertedMimeTypes(): array
+    {
+        return ['image/gif'];
+    }
+
+    /**
+     * Teto menor para o que é servido sem conversão: nesses formatos o peso do
+     * upload é o peso que cada visita ao perfil baixa.
+     */
+    public static function unconvertedMaxKilobytes(): int
+    {
+        return 2_048;
+    }
+
+    /**
+     * Os mesmos formatos, como o usuário os reconhece.
+     *
+     * GIF entra, mas sai estático: a conversão roda no GD, que lê só o
+     * primeiro quadro, e o editor de recorte serializa via canvas, que não
+     * preserva animação em formato nenhum. Preservar exigiria Imagick e
+     * servir o arquivo original, abrindo mão da dimensão normalizada.
+     */
+    public static function formatLabels(): string
+    {
+        return 'JPG, PNG, GIF, WEBP';
+    }
+
+    /**
+     * Largura da conversão servida ao front.
+     */
+    public function width(): int
+    {
+        return match ($this) {
+            self::Avatar => 500,
+            self::Cover => 1_800,
+        };
+    }
+
+    public function height(): int
+    {
+        return $this->heightFor($this->width());
+    }
+
+    /**
+     * Menor largura aceita no upload. Abaixo disso o upscale ficaria agressivo
+     * demais; entre o piso e a largura ideal, quem estica é a conversão.
+     */
+    public function minWidth(): int
+    {
+        return match ($this) {
+            self::Avatar => 256,
+            self::Cover => 1_200,
+        };
+    }
+
+    public function minHeight(): int
+    {
+        return $this->heightFor($this->minWidth());
+    }
+
+    /**
+     * Proporção no formato aceito pelo editor de recorte do Filament.
+     */
+    public function aspectRatio(): string
+    {
+        [$width, $height] = $this->ratio();
+
+        return sprintf('%d:%d', $width, $height);
+    }
+
+    /**
+     * A mesma proporção, no formato da propriedade CSS `aspect-ratio`. O blade
+     * não deve conhecer esses números por conta própria.
+     */
+    public function cssAspectRatio(): string
+    {
+        [$width, $height] = $this->ratio();
+
+        return sprintf('%d / %d', $width, $height);
+    }
+
+    public function maxKilobytes(): int
+    {
+        return match ($this) {
+            self::Avatar => 2_048,
+            self::Cover => 4_096,
+        };
+    }
+
+    /**
+     * @return array{int, int}
+     */
+    private function ratio(): array
+    {
+        return match ($this) {
+            self::Avatar => [1, 1],
+            self::Cover => [3, 1],
+        };
+    }
+
+    private function heightFor(int $width): int
+    {
+        [$ratioWidth, $ratioHeight] = $this->ratio();
+
+        return intdiv($width * $ratioHeight, $ratioWidth);
+    }
+}

--- a/app-modules/identity/src/User/Enums/ProfileImage.php
+++ b/app-modules/identity/src/User/Enums/ProfileImage.php
@@ -53,10 +53,9 @@ enum ProfileImage: string
     /**
      * Os mesmos formatos, como o usuário os reconhece.
      *
-     * GIF entra, mas sai estático: a conversão roda no GD, que lê só o
-     * primeiro quadro, e o editor de recorte serializa via canvas, que não
-     * preserva animação em formato nenhum. Preservar exigiria Imagick e
-     * servir o arquivo original, abrindo mão da dimensão normalizada.
+     * GIF entra e é servido como chega, com a animação intacta: converter
+     * leria só o primeiro quadro no GD. Quem recorta pelo editor perde a
+     * animação, porque o recorte acontece no canvas do browser.
      */
     public static function formatLabels(): string
     {

--- a/app-modules/identity/src/User/Models/User.php
+++ b/app-modules/identity/src/User/Models/User.php
@@ -13,6 +13,7 @@ use He4rt\Activity\Tracking\Concerns\HasInteractions;
 use He4rt\Gamification\Character\Models\Character;
 use He4rt\Identity\Database\Factories\UserFactory;
 use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
+use He4rt\Identity\User\Concerns\HasProfileImages;
 use He4rt\Identity\User\Enums\UserSituation;
 use He4rt\Identity\User\Observers\UserObserver;
 use He4rt\Profile\Models\Profile;
@@ -54,6 +55,7 @@ final class User extends Authenticatable implements FilamentUser, HasMedia, HasN
     /** @use HasFactory<UserFactory> */
     use HasFactory;
     use HasInteractions;
+    use HasProfileImages;
     use HasUuids;
     use InteractsWithMedia;
     use Notifiable;
@@ -94,13 +96,7 @@ final class User extends Authenticatable implements FilamentUser, HasMedia, HasN
 
     public function registerMediaCollections(): void
     {
-        $this->addMediaCollection('avatar')
-            ->singleFile()
-            ->useDisk('public');
-
-        $this->addMediaCollection('cover')
-            ->singleFile()
-            ->useDisk('public');
+        $this->registerProfileImageCollections();
     }
 
     public function canAccessPanel(Panel $panel): bool

--- a/app-modules/identity/tests/Unit/User/ProfileImageTest.php
+++ b/app-modules/identity/tests/Unit/User/ProfileImageTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Identity\User\Enums\ProfileImage;
+
+test('height is always derived from the aspect ratio', function (ProfileImage $image): void {
+    [$ratioWidth, $ratioHeight] = explode(':', $image->aspectRatio());
+
+    expect($image->height())->toBe(intdiv($image->width() * (int) $ratioHeight, (int) $ratioWidth))
+        ->and($image->minHeight())->toBe(intdiv($image->minWidth() * (int) $ratioHeight, (int) $ratioWidth));
+})->with(ProfileImage::cases());
+
+test('the minimum is never bigger than the recommended size', function (ProfileImage $image): void {
+    expect($image->minWidth())->toBeLessThanOrEqual($image->width())
+        ->and($image->minHeight())->toBeLessThanOrEqual($image->height());
+})->with(ProfileImage::cases());
+
+test('css aspect ratio mirrors the cropper aspect ratio', function (ProfileImage $image): void {
+    expect($image->cssAspectRatio())->toBe(str_replace(':', ' / ', $image->aspectRatio()));
+})->with(ProfileImage::cases());
+
+test('cover is wide and avatar is square', function (): void {
+    expect(ProfileImage::Cover->aspectRatio())->toBe('3:1')
+        ->and(ProfileImage::Avatar->aspectRatio())->toBe('1:1');
+});

--- a/app-modules/panel-app/lang/en/profile.php
+++ b/app-modules/panel-app/lang/en/profile.php
@@ -58,12 +58,21 @@ return [
     ],
 
     'hints' => [
+        'adjust_framing' => 'Drag to choose which slice of the image stays visible.',
+        'image_upload' => ':formats up to :max_mb MB. Recommended :width × :height px, at least :min_width × :min_height px after cropping. GIFs keep their animation, but cropping drops it.',
+        'image_upload_with_gif_limit' => ':formats up to :max_mb MB, GIF up to :gif_mb MB. Recommended :width × :height px, at least :min_width × :min_height px after cropping. GIFs keep their animation, but cropping drops it.',
         'headline' => 'e.g. Frontend Developer, Product Designer',
         'available_for_proposals' => 'When active, recruiters will see a green badge on your profile',
         'city' => 'If your city is not listed, search for it.',
         'has_disability' => 'Sensitive information — used only for affirmative-action roles.',
         'expected_salary' => 'Monthly amount in BRL. Private, used only in proposals.',
         'skills' => 'Pick your skills and set your level and years of experience for each.',
+    ],
+
+    'validation' => [
+        'image_dimensions' => 'After cropping, the image must be at least :min_width × :min_height px. The recommended size is :width × :height px.',
+        'image_mimetypes' => 'Unsupported format. Upload a :formats image.',
+        'image_unconverted_max_size' => 'A GIF can be at most :gif_mb MB. It is served exactly as it arrives, with no compression, so the file weighs on every profile visit.',
     ],
 
     'actions' => [
@@ -73,6 +82,9 @@ return [
         'add_skill' => 'Add skill',
         'change_avatar' => 'Change photo',
         'change_cover' => 'Change cover',
+        'adjust_avatar' => 'Adjust photo framing',
+        'adjust_cover' => 'Adjust framing',
+        'save_framing' => 'Save framing',
         'save_avatar' => 'Save photo',
         'save_cover' => 'Save cover',
     ],
@@ -81,6 +93,7 @@ return [
         'saved' => 'Profile saved successfully!',
         'avatar_updated' => 'Photo updated successfully!',
         'cover_updated' => 'Cover updated successfully!',
+        'framing_updated' => 'Framing saved!',
         'no_profile' => 'Profile not found for this tenant.',
     ],
 

--- a/app-modules/panel-app/lang/pt_BR/profile.php
+++ b/app-modules/panel-app/lang/pt_BR/profile.php
@@ -58,12 +58,21 @@ return [
     ],
 
     'hints' => [
+        'adjust_framing' => 'Arraste para escolher a faixa da imagem que fica visível.',
+        'image_upload' => ':formats até :max_mb MB. Recomendado :width × :height px, mínimo :min_width × :min_height px depois do recorte. GIF mantém a animação, mas o recorte a remove.',
+        'image_upload_with_gif_limit' => ':formats até :max_mb MB, GIF até :gif_mb MB. Recomendado :width × :height px, mínimo :min_width × :min_height px depois do recorte. GIF mantém a animação, mas o recorte a remove.',
         'headline' => 'Ex: Frontend Developer, Product Designer',
         'available_for_proposals' => 'Quando ativo, recrutadores verão um badge verde no seu perfil',
         'has_disability' => 'Informação sensível — usada apenas para vagas afirmativas/PcD.',
         'expected_salary' => 'Valor mensal em R$. Informação privada, usada apenas em propostas.',
         'skills' => 'Selecione suas skills e informe o nível e os anos de experiência em cada uma.',
         'city' => 'Se sua cidade não estiver na listagem, pesquise.',
+    ],
+
+    'validation' => [
+        'image_dimensions' => 'A imagem, depois do recorte, precisa ter no mínimo :min_width × :min_height px. O recomendado é :width × :height px.',
+        'image_mimetypes' => 'Formato não suportado. Envie uma imagem :formats.',
+        'image_unconverted_max_size' => 'GIF pode ter no máximo :gif_mb MB. Como ele é exibido do jeito que chega, sem compressão, o arquivo pesa em cada visita ao perfil.',
     ],
 
     'actions' => [
@@ -73,6 +82,9 @@ return [
         'add_skill' => 'Adicionar skill',
         'change_avatar' => 'Alterar foto',
         'change_cover' => 'Alterar capa',
+        'adjust_avatar' => 'Ajustar enquadramento da foto',
+        'adjust_cover' => 'Ajustar enquadramento',
+        'save_framing' => 'Salvar enquadramento',
         'save_avatar' => 'Salvar foto',
         'save_cover' => 'Salvar capa',
     ],
@@ -81,6 +93,7 @@ return [
         'saved' => 'Perfil salvo com sucesso!',
         'avatar_updated' => 'Foto atualizada com sucesso!',
         'cover_updated' => 'Capa atualizada com sucesso!',
+        'framing_updated' => 'Enquadramento salvo!',
         'no_profile' => 'Perfil não encontrado para este tenant.',
     ],
 

--- a/app-modules/panel-app/resources/views/components/image-focal-picker.blade.php
+++ b/app-modules/panel-app/resources/views/components/image-focal-picker.blade.php
@@ -1,0 +1,32 @@
+{{-- O preview roda no Alpine, sem ida ao servidor: arrastar precisa responder
+     na hora. O valor entra no state do formulário e só é salvo no submit. --}}
+<div
+    x-data="{ focalY: $wire.$entangle('{{ $getStatePath() }}') }"
+    class="space-y-3"
+>
+    <div
+        @class([
+            'overflow-hidden ring-1 ring-gray-950/5 dark:ring-white/10',
+            'mx-auto w-40 rounded-full' => $isCircle ?? false,
+            'rounded-lg' => !($isCircle ?? false),
+        ])
+        style="aspect-ratio: {{ $aspectRatio }}"
+    >
+        <img
+            src="{{ $imageUrl }}"
+            alt=""
+            class="h-full w-full object-cover"
+            :style="`object-position: center ${focalY}%`"
+        />
+    </div>
+
+    <input
+        type="range"
+        min="0"
+        max="100"
+        step="1"
+        x-model.number="focalY"
+        class="w-full accent-primary-600"
+        aria-label="{{ __('panel-app::profile.hints.adjust_framing') }}"
+    />
+</div>

--- a/app-modules/panel-app/resources/views/components/profile-media-header.blade.php
+++ b/app-modules/panel-app/resources/views/components/profile-media-header.blade.php
@@ -50,7 +50,7 @@
                 type="button"
                 wire:click="mountAction('adjustCover')"
                 title="{{ __('panel-app::profile.actions.adjust_cover') }}"
-                class="absolute top-3 right-12 z-20 rounded-full bg-black/60 p-1.5 text-white transition-opacity hover:bg-black/80"
+                class="absolute top-3 right-12 z-20 rounded-full bg-black/60 p-1.5 text-white transition-opacity hover:bg-black/80 focus-visible:opacity-100"
                 :class="hover ? 'opacity-100' : 'opacity-0'"
             >
                 <x-heroicon-m-arrows-up-down class="h-4 w-4" />
@@ -59,7 +59,7 @@
             <button
                 type="button"
                 wire:click="removeCover"
-                class="absolute top-3 right-3 z-20 rounded-full bg-black/60 p-1.5 text-white transition-opacity hover:bg-black/80"
+                class="absolute top-3 right-3 z-20 rounded-full bg-black/60 p-1.5 text-white transition-opacity hover:bg-black/80 focus-visible:opacity-100"
                 :class="hover ? 'opacity-100' : 'opacity-0'"
             >
                 <x-heroicon-m-x-mark class="h-4 w-4" />
@@ -111,7 +111,7 @@
                     <button
                         type="button"
                         wire:click="removeAvatar"
-                        class="absolute -top-1 -right-1 z-20 rounded-full bg-red-500 p-1 text-white shadow-md transition-opacity hover:bg-red-600"
+                        class="absolute -top-1 -right-1 z-20 rounded-full bg-red-500 p-1 text-white shadow-md transition-opacity hover:bg-red-600 focus-visible:opacity-100"
                         :class="hover ? 'opacity-100' : 'opacity-0'"
                     >
                         <x-heroicon-m-x-mark class="h-3.5 w-3.5" />

--- a/app-modules/panel-app/resources/views/components/profile-media-header.blade.php
+++ b/app-modules/panel-app/resources/views/components/profile-media-header.blade.php
@@ -4,18 +4,27 @@
     'initials' => '',
     'name' => '',
     'birthdateForm' => null,
+    'coverAspectRatio',
+    'coverFocalY' => 50,
+    'avatarFocalY' => 50,
 ])
 
 <div class="relative rounded-xl border border-gray-200 bg-white dark:border-white/10 dark:bg-gray-900">
-    {{-- Cover --}}
+    {{-- Cover: a proporcao vem do enum, para o recorte nao depender da viewport --}}
     <div
-        class="group relative h-40 overflow-hidden rounded-t-xl sm:h-48"
+        class="group relative overflow-hidden rounded-t-xl"
+        style="aspect-ratio: {{ $coverAspectRatio }}"
         x-data="{ hover: false }"
         @mouseenter="hover = true"
         @mouseleave="hover = false"
     >
         @if ($coverPreviewUrl)
-            <img src="{{ $coverPreviewUrl }}" alt="" class="absolute inset-0 h-full w-full object-cover" />
+            <img
+                src="{{ $coverPreviewUrl }}"
+                alt=""
+                class="absolute inset-0 h-full w-full object-cover"
+                style="object-position: center {{ $coverFocalY }}%"
+            />
         @else
             <div class="absolute inset-0 bg-gradient-to-br from-purple-600 via-purple-500 to-indigo-600"></div>
         @endif
@@ -37,6 +46,16 @@
         </button>
 
         @if ($coverPreviewUrl)
+            <button
+                type="button"
+                wire:click="mountAction('adjustCover')"
+                title="{{ __('panel-app::profile.actions.adjust_cover') }}"
+                class="absolute top-3 right-12 z-20 rounded-full bg-black/60 p-1.5 text-white transition-opacity hover:bg-black/80"
+                :class="hover ? 'opacity-100' : 'opacity-0'"
+            >
+                <x-heroicon-m-arrows-up-down class="h-4 w-4" />
+            </button>
+
             <button
                 type="button"
                 wire:click="removeCover"
@@ -63,6 +82,7 @@
                         src="{{ $avatarPreviewUrl }}"
                         alt="{{ $name }}"
                         class="h-full w-full rounded-full border-4 border-white object-cover shadow-lg dark:border-gray-800"
+                        style="object-position: center {{ $avatarFocalY }}%"
                     />
                 @else
                     <div

--- a/app-modules/panel-app/resources/views/components/profile-preview-card.blade.php
+++ b/app-modules/panel-app/resources/views/components/profile-preview-card.blade.php
@@ -4,7 +4,10 @@
     'character' => null,
     'initials' => '',
     'avatarPreviewUrl' => null,
-    'coverPreviewUrl' => null
+    'coverPreviewUrl' => null,
+    'coverAspectRatio',
+    'coverFocalY' => 50,
+    'avatarFocalY' => 50
 ])
 
 @php
@@ -82,9 +85,17 @@
     class="w-full overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm dark:border-white/10 dark:bg-gray-900"
 >
     {{-- Header gradient / cover --}}
-    <div class="relative h-24 bg-gradient-to-r from-purple-600 to-purple-500">
+    <div
+        class="relative bg-gradient-to-r from-purple-600 to-purple-500"
+        style="aspect-ratio: {{ $coverAspectRatio }}"
+    >
         @if ($coverPreviewUrl)
-            <img src="{{ $coverPreviewUrl }}" alt="" class="absolute inset-0 h-full w-full object-cover" />
+            <img
+                src="{{ $coverPreviewUrl }}"
+                alt=""
+                class="absolute inset-0 h-full w-full object-cover"
+                style="object-position: center {{ $coverFocalY }}%"
+            />
         @endif
 
         {{-- Level badge --}}
@@ -100,6 +111,7 @@
                 <img
                     src="{{ $avatarPreviewUrl }}"
                     alt="{{ $name }}"
+                    style="object-position: center {{ $avatarFocalY }}%"
                     class="h-16 w-16 rounded-full border-4 border-white object-cover shadow-md dark:border-gray-800"
                 />
             @else

--- a/app-modules/panel-app/resources/views/pages/profile.blade.php
+++ b/app-modules/panel-app/resources/views/pages/profile.blade.php
@@ -10,6 +10,9 @@
                 [
                     'avatarPreviewUrl' => $this->avatarPreviewUrl,
                     'coverPreviewUrl' => $this->coverPreviewUrl,
+                    'coverAspectRatio' => $this->coverAspectRatio,
+                    'coverFocalY' => $this->coverFocalY,
+                    'avatarFocalY' => $this->avatarFocalY,
                     'initials' => $this->initials,
                     'name' => auth()->user()->name,
                     'birthdateForm' => $this->birthdateForm,
@@ -27,7 +30,10 @@
                     'character' => $this->character,
                     'initials' => $this->initials,
                     'avatarPreviewUrl' => $this->avatarPreviewUrl,
-                    'coverPreviewUrl' => $this->coverPreviewUrl
+                    'coverPreviewUrl' => $this->coverPreviewUrl,
+                    'coverAspectRatio' => $this->coverAspectRatio,
+                    'coverFocalY' => $this->coverFocalY,
+                    'avatarFocalY' => $this->avatarFocalY
                 ])
 
             <div class="rounded-xl bg-white p-4 ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10">

--- a/app-modules/panel-app/src/Pages/ProfilePage.php
+++ b/app-modules/panel-app/src/Pages/ProfilePage.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace He4rt\PanelApp\Pages;
 
 use App\Geo\Support\GeoLocation;
+use App\Support\UploadLimit;
 use BackedEnum;
 use Filament\Actions\Action;
 use Filament\Forms\Components\DatePicker;
@@ -14,6 +15,7 @@ use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
+use Filament\Forms\Components\ViewField;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Filament\Schemas\Components\Actions;
@@ -26,7 +28,9 @@ use Filament\Schemas\JsContent;
 use Filament\Schemas\Schema;
 use Filament\Support\Enums\Width;
 use He4rt\Gamification\Character\Models\Character;
+use He4rt\Identity\User\Enums\ProfileImage;
 use He4rt\Identity\User\Models\User;
+use He4rt\PanelApp\Rules\UnconvertedImageSize;
 use He4rt\Profile\Actions\SyncProfileSkills;
 use He4rt\Profile\Actions\ToggleAvailability;
 use He4rt\Profile\Actions\UpsertProfile;
@@ -39,6 +43,7 @@ use He4rt\Profile\Enums\SocialPlatform;
 use He4rt\Profile\Enums\StartAvailability;
 use He4rt\Profile\Models\Profile;
 use He4rt\Profile\Models\Skill;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Str;
 use Livewire\Attributes\Computed;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
@@ -47,6 +52,10 @@ use Livewire\WithFileUploads;
 /**
  * @property-read Schema $form
  * @property-read Schema $birthdateForm
+ * @property-read string|null $avatarPreviewUrl
+ * @property-read string|null $coverPreviewUrl
+ * @property-read int $avatarFocalY
+ * @property-read int $coverFocalY
  */
 class ProfilePage extends Page
 {
@@ -478,83 +487,22 @@ class ProfilePage extends Page
 
     public function editAvatarAction(): Action
     {
-        return Action::make('editAvatar')
-            ->label(__('panel-app::profile.actions.change_avatar'))
-            ->modalHeading(__('panel-app::profile.actions.change_avatar'))
-            ->modalSubmitActionLabel(__('panel-app::profile.actions.save_avatar'))
-            ->modalSubmitAction(fn (Action $action) => $action->color('primary'))
-            ->schema([
-                FileUpload::make('avatar')
-                    ->label(__('panel-app::profile.fields.avatar'))
-                    ->avatar()
-                    ->imageEditor()
-                    ->circleCropper()
-                    ->imageEditorAspectRatioOptions(['1:1'])
-                    ->storeFiles(condition: false)
-                    ->required()
-                    ->maxSize(2_048),
-            ])
-            ->action(function (array $data): void {
-                $avatar = $data['avatar'] ?? null;
-
-                if (is_string($avatar)) {
-                    $avatar = TemporaryUploadedFile::createFromLivewire($avatar);
-                }
-
-                if (!$avatar instanceof TemporaryUploadedFile) {
-                    return;
-                }
-
-                $this->replaceMedia('avatar', $avatar);
-
-                Notification::make()
-                    ->success()
-                    ->title(__('panel-app::profile.notifications.avatar_updated'))
-                    ->send();
-            });
+        return $this->imageUploadAction('editAvatar', ProfileImage::Avatar);
     }
 
     public function editCoverAction(): Action
     {
-        return Action::make('editCover')
-            ->label(__('panel-app::profile.actions.change_cover'))
-            ->modalHeading(__('panel-app::profile.actions.change_cover'))
-            ->modalSubmitActionLabel(__('panel-app::profile.actions.save_cover'))
-            ->modalSubmitAction(fn (Action $action) => $action->color('primary'))
-            ->schema([
-                FileUpload::make('cover')
-                    ->label(__('panel-app::profile.fields.cover'))
-                    ->image()
-                    ->panelAspectRatio('3:1')
-                    ->imageEditor()
-                    ->imageAspectRatio('3:1')
-                    ->imageEditorAspectRatioOptions(['3:1'])
-                    ->automaticallyCropImagesToAspectRatio()
-                    ->automaticallyResizeImagesMode('cover')
-                    ->automaticallyResizeImagesToWidth('1800')
-                    ->automaticallyResizeImagesToHeight('600')
-                    ->storeFiles(condition: false)
-                    ->required()
-                    ->maxSize(4_096),
-            ])
-            ->action(function (array $data): void {
-                $cover = $data['cover'] ?? null;
+        return $this->imageUploadAction('editCover', ProfileImage::Cover);
+    }
 
-                if (is_string($cover)) {
-                    $cover = TemporaryUploadedFile::createFromLivewire($cover);
-                }
+    public function adjustAvatarAction(): Action
+    {
+        return $this->imageFramingAction('adjustAvatar', ProfileImage::Avatar);
+    }
 
-                if (!$cover instanceof TemporaryUploadedFile) {
-                    return;
-                }
-
-                $this->replaceMedia('cover', $cover);
-
-                Notification::make()
-                    ->success()
-                    ->title(__('panel-app::profile.notifications.cover_updated'))
-                    ->send();
-            });
+    public function adjustCoverAction(): Action
+    {
+        return $this->imageFramingAction('adjustCover', ProfileImage::Cover);
     }
 
     public function getRecord(): Profile
@@ -587,12 +535,36 @@ class ProfilePage extends Page
     }
 
     #[Computed]
+    public function coverAspectRatio(): string
+    {
+        return ProfileImage::Cover->cssAspectRatio();
+    }
+
+    #[Computed]
+    public function coverFocalY(): int
+    {
+        /** @var User $user */
+        $user = auth()->user()->fresh();
+
+        return $user->imageFocalY(ProfileImage::Cover);
+    }
+
+    #[Computed]
+    public function avatarFocalY(): int
+    {
+        /** @var User $user */
+        $user = auth()->user()->fresh();
+
+        return $user->imageFocalY(ProfileImage::Avatar);
+    }
+
+    #[Computed]
     public function avatarPreviewUrl(): ?string
     {
         /** @var User $user */
         $user = auth()->user()->fresh();
 
-        return $user->getFirstMediaUrl('avatar') ?: null;
+        return $user->imageUrl(ProfileImage::Avatar);
     }
 
     #[Computed]
@@ -601,28 +573,241 @@ class ProfilePage extends Page
         /** @var User $user */
         $user = auth()->user()->fresh();
 
-        return $user->getFirstMediaUrl('cover') ?: null;
+        return $user->imageUrl(ProfileImage::Cover);
     }
 
     public function removeAvatar(): void
     {
-        auth()->user()->clearMediaCollection('avatar');
+        $this->removeImage(ProfileImage::Avatar);
     }
 
     public function removeCover(): void
     {
-        auth()->user()->clearMediaCollection('cover');
+        $this->removeImage(ProfileImage::Cover);
     }
 
-    private function replaceMedia(string $collection, TemporaryUploadedFile $file): void
+    /**
+     * Escolhe qual faixa vertical da imagem aparece no recorte da tela.
+     *
+     * Existe para o que nao passa pelo editor: recortar um GIF achataria a
+     * animacao, entao ele e servido inteiro e o enquadramento vira CSS.
+     */
+    private function imageFramingAction(string $name, ProfileImage $image): Action
+    {
+        return Action::make($name)
+            ->label(__('panel-app::profile.actions.adjust_'.$image->value))
+            ->modalHeading(__('panel-app::profile.actions.adjust_'.$image->value))
+            ->modalDescription(__('panel-app::profile.hints.adjust_framing'))
+            ->modalSubmitActionLabel(__('panel-app::profile.actions.save_framing'))
+            ->modalSubmitAction(fn (Action $action) => $action->color('primary'))
+            ->modalWidth(Width::TwoExtraLarge)
+            ->visible(fn (): bool => filled($this->imagePreviewUrl($image)))
+            ->schema([
+                ViewField::make('focal_y')
+                    ->hiddenLabel()
+                    ->view('panel-app::components.image-focal-picker')
+                    ->viewData([
+                        'imageUrl' => $this->imagePreviewUrl($image),
+                        'aspectRatio' => $image->cssAspectRatio(),
+                        'isCircle' => $image === ProfileImage::Avatar,
+                    ])
+                    ->default(function () use ($image): int {
+                        /** @var User $user */
+                        $user = auth()->user();
+
+                        return $user->imageFocalY($image);
+                    }),
+            ])
+            ->action(function (array $data) use ($image): void {
+                $focalY = $data['focal_y'] ?? null;
+
+                /** @var User $user */
+                $user = auth()->user();
+                $user->setImageFocalY($image, is_numeric($focalY) ? (int) $focalY : ProfileImage::DEFAULT_FOCAL_Y);
+
+                $this->refreshImageComputeds();
+
+                Notification::make()
+                    ->success()
+                    ->title(__('panel-app::profile.notifications.framing_updated'))
+                    ->send();
+            });
+    }
+
+    /**
+     * Upload com recorte na proporcao da imagem. O editor do Filament roda no
+     * browser antes do upload, entao a validacao de dimensao abaixo mede o
+     * resultado do recorte, e nao o arquivo bruto.
+     */
+    private function imageUploadAction(string $name, ProfileImage $image): Action
+    {
+        $limits = $this->imageLimits($image);
+
+        return Action::make($name)
+            ->label(__('panel-app::profile.actions.change_'.$image->value))
+            ->modalHeading(__('panel-app::profile.actions.change_'.$image->value))
+            ->modalSubmitActionLabel(__('panel-app::profile.actions.save_'.$image->value))
+            ->modalSubmitAction(fn (Action $action) => $action->color('primary'))
+            // O autofocus do modal cai no input do FilePond, que responde ao
+            // foco abrindo o seletor de arquivos; com o focus trap reaplicando
+            // o foco, o dialogo do sistema reabre em loop.
+            ->modalAutofocus(condition: false)
+            ->schema([
+                $this->imageUploadField($image, $limits),
+            ])
+            ->action(function (array $data) use ($image): void {
+                $file = $data[$image->value] ?? null;
+
+                if (is_string($file)) {
+                    $file = TemporaryUploadedFile::createFromLivewire($file);
+                }
+
+                if (!$file instanceof UploadedFile) {
+                    return;
+                }
+
+                /** @var User $user */
+                $user = auth()->user();
+                $user->putImage($image, $file);
+
+                $this->refreshImageComputeds();
+
+                Notification::make()
+                    ->success()
+                    ->title(__('panel-app::profile.notifications.'.$image->value.'_updated'))
+                    ->send();
+
+                // Sem conversao a imagem vai inteira para a tela, e ai o
+                // enquadramento e que decide o que aparece. Emenda o ajuste no
+                // mesmo fluxo em vez de exigir que o usuario ache o botao.
+                if ($user->imageNeedsFraming($image)) {
+                    $this->replaceMountedAction($this->framingActionName($image));
+                }
+            });
+    }
+
+    /**
+     * Limites de upload da imagem, em KB para as regras e em MB para o texto.
+     *
+     * O teto anunciado nunca passa do que o php.ini aceita, senao o PHP recusa
+     * o arquivo antes da validacao e o que sobra na tela e "failed to upload".
+     *
+     * @return array{width: int, height: int, min_width: int, min_height: int, max_kb: int, unconverted_max_kb: int, max_mb: float, gif_mb: float, formats: string}
+     */
+    private function imageLimits(ProfileImage $image): array
+    {
+        $maxKilobytes = UploadLimit::kilobytes($image->maxKilobytes());
+        $unconvertedMaxKilobytes = min($maxKilobytes, ProfileImage::unconvertedMaxKilobytes());
+
+        return [
+            'width' => $image->width(),
+            'height' => $image->height(),
+            'min_width' => $image->minWidth(),
+            'min_height' => $image->minHeight(),
+            'max_kb' => $maxKilobytes,
+            'unconverted_max_kb' => $unconvertedMaxKilobytes,
+            'max_mb' => round($maxKilobytes / 1_024, 1),
+            'gif_mb' => round($unconvertedMaxKilobytes / 1_024, 1),
+            'formats' => ProfileImage::formatLabels(),
+        ];
+    }
+
+    /**
+     * @param  array{width: int, height: int, min_width: int, min_height: int, max_kb: int, unconverted_max_kb: int, max_mb: float, gif_mb: float, formats: string}  $limits
+     */
+    private function imageUploadField(ProfileImage $image, array $limits): FileUpload
+    {
+        $field = match ($image) {
+            ProfileImage::Avatar => FileUpload::make($image->value)->avatar(),
+            ProfileImage::Cover => FileUpload::make($image->value)
+                ->image()
+                ->panelAspectRatio($image->aspectRatio()),
+        };
+
+        return $field
+            ->label(__('panel-app::profile.fields.'.$image->value))
+            // O teto do GIF só entra no texto quando ele é de fato menor: no
+            // ambiente onde o limite geral já é o mesmo, repetir confunde.
+            ->helperText(__(
+                $limits['unconverted_max_kb'] < $limits['max_kb']
+                    ? 'panel-app::profile.hints.image_upload_with_gif_limit'
+                    : 'panel-app::profile.hints.image_upload',
+                $limits,
+            ))
+            // imageAspectRatio() fica desligado de proposito. Ele instala uma
+            // regra Rule::dimensions()->ratio() que exige a proporcao exata,
+            // com tolerancia menor que um pixel. Como o editor recorta no
+            // canvas e arredonda, o arquivo chega fora da razao por 1px e a
+            // validacao reprova com "invalid image dimensions", que e o erro
+            // generico da issue #458. Quem enquadra e a conversion.
+            ->imageAspectRatio(ratio: null)
+            ->automaticallyCropImagesToAspectRatio(condition: false)
+            ->imageEditor()
+            // Sem imageAspectRatio, e o viewport que trava o recorte na
+            // proporcao certa dentro do editor.
+            ->imageEditorViewportWidth($image->width())
+            ->imageEditorViewportHeight($image->height())
+            ->imageEditorAspectRatioOptions([$image->aspectRatio()])
+            // Sem alvo de redimensionamento: o editor usa esses valores no
+            // getCroppedCanvas(), entao com eles o recorte sairia sempre no
+            // tamanho alvo, esticado no canvas do browser, e a validacao de
+            // dimensao minima nunca falharia. Quem estica e a conversion.
+            ->automaticallyResizeImagesToWidth(width: null)
+            ->automaticallyResizeImagesToHeight(height: null)
+            ->acceptedFileTypes(ProfileImage::mimeTypes())
+            ->maxSize($limits['max_kb'])
+            ->rules([
+                sprintf(
+                    'dimensions:min_width=%d,min_height=%d',
+                    $image->minWidth(),
+                    $image->minHeight(),
+                ),
+                new UnconvertedImageSize($limits['unconverted_max_kb']),
+            ])
+            ->validationMessages([
+                'dimensions' => __('panel-app::profile.validation.image_dimensions', $limits),
+                // O GIF chega ate aqui quando o usuario burla o filtro do
+                // seletor de arquivos. Sem esta mensagem, o erro que aparece
+                // e o generico do Laravel.
+                'mimetypes' => __('panel-app::profile.validation.image_mimetypes', $limits),
+            ])
+            ->storeFiles(condition: false)
+            ->required();
+    }
+
+    private function removeImage(ProfileImage $image): void
     {
         /** @var User $user */
         $user = auth()->user();
-        $extension = $file->getClientOriginalExtension() ?: $file->guessExtension() ?: 'jpg';
-        $user->clearMediaCollection($collection);
-        $user->addMedia($file->getRealPath())
-            ->usingFileName(Str::uuid()->toString().'.'.$extension)
-            ->toMediaCollection($collection);
+        $user->removeImage($image);
+
+        $this->refreshImageComputeds();
+    }
+
+    private function framingActionName(ProfileImage $image): string
+    {
+        return match ($image) {
+            ProfileImage::Avatar => 'adjustAvatar',
+            ProfileImage::Cover => 'adjustCover',
+        };
+    }
+
+    private function imagePreviewUrl(ProfileImage $image): ?string
+    {
+        return match ($image) {
+            ProfileImage::Avatar => $this->avatarPreviewUrl,
+            ProfileImage::Cover => $this->coverPreviewUrl,
+        };
+    }
+
+    private function refreshImageComputeds(): void
+    {
+        unset(
+            $this->avatarPreviewUrl,
+            $this->coverPreviewUrl,
+            $this->avatarFocalY,
+            $this->coverFocalY,
+        );
     }
 
     /**

--- a/app-modules/panel-app/src/Rules/UnconvertedImageSize.php
+++ b/app-modules/panel-app/src/Rules/UnconvertedImageSize.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\PanelApp\Rules;
+
+use Closure;
+use He4rt\Identity\User\Enums\ProfileImage;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Http\UploadedFile;
+
+/**
+ * Teto de tamanho para os formatos que são servidos sem conversão.
+ *
+ * Nesses formatos o peso do upload é o peso que cada visita ao perfil baixa,
+ * então eles têm um limite menor que o dos demais. Quando o limite geral do
+ * ambiente já é menor que este, quem reprova é o limite geral.
+ */
+final readonly class UnconvertedImageSize implements ValidationRule
+{
+    public function __construct(private int $maxKilobytes) {}
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (!$value instanceof UploadedFile) {
+            return;
+        }
+
+        if (!in_array($value->getMimeType(), ProfileImage::unconvertedMimeTypes(), strict: true)) {
+            return;
+        }
+
+        if ($value->getSize() <= $this->maxKilobytes * 1_024) {
+            return;
+        }
+
+        $fail('panel-app::profile.validation.image_unconverted_max_size')->translate([
+            'gif_mb' => round($this->maxKilobytes / 1_024, 1),
+            'formats' => ProfileImage::formatLabels(),
+        ]);
+    }
+}

--- a/app-modules/panel-app/tests/Feature/ProfileMediaTest.php
+++ b/app-modules/panel-app/tests/Feature/ProfileMediaTest.php
@@ -1,0 +1,245 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Facades\Filament;
+use He4rt\Identity\User\Enums\ProfileImage;
+use He4rt\Identity\User\Models\User;
+use He4rt\PanelApp\Pages\ProfilePage;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(function (): void {
+    Storage::fake('public');
+
+    Cache::flush();
+
+    // A pagina renderiza os selects de localizacao, que consultam a API de geo.
+    Http::fake([
+        'world.bmbc.cloud/*' => Http::response(['success' => true, 'data' => []]),
+    ]);
+
+    $this->user = User::factory()->create();
+
+    $this->actingAs($this->user);
+
+    Filament::setCurrentPanel(Filament::getPanel('app'));
+});
+
+test('cover upload generates the normalized webp conversion', function (): void {
+    $cover = ProfileImage::Cover;
+
+    livewire(ProfilePage::class)
+        ->callAction('editCover', [
+            $cover->value => UploadedFile::fake()->image('capa.jpg', $cover->width(), $cover->height()),
+        ])
+        ->assertHasNoActionErrors()
+        ->assertNotified();
+
+    $media = $this->user->refresh()->getFirstMedia($cover->value);
+
+    expect($media)->not->toBeNull()
+        ->and($media->hasGeneratedConversion($cover->value))->toBeTrue()
+        ->and($this->user->imageUrl($cover))->toContain('.webp');
+});
+
+test('cover upload accepts the minimum size and lets the conversion upscale it', function (): void {
+    $cover = ProfileImage::Cover;
+
+    livewire(ProfilePage::class)
+        ->callAction('editCover', [
+            $cover->value => UploadedFile::fake()->image('capa.jpg', $cover->minWidth(), $cover->minHeight()),
+        ])
+        ->assertHasNoActionErrors();
+
+    expect($this->user->refresh()->getFirstMedia($cover->value))->not->toBeNull();
+});
+
+test('cover upload accepts a crop that lands a pixel off the exact ratio', function (): void {
+    // O editor recorta no canvas e arredonda para pixel inteiro, entao o
+    // arquivo quase nunca sai na proporcao exata. A validacao nao pode exigir
+    // exatidao: quem enquadra e a conversion. Ver issue #458.
+    $cover = ProfileImage::Cover;
+
+    livewire(ProfilePage::class)
+        ->callAction('editCover', [
+            $cover->value => UploadedFile::fake()->image('capa.jpg', $cover->width() + 1, $cover->height()),
+        ])
+        ->assertHasNoActionErrors();
+
+    expect($this->user->refresh()->getFirstMedia($cover->value))->not->toBeNull();
+});
+
+test('cover upload rejects an image below the minimum width', function (): void {
+    $cover = ProfileImage::Cover;
+
+    livewire(ProfilePage::class)
+        ->callAction('editCover', [
+            $cover->value => UploadedFile::fake()->image('capa.jpg', $cover->minWidth() - 1, $cover->minHeight()),
+        ])
+        ->assertHasActionErrors([$cover->value]);
+
+    expect($this->user->refresh()->getMedia($cover->value))->toBeEmpty();
+});
+
+test('avatar upload rejects an image below the minimum size', function (): void {
+    $avatar = ProfileImage::Avatar;
+
+    livewire(ProfilePage::class)
+        ->callAction('editAvatar', [
+            $avatar->value => UploadedFile::fake()->image('foto.jpg', $avatar->minWidth() - 1, $avatar->minHeight() - 1),
+        ])
+        ->assertHasActionErrors([$avatar->value]);
+
+    expect($this->user->refresh()->getMedia($avatar->value))->toBeEmpty();
+});
+
+test('cover upload keeps a gif untouched so the animation survives', function (): void {
+    // Converter achataria a animacao: o GD le so o primeiro quadro. Quem
+    // enquadra o GIF e o object-cover do header. Ver issue #458.
+    $cover = ProfileImage::Cover;
+
+    livewire(ProfilePage::class)
+        ->callAction('editCover', [
+            $cover->value => UploadedFile::fake()->image('animado.gif', $cover->width(), $cover->height()),
+        ])
+        ->assertHasNoActionErrors()
+        ->assertNotified();
+
+    $media = $this->user->refresh()->getFirstMedia($cover->value);
+
+    expect($media)->not->toBeNull()
+        ->and($media->mime_type)->toBe('image/gif')
+        ->and($media->hasGeneratedConversion($cover->value))->toBeFalse()
+        ->and($this->user->imageUrl($cover))->toEndWith('.gif');
+});
+
+test('an unsupported format is rejected with a message that names the accepted ones', function (): void {
+    $cover = ProfileImage::Cover;
+
+    $component = livewire(ProfilePage::class)
+        ->callAction('editCover', [
+            $cover->value => UploadedFile::fake()->create('capa.bmp', 64, 'image/bmp'),
+        ])
+        ->assertHasActionErrors([$cover->value]);
+
+    $errors = $component->instance()->getErrorBag()->all();
+
+    expect(implode(' ', $errors))->toContain(ProfileImage::formatLabels())
+        ->and($this->user->refresh()->getMedia($cover->value))->toBeEmpty();
+});
+
+test('a new upload replaces the previous image instead of piling up', function (): void {
+    $cover = ProfileImage::Cover;
+
+    $page = livewire(ProfilePage::class);
+
+    foreach (['primeira.jpg', 'segunda.jpg'] as $fileName) {
+        $page->callAction('editCover', [
+            $cover->value => UploadedFile::fake()->image($fileName, $cover->width(), $cover->height()),
+        ])->assertHasNoActionErrors();
+    }
+
+    expect($this->user->refresh()->getMedia($cover->value))->toHaveCount(1);
+});
+
+test('a gif over the ceiling never reaches the collection', function (): void {
+    // Qual mensagem aparece depende de qual teto e menor no ambiente, e a regra
+    // em si esta coberta em UnconvertedImageSizeTest. Aqui o que importa e que
+    // o arquivo nao entra.
+    $cover = ProfileImage::Cover;
+
+    $gif = UploadedFile::fake()->create('pesado.gif', ProfileImage::unconvertedMaxKilobytes() + 512, 'image/gif');
+
+    livewire(ProfilePage::class)
+        ->callAction('editCover', [$cover->value => $gif])
+        ->assertHasActionErrors([$cover->value]);
+
+    expect($this->user->refresh()->getMedia($cover->value))->toBeEmpty();
+});
+
+test('uploading a gif chains straight into the framing step', function (): void {
+    // Sem conversao a imagem vai inteira para a tela: o enquadramento deixa de
+    // ser opcional, entao o modal seguinte abre sozinho.
+    $cover = ProfileImage::Cover;
+
+    $component = livewire(ProfilePage::class)
+        ->callAction('editCover', [
+            $cover->value => UploadedFile::fake()->image('animado.gif', $cover->width(), $cover->height()),
+        ])
+        ->assertHasNoActionErrors();
+
+    expect($component->instance()->getMountedActions())->toHaveCount(1)
+        ->and($component->instance()->getMountedActions()[0]->getName())->toBe('adjustCover');
+});
+
+test('uploading a jpg does not ask for framing, the conversion already crops it', function (): void {
+    $cover = ProfileImage::Cover;
+
+    $component = livewire(ProfilePage::class)
+        ->callAction('editCover', [
+            $cover->value => UploadedFile::fake()->image('capa.jpg', $cover->width(), $cover->height()),
+        ])
+        ->assertHasNoActionErrors();
+
+    expect($component->instance()->getMountedActions())->toBeEmpty();
+});
+
+test('the cover framing is saved on the media and defaults to the centre', function (): void {
+    $cover = ProfileImage::Cover;
+
+    $this->user->putImage($cover, UploadedFile::fake()->image('animado.gif', $cover->width(), $cover->height()));
+
+    expect($this->user->refresh()->imageFocalY($cover))->toBe(ProfileImage::DEFAULT_FOCAL_Y);
+
+    livewire(ProfilePage::class)
+        ->callAction('adjustCover', ['focal_y' => 80])
+        ->assertHasNoActionErrors()
+        ->assertNotified();
+
+    expect($this->user->refresh()->imageFocalY($cover))->toBe(80);
+});
+
+test('the framing is clamped to the image bounds', function (): void {
+    $cover = ProfileImage::Cover;
+
+    $this->user->putImage($cover, UploadedFile::fake()->image('capa.jpg', $cover->width(), $cover->height()));
+
+    $this->user->setImageFocalY($cover, 140);
+
+    expect($this->user->refresh()->imageFocalY($cover))->toBe(100);
+
+    $this->user->setImageFocalY($cover, -20);
+
+    expect($this->user->refresh()->imageFocalY($cover))->toBe(0);
+});
+
+test('removing the cover clears the collection', function (): void {
+    $cover = ProfileImage::Cover;
+
+    $this->user->putImage($cover, UploadedFile::fake()->image('capa.jpg', $cover->width(), $cover->height()));
+
+    expect($this->user->refresh()->getMedia($cover->value))->toHaveCount(1);
+
+    livewire(ProfilePage::class)->call('removeCover');
+
+    expect($this->user->refresh()->getMedia($cover->value))->toBeEmpty();
+});
+
+test('imageUrl falls back to the original while the conversion does not exist', function (): void {
+    $cover = ProfileImage::Cover;
+
+    $this->user->putImage($cover, UploadedFile::fake()->image('capa.jpg', $cover->width(), $cover->height()));
+
+    $media = $this->user->refresh()->getFirstMedia($cover->value);
+    $media->generated_conversions = [];
+    $media->save();
+
+    expect($this->user->refresh()->imageUrl($cover))
+        ->toBe($media->refresh()->getUrl())
+        ->not->toContain('-'.$cover->value.'.webp');
+});

--- a/app-modules/panel-app/tests/Unit/UnconvertedImageSizeTest.php
+++ b/app-modules/panel-app/tests/Unit/UnconvertedImageSizeTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\PanelApp\Rules\UnconvertedImageSize;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Validator;
+
+/**
+ * @param  int  $kilobytes  tamanho do arquivo enviado
+ * @param  int  $ceiling  teto configurado para formatos sem conversão
+ * @return array<int, string>
+ */
+function validateAgainstCeiling(string $name, string $mimeType, int $kilobytes, int $ceiling): array
+{
+    $validator = Validator::make(
+        ['file' => UploadedFile::fake()->create($name, $kilobytes, $mimeType)],
+        ['file' => [new UnconvertedImageSize($ceiling)]],
+    );
+
+    return $validator->errors()->get('file');
+}
+
+test('a gif above the ceiling is rejected', function (): void {
+    $errors = validateAgainstCeiling('animado.gif', 'image/gif', 3_000, 2_048);
+
+    expect($errors)->not->toBeEmpty()
+        ->and($errors[0])->toContain('2');
+});
+
+test('a gif within the ceiling passes', function (): void {
+    expect(validateAgainstCeiling('animado.gif', 'image/gif', 1_500, 2_048))->toBeEmpty();
+});
+
+test('a converted format is not subject to this ceiling', function (): void {
+    // JPG vira webp de poucos KB na conversão: o peso do upload não é o peso
+    // que a página serve, então o teto menor não se aplica a ele.
+    expect(validateAgainstCeiling('capa.jpg', 'image/jpeg', 3_000, 2_048))->toBeEmpty();
+});
+
+test('the ceiling is honoured whatever number it is', function (): void {
+    expect(validateAgainstCeiling('animado.gif', 'image/gif', 1_500, 1_024))->not->toBeEmpty()
+        ->and(validateAgainstCeiling('animado.gif', 'image/gif', 1_500, 8_192))->toBeEmpty();
+});

--- a/app/Support/UploadLimit.php
+++ b/app/Support/UploadLimit.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+/**
+ * Teto de upload que a aplicação pode prometer sem mentir.
+ *
+ * O PHP recusa o arquivo antes de qualquer validação do Laravel, e o que sobra
+ * na tela é um "failed to upload" sem explicação. Anunciar o menor entre o
+ * limite desejado e o que a infra aceita faz o erro acontecer no lugar certo,
+ * com a mensagem certa.
+ */
+final class UploadLimit
+{
+    public static function kilobytes(int $desired): int
+    {
+        $limit = $desired;
+
+        foreach (['upload_max_filesize', 'post_max_size'] as $directive) {
+            $ceiling = self::fromIni($directive);
+
+            if ($ceiling !== null) {
+                $limit = min($limit, $ceiling);
+            }
+        }
+
+        return $limit;
+    }
+
+    private static function fromIni(string $directive): ?int
+    {
+        $value = ini_get($directive);
+
+        if (!is_string($value) || mb_trim($value) === '') {
+            return null;
+        }
+
+        $kilobytes = self::toKilobytes(mb_trim($value));
+
+        // Zero, na configuração do PHP, quer dizer sem limite.
+        return $kilobytes > 0 ? $kilobytes : null;
+    }
+
+    private static function toKilobytes(string $value): int
+    {
+        $number = (int) $value;
+
+        return match (mb_strtolower(mb_substr($value, -1))) {
+            'g' => $number * 1_024 * 1_024,
+            'm' => $number * 1_024,
+            'k' => $number,
+            default => (int) ceil($number / 1_024),
+        };
+    }
+}

--- a/tests/Unit/UploadLimitTest.php
+++ b/tests/Unit/UploadLimitTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\UploadLimit;
+
+test('never announces more than the application asked for', function (): void {
+    expect(UploadLimit::kilobytes(4_096))->toBeLessThanOrEqual(4_096);
+});
+
+test('a request the environment can honour comes back untouched', function (): void {
+    expect(UploadLimit::kilobytes(1))->toBe(1);
+});
+
+test('the php ceiling wins when it is the smaller one', function (): void {
+    // Prometer mais do que o php.ini aceita gera um "failed to upload" sem
+    // explicação, porque o PHP recusa o arquivo antes da validação.
+    $directive = mb_trim((string) ini_get('upload_max_filesize'));
+
+    if (!str_ends_with(mb_strtoupper($directive), 'M')) {
+        $this->markTestSkipped('Este ambiente não declara o limite em megabytes.');
+    }
+
+    expect(UploadLimit::kilobytes(PHP_INT_MAX))->toBe(((int) $directive) * 1_024);
+});


### PR DESCRIPTION
Closes #458

## O que estava acontecendo

A issue descrevia três coisas: mensagem de erro genérica, GIF quebrando e falta de recorte. Investigando, achei que o erro genérico tinha uma causa só, e não era a que parecia.

O `imageAspectRatio()` do Filament instala uma regra de validação escondida (`Rule::dimensions()->ratio()`) que exige a proporção **exata**. A tolerância do Laravel é menor que um pixel:

```php
$precision = 1 / (max(($width + $height) / 2, $height) + 1);   // 1800×600 → 0.000833
abs(3 - 1801/600) = 0.00167   →  reprova
```

O editor recorta no canvas e arredonda para pixel inteiro, então o arquivo quase nunca sai na razão exata. Uma imagem que erra por um pixel era barrada com *"The cover has invalid image dimensions"*, que é exatamente o print da issue. Reproduzi nos dois lados: com 1800×600 exatos passa, com 1801×600 falha.

Isso também explica por que os testes daqui passavam enquanto as pessoas reclamavam: os testes usavam dimensões exatas, o único caso que a regra aceita.

## O que mudou

**A proporção deixou de ser regra de entrada.** O upload aceita o que chegar dentro de limites razoáveis, e quem garante o enquadramento é a conversão no servidor (`Fit::Crop` para 1800×600, saindo em webp). O que sobrou de validação é só o que protege qualidade: dimensão mínima, formato e tamanho, cada um com mensagem dizendo os números.

**GIF é aceito.** Ele não passa por conversão, senão a animação morreria no primeiro quadro — o GD só lê um. Como é servido do jeito que chega, ganhou teto próprio de 2 MB e um passo de enquadramento, que abre no mesmo fluxo depois do upload. Testei com um GIF de 45 quadros: entra e sai com os 45.

**O teto anunciado passou a ser verdade.** O campo prometia 4 MB, mas o `upload_max_filesize` do PHP corta em 2 MB antes de qualquer validação, e sobrava um `failed to upload` sem explicação — foi o [@boombertz](https://github.com/boombertz) quem achou isso nos testes dele. Agora o campo anuncia o menor entre o nosso limite e o que o ambiente aceita, e o erro aparece na hora certa.

**Dois bugs vizinhos que apareceram no caminho.** O `singleFile` não removia a imagem anterior quando a relação `media` já estava carregada na instância, então cada troca de capa deixava arquivo órfão no disco. E a capa não tinha proporção fixa: com altura fixa no CSS e largura fluida, o recorte mudava conforme a viewport de quem estava olhando.

## Os números

Vieram da discussão na issue, com [@hefeus](https://github.com/hefeus), [@reag-dev](https://github.com/reag-dev) e [@boombertz](https://github.com/boombertz):

| | proporção | servido | mínimo | teto |
|---|---|---|---|---|
| Capa | 3:1 | 1800 × 600 | 1200 × 400 | 4 MB, ou o do ambiente |
| Avatar | 1:1 | 500 × 500 | 256 × 256 | 2 MB, ou o do ambiente |
| GIF | como chega | como chega | igual acima | 2 MB |

Tudo isso mora no enum `ProfileImage`. Mudar qualquer número é uma linha, e o CSS do header lê a mesma proporção, então tela e arquivo não podem divergir.

## O que ficou de fora

**Animação em GIF recortado.** Quem usar o botão de recorte perde a animação, porque o recorte acontece no canvas do browser, que não tem noção de quadros. O texto do campo avisa.

**Converter GIF para webm**, sugestão do [@boombertz](https://github.com/boombertz). O ganho é real, mas precisa de ffmpeg no servidor. Fica em aberto: no código, a troca é mexer na lista de formatos que não passam por conversão.

## Demonstração



https://github.com/user-attachments/assets/b02a4807-aad2-4fc4-9b38-fcdf5ef3afe8





## Como testar

1. Suba uma imagem fora de 3:1, recorte pelo lápis e salve. Antes reprovava.
2. Suba um GIF animado. Ele anima, e o ajuste de enquadramento abre em seguida.
3. Suba um GIF acima de 2 MB. A mensagem diz o limite em vez de falhar calado.
4. Suba a mesma capa duas vezes sem recarregar. Só sobra um arquivo em `storage/app/public`.

Depois do deploy: `php artisan media-library:regenerate`, para as mídias que já existem ganharem a conversão. Até lá o fallback serve o original.

## Testes

18 casos novos cobrindo o que quebrava: o recorte com um pixel de diferença, o mínimo de dimensão, o GIF chegando inteiro, o teto do GIF, o encadeamento do enquadramento, o `singleFile` e o limite real de upload. Validei o resto no navegador, porque o recorte roda no Alpine e nenhum teste PHP alcança.
