### PR TITLE
feat(portal): redesign visual do navbar

### DIFF
--- a/app-modules/portal/resources/views/components/navbar.blade.php
+++ b/app-modules/portal/resources/views/components/navbar.blade.php
@@ -45,55 +45,57 @@
         {{-- a PILL de vidro --}}
         <nav
             :class="scrolled
-                ? 'mt-2 bg-elevation-surface/80 py-2 shadow-lg shadow-zinc-950/12 dark:shadow-black/40'
-                : 'mt-4 bg-elevation-surface/55 py-3 shadow-md shadow-zinc-950/8 dark:shadow-black/20'"
-            class="relative flex items-center justify-between gap-4 rounded-2xl px-4 ring-1 ring-zinc-950/8 backdrop-blur-xl transition-all duration-300 dark:ring-white/10 md:px-6"
+                ? 'mt-2 bg-elevation-surface/80 py-3 dark:bg-zinc-900/80'
+                : 'mt-4 bg-elevation-surface/55 py-4 dark:bg-zinc-900/60'"
+            class="relative flex items-center justify-between gap-4 rounded-2xl px-4 shadow-md backdrop-blur-xl transition-all duration-300 dark:rounded-xl dark:shadow-white/5 md:px-6"
         >
             <x-portal::logo size="sm" />
 
             {{-- navegação + CTAs alinhados à direita (desktop) --}}
-            <div class="hidden items-center gap-6 lg:flex">
-                <div class="flex items-center gap-1">
+            <div class="hidden items-center gap-8 lg:flex">
+                <div class="flex items-center gap-4">
                     @foreach ($links as $link)
                         <a
                             href="{{ $link['href'] }}"
                             @if ($link['active']) aria-current="page" @endif
-                            class="group relative rounded-full px-3 py-1.5 text-sm font-medium transition-colors {{ $link['active'] ? 'text-text-high' : 'text-text-medium hover:text-text-high' }}"
+                            class="relative border-b px-3 py-1.5 text-sm transition-all duration-200 hover:-translate-y-0.5 {{ $link['active'] ? 'border-[#8525d8] font-semibold text-zinc-900 dark:text-white' : 'border-transparent font-medium text-slate-500 hover:text-slate-900 dark:text-zinc-400 dark:hover:text-white' }}"
                         >
-                            <span
-                                class="absolute inset-0 -z-10 rounded-full bg-zinc-950/5 transition-opacity dark:bg-white/5 {{ $link['active'] ? 'opacity-100' : 'opacity-0 group-hover:opacity-100' }}"
-                            ></span>
                             {{ $link['label'] }}
-                            @if ($link['active'])
-                                <span
-                                    class="absolute -bottom-0.5 left-1/2 h-1 w-1 -translate-x-1/2 rounded-full bg-[var(--primary)]"
-                                ></span>
-                            @endif
                         </a>
                     @endforeach
-                </div>
 
-                <div class="flex items-center gap-2">
                     <x-he4rt::button
                         href="https://loja.heartdevs.com/he4rt/"
                         size="sm"
                         variant="outline"
-                        icon="heroicon-s-shopping-bag"
+                        icon="heroicon-o-shopping-bag"
                         iconPosition="leading"
-                        iconOnly
                         aria-label="Loja"
                         target="_blank"
                         rel="noopener"
-                    />
-                    <x-he4rt::button href="/app" size="sm" variant="outline"> Área do Usuário </x-he4rt::button>
+                        class="rounded-lg border-none bg-transparent px-3 py-2.5 font-medium text-slate-500 hover:bg-transparent hover:text-zinc-900 focus:ring-2 focus:ring-purple-600 dark:text-zinc-300 dark:hover:text-white"
+                    >
+                        Loja
+                    </x-he4rt::button>
+                </div>
+
+                <div class="flex items-center gap-3">
                     <x-he4rt::button
                         href="https://discord.gg/he4rt"
                         size="sm"
                         icon="fab-discord"
                         iconPosition="leading"
-                        class="hp-navbar-static-icon"
+                        class="hp-navbar-static-icon rounded-lg bg-none bg-[#f3e8ff] px-4 py-2.5 text-sm font-medium text-purple-600 hover:bg-[#e9d5ff] focus:ring-2 focus:ring-purple-600 dark:bg-[#8525d8]/15 dark:text-zinc-100 dark:hover:bg-[#8525d8]/25"
                     >
                         Discord
+                    </x-he4rt::button>
+                    <x-he4rt::button
+                        href="/app"
+                        size="sm"
+                        variant="outline"
+                        class="rounded-lg border-none bg-purple-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-purple-700 focus:ring-2 focus:ring-purple-600 focus:ring-offset-2 focus:ring-offset-white dark:focus:ring-offset-zinc-900"
+                    >
+                        Área do Usuário
                     </x-he4rt::button>
                 </div>
             </div>

--- a/app-modules/portal/resources/views/components/navbar.blade.php
+++ b/app-modules/portal/resources/views/components/navbar.blade.php
@@ -58,7 +58,7 @@
                         <a
                             href="{{ $link['href'] }}"
                             @if ($link['active']) aria-current="page" @endif
-                            class="relative border-b px-3 py-1.5 text-sm transition-all duration-200 hover:-translate-y-0.5 {{ $link['active'] ? 'border-[#8525d8] font-semibold text-zinc-900 dark:text-white' : 'border-transparent font-medium text-slate-500 hover:text-slate-900 dark:text-zinc-400 dark:hover:text-white' }}"
+                            class="relative border-b px-3 py-1.5 text-sm transition-all duration-200 hover:-translate-y-0.5 {{ $link['active'] ? 'text-text-high border-purple-700 font-semibold' : 'text-text-medium hover:text-text-high border-transparent font-medium' }}"
                         >
                             {{ $link['label'] }}
                         </a>
@@ -73,7 +73,7 @@
                         aria-label="Loja"
                         target="_blank"
                         rel="noopener"
-                        class="rounded-lg border-none bg-transparent px-3 py-2.5 font-medium text-slate-500 hover:bg-transparent hover:text-zinc-900 focus:ring-2 focus:ring-purple-600 dark:text-zinc-300 dark:hover:text-white"
+                        class="text-text-medium hover:text-text-high rounded-lg border-none bg-transparent px-3 py-2.5 font-medium hover:bg-transparent focus:ring-2 focus:ring-purple-600"
                     >
                         Loja
                     </x-he4rt::button>
@@ -85,7 +85,7 @@
                         size="sm"
                         icon="fab-discord"
                         iconPosition="leading"
-                        class="hp-navbar-static-icon rounded-lg bg-none bg-[#f3e8ff] px-4 py-2.5 text-sm font-medium text-purple-600 hover:bg-[#e9d5ff] focus:ring-2 focus:ring-purple-600 dark:bg-[#8525d8]/15 dark:text-zinc-100 dark:hover:bg-[#8525d8]/25"
+                        class="hp-navbar-static-icon dark:text-text-high rounded-lg bg-none bg-[#f3e8ff] px-4 py-2.5 text-sm font-medium text-purple-600 hover:bg-[#e9d5ff] focus:ring-2 focus:ring-purple-600 dark:bg-[#8525d8]/15 dark:hover:bg-[#8525d8]/25"
                     >
                         Discord
                     </x-he4rt::button>
@@ -93,7 +93,7 @@
                         href="/app"
                         size="sm"
                         variant="outline"
-                        class="rounded-lg border-none bg-purple-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-purple-700 focus:ring-2 focus:ring-purple-600 focus:ring-offset-2 focus:ring-offset-white dark:focus:ring-offset-zinc-900"
+                        class="text-text-light focus:ring-offset-elevation-surface rounded-lg border-none bg-purple-600 px-4 py-2.5 text-sm font-semibold shadow-sm hover:bg-purple-700 focus:ring-2 focus:ring-purple-600 focus:ring-offset-2"
                     >
                         Área do Usuário
                     </x-he4rt::button>


### PR DESCRIPTION

## Contexto

O navbar anterior escondia CTAs importantes atrás de detalhes visuais pouco perceptíveis: o botão "Loja" era somente ícone (sem rótulo de texto) e o botão "Área do Usuário" usava estilo outline discreto, sem destaque como ação principal. Esta alteração moderniza o visual do navbar e reforça a hierarquia das CTAs.

### Alterações

- `app-modules/portal/resources/views/components/navbar.blade.php`
  - Botão "Loja" agora exibe o rótulo de texto (antes era `iconOnly`) e passou a ficar agrupado junto aos links de navegação.
  - Links de navegação trocaram o estilo de "pill" com indicador de bolinha ativa para sublinhado (`border-b`) com leve elevação no hover.
  - Botão "Discord" ganhou fundo roxo suave (light/dark) em vez de estilo neutro.
  - Botão "Área do Usuário" passou de `variant="outline"` para CTA primário sólido (fundo roxo, texto branco).
  - Ajustes de sombra/blur/cantos da pill do navbar (`shadow-md`, `dark:rounded-xl`, `dark:shadow-white/5`).

---

## Plano de Testes

- [x] Rodar `composer run dev` e validar visualmente o navbar em `http://localhost:8000` (desktop)
- [x] Conferir estados: link ativo, hover dos links, hover dos botões Loja/Discord/Área do Usuário
- [x] Conferir dark mode
- [x] Conferir responsividade (o menu mobile não foi alterado neste diff, mas vale confirmar que segue funcionando)

---

## Evidências

### Antes

<img width="1330" height="93" alt="Captura de tela 2026-08-30 090932" src="https://github.com/user-attachments/assets/a83fcefc-d6d5-43f6-b5f8-c2d67b78a319" />


### Depois

<img width="1314" height="113" alt="Captura de tela 2026-08-30 090946" src="https://github.com/user-attachments/assets/2ffdcf11-9c51-476c-8455-e897798f286f" />


---
### Antes

<img width="1313" height="100" alt="Captura de tela 2026-08-30 091001" src="https://github.com/user-attachments/assets/2625c6d3-f521-4c1a-b949-0b1ebe3cadc4" />


### Depois

<img width="1316" height="109" alt="Captura de tela 2026-08-30 091007" src="https://github.com/user-attachments/assets/1a62f8db-301a-4885-a595-d18b0bea2dff" />


---
