### PR TITLE
feat(live): discord activity — assistir e comentar a live de dentro do discord

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,6 +85,11 @@ VITE_PUSHER_SCHEME="${PUSHER_SCHEME}"
 VITE_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
 
 DISCORD_TOKEN=
+# Login Discord (config/services.php) e Discord Activity (app-modules/integration-discord/src/Activity)
+# usam o mesmo app do Developer Portal — o mesmo Client ID/Secret serve pros dois.
+DISCORD_OAUTH_CLIENT_ID=
+DISCORD_OAUTH_CLIENT_SECRET=
+VITE_DISCORD_CLIENT_ID="${DISCORD_OAUTH_CLIENT_ID}"
 GITHUB_WEBHOOK_SECRET=
 GITHUB_API_TOKEN=
 # Dev.to — slug da organização cujos artigos o contents:sync-articles busca.

--- a/app-modules/identity/src/ExternalIdentity/Actions/FindConnectedUser.php
+++ b/app-modules/identity/src/ExternalIdentity/Actions/FindConnectedUser.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Identity\ExternalIdentity\Actions;
+
+use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
+use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
+use He4rt\Identity\User\Models\User;
+
+/** Só leitura: nunca cria identidade, ao contrário de ResolveExternalIdentity. */
+final class FindConnectedUser
+{
+    public function execute(IdentityProvider $provider, string $externalAccountId): ?User
+    {
+        return ExternalIdentity::query()
+            ->where('provider', $provider)
+            ->where('external_account_id', $externalAccountId)
+            ->activelyConnected()
+            ->first()
+            ?->user;
+    }
+}

--- a/app-modules/identity/tests/Feature/ExternalIdentity/FindConnectedUserTest.php
+++ b/app-modules/identity/tests/Feature/ExternalIdentity/FindConnectedUserTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Identity\ExternalIdentity\Actions\FindConnectedUser;
+use He4rt\Identity\ExternalIdentity\Data\ClientAccessManager;
+use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
+use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
+use He4rt\Identity\User\Models\User;
+
+it('returns the linked user for an actively connected identity', function (): void {
+    $user = User::factory()->create();
+
+    ExternalIdentity::factory()
+        ->morphFor(User::class)
+        ->create([
+            'model_id' => $user->id,
+            'provider' => IdentityProvider::Discord,
+            'external_account_id' => '123456789',
+        ]);
+
+    $result = (new FindConnectedUser)->execute(IdentityProvider::Discord, '123456789');
+
+    expect($result?->id)->toBe($user->id);
+});
+
+it('returns null for an identity created by the ETL, without real credentials', function (): void {
+    $user = User::factory()->create();
+
+    ExternalIdentity::factory()
+        ->morphFor(User::class)
+        ->create([
+            'model_id' => $user->id,
+            'provider' => IdentityProvider::Discord,
+            'external_account_id' => '123456789',
+            'credentials' => ClientAccessManager::make(),
+        ]);
+
+    $result = (new FindConnectedUser)->execute(IdentityProvider::Discord, '123456789');
+
+    expect($result)->toBeNull();
+});
+
+it('returns null when no identity matches the provider and external account id', function (): void {
+    $result = (new FindConnectedUser)->execute(IdentityProvider::Discord, 'nonexistent');
+
+    expect($result)->toBeNull();
+});

--- a/app-modules/integration-discord/composer.json
+++ b/app-modules/integration-discord/composer.json
@@ -4,9 +4,7 @@
     "type": "library",
     "version": "1.0",
     "license": "proprietary",
-    "require": {
-        "he4rt/identity": "^1.0.0"
-    },
+    "require": {},
     "autoload": {
         "psr-4": {
             "He4rt\\IntegrationDiscord\\": "src/",

--- a/app-modules/integration-discord/composer.json
+++ b/app-modules/integration-discord/composer.json
@@ -4,7 +4,9 @@
     "type": "library",
     "version": "1.0",
     "license": "proprietary",
-    "require": {},
+    "require": {
+        "he4rt/identity": "^1.0.0"
+    },
     "autoload": {
         "psr-4": {
             "He4rt\\IntegrationDiscord\\": "src/",

--- a/app-modules/integration-discord/routes/activity-routes.php
+++ b/app-modules/integration-discord/routes/activity-routes.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Middleware\PrepareDiscordActivityContext;
+use He4rt\IntegrationDiscord\Activity\Http\Controllers\ActivityAuthController;
+use Illuminate\Support\Facades\Route;
+
+// Sessão/CSRF exigidos aqui, diferente das rotas de ingest do módulo `live`: é o
+// navegador dentro do iframe da Activity chamando, não o mediamtx server-to-server.
+Route::middleware('web')->group(static function (): void {
+    Route::post('discord-activity/auth', ActivityAuthController::class)
+        ->middleware(PrepareDiscordActivityContext::class)
+        ->name('discord-activity.auth');
+});

--- a/app-modules/integration-discord/src/Activity/Actions/AuthenticateActivityUser.php
+++ b/app-modules/integration-discord/src/Activity/Actions/AuthenticateActivityUser.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\IntegrationDiscord\Activity\Actions;
+
+use He4rt\Identity\Auth\Exceptions\OAuthFlowException;
+use He4rt\Identity\ExternalIdentity\Actions\FindConnectedUser;
+use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
+use He4rt\IntegrationDiscord\Activity\DTOs\ActivityAuthResult;
+use He4rt\IntegrationDiscord\Transport\DiscordOAuthConnector;
+use He4rt\IntegrationDiscord\Transport\Requests\OAuth\ExchangeCodeForToken;
+use He4rt\IntegrationDiscord\Transport\Requests\OAuth\GetCurrentUser;
+
+/**
+ * Troca o `code` do `authorize()` do SDK por token e resolve o User já vinculado a esse
+ * Discord id. `user` vem null quando não há vínculo (estado esperado, não erro); o
+ * `access_token` sempre volta preenchido — o client precisa dele pra `authenticate()`.
+ */
+final readonly class AuthenticateActivityUser
+{
+    public function __construct(
+        private DiscordOAuthConnector $connector,
+        private FindConnectedUser $findConnectedUser,
+    ) {}
+
+    public function execute(string $code): ActivityAuthResult
+    {
+        $tokenResponse = $this->connector->send(new ExchangeCodeForToken(
+            code: $code,
+            clientId: $this->connector->clientId,
+            clientSecret: $this->connector->clientSecret,
+        ));
+
+        /** @var array<string, mixed> $tokenPayload */
+        $tokenPayload = $tokenResponse->json();
+
+        if (!isset($tokenPayload['access_token'])) {
+            throw OAuthFlowException::tokenExchangeFailed('discord', (string) ($tokenPayload['error'] ?? 'unknown'));
+        }
+
+        $accessToken = (string) $tokenPayload['access_token'];
+
+        $userResponse = $this->connector->send(new GetCurrentUser(
+            accessToken: $accessToken,
+        ));
+
+        /** @var array<string, mixed> $userPayload */
+        $userPayload = $userResponse->json();
+
+        $user = $this->findConnectedUser->execute(IdentityProvider::Discord, (string) $userPayload['id']);
+
+        return new ActivityAuthResult($accessToken, $user);
+    }
+}

--- a/app-modules/integration-discord/src/Activity/DTOs/ActivityAuthResult.php
+++ b/app-modules/integration-discord/src/Activity/DTOs/ActivityAuthResult.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\IntegrationDiscord\Activity\DTOs;
+
+use He4rt\Identity\User\Models\User;
+
+/**
+ * O `access_token` sempre volta pro client — o SDK da Activity exige ele em
+ * `authenticate()` mesmo quando a conta HeartDevs não está vinculada.
+ */
+final readonly class ActivityAuthResult
+{
+    public function __construct(
+        public string $accessToken,
+        public ?User $user,
+    ) {}
+}

--- a/app-modules/integration-discord/src/Activity/Http/Controllers/ActivityAuthController.php
+++ b/app-modules/integration-discord/src/Activity/Http/Controllers/ActivityAuthController.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\IntegrationDiscord\Activity\Http\Controllers;
+
+use He4rt\Identity\User\Models\User;
+use He4rt\IntegrationDiscord\Activity\Actions\AuthenticateActivityUser;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/** Troca o `code` do SDK da Discord Activity por sessão autenticada, quando a conta já está vinculada. */
+final class ActivityAuthController
+{
+    public function __invoke(Request $request, AuthenticateActivityUser $action): JsonResponse
+    {
+        $request->validate(['code' => ['required', 'string']]);
+
+        $result = $action->execute($request->string('code')->toString());
+
+        if ($result->user instanceof User) {
+            auth()->login($result->user);
+        }
+
+        return response()->json([
+            'linked' => $result->user instanceof User,
+            'access_token' => $result->accessToken,
+        ]);
+    }
+}

--- a/app-modules/integration-discord/src/Transport/Requests/OAuth/ExchangeCodeForToken.php
+++ b/app-modules/integration-discord/src/Transport/Requests/OAuth/ExchangeCodeForToken.php
@@ -19,7 +19,7 @@ final class ExchangeCodeForToken extends Request implements HasBody
         private readonly string $code,
         private readonly string $clientId,
         private readonly string $clientSecret,
-        private readonly string $redirectUri,
+        private readonly ?string $redirectUri = null,
     ) {}
 
     public function resolveEndpoint(): string
@@ -32,12 +32,12 @@ final class ExchangeCodeForToken extends Request implements HasBody
      */
     protected function defaultBody(): array
     {
-        return [
+        return array_filter([
             'grant_type' => 'authorization_code',
             'code' => $this->code,
             'redirect_uri' => $this->redirectUri,
             'client_id' => $this->clientId,
             'client_secret' => $this->clientSecret,
-        ];
+        ]);
     }
 }

--- a/app-modules/integration-discord/tests/Feature/Activity/ActivityAuthControllerTest.php
+++ b/app-modules/integration-discord/tests/Feature/Activity/ActivityAuthControllerTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
+use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
+use He4rt\Identity\User\Models\User;
+use He4rt\IntegrationDiscord\Transport\DiscordOAuthConnector;
+use He4rt\IntegrationDiscord\Transport\Requests\OAuth\ExchangeCodeForToken;
+use He4rt\IntegrationDiscord\Transport\Requests\OAuth\GetCurrentUser;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+function mockDiscordConnectorInApp(string $discordUserId): void
+{
+    // Client/secret literais bastam — não precisa resolver o singleton real via config.
+    $connector = new DiscordOAuthConnector('client-id', 'client-secret', 'https://example.com/callback');
+    $connector->withMockClient(new MockClient([
+        ExchangeCodeForToken::class => MockResponse::make([
+            'access_token' => 'test-access-token',
+            'refresh_token' => 'test-refresh-token',
+            'expires_in' => 604_800,
+        ]),
+        GetCurrentUser::class => MockResponse::make(['id' => $discordUserId, 'username' => 'testuser']),
+    ]));
+
+    app()->instance(DiscordOAuthConnector::class, $connector);
+}
+
+it('logs the user in and reports linked when the discord account is connected', function (): void {
+    $user = User::factory()->create();
+
+    ExternalIdentity::factory()
+        ->morphFor(User::class)
+        ->create([
+            'model_id' => $user->id,
+            'provider' => IdentityProvider::Discord,
+            'external_account_id' => '123456789',
+        ]);
+
+    mockDiscordConnectorInApp('123456789');
+
+    $response = $this->postJson('/discord-activity/auth', ['code' => 'some-code'])
+        ->assertSuccessful()
+        ->assertJson(['linked' => true, 'access_token' => 'test-access-token']);
+
+    $this->assertAuthenticatedAs($user);
+
+    // Essa rota não tem `frame_id` — sem o PrepareDiscordActivityContext detectar o
+    // contexto Discord pelo nome da rota, o cookie sairia SameSite=Lax.
+    $sessionCookie = collect($response->headers->getCookies())
+        ->first(fn ($cookie) => $cookie->getName() === config()->string('session.cookie'));
+
+    expect($sessionCookie)->not->toBeNull()
+        ->and($sessionCookie->getSameSite())->toBe('none')
+        ->and($sessionCookie->isSecure())->toBeTrue();
+});
+
+it('reports not linked without authenticating when the discord account has no linked user', function (): void {
+    mockDiscordConnectorInApp('unlinked-discord-id');
+
+    $this->postJson('/discord-activity/auth', ['code' => 'some-code'])
+        ->assertSuccessful()
+        ->assertJson(['linked' => false, 'access_token' => 'test-access-token']);
+
+    $this->assertGuest();
+});
+
+it('validates that code is required', function (): void {
+    // O container injeta AuthenticateActivityUser antes da validação rodar, então
+    // o connector precisa estar mockado mesmo aqui.
+    mockDiscordConnectorInApp('n/a');
+
+    $this->postJson('/discord-activity/auth', [])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors('code');
+});

--- a/app-modules/integration-discord/tests/Feature/Activity/AuthenticateActivityUserTest.php
+++ b/app-modules/integration-discord/tests/Feature/Activity/AuthenticateActivityUserTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Identity\Auth\Exceptions\OAuthFlowException;
+use He4rt\Identity\ExternalIdentity\Actions\FindConnectedUser;
+use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
+use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
+use He4rt\Identity\User\Models\User;
+use He4rt\IntegrationDiscord\Activity\Actions\AuthenticateActivityUser;
+use He4rt\IntegrationDiscord\Activity\DTOs\ActivityAuthResult;
+use He4rt\IntegrationDiscord\Transport\DiscordOAuthConnector;
+use He4rt\IntegrationDiscord\Transport\Requests\OAuth\ExchangeCodeForToken;
+use He4rt\IntegrationDiscord\Transport\Requests\OAuth\GetCurrentUser;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+function fakeDiscordActivityMockClient(array $userPayload): MockClient
+{
+    return new MockClient([
+        ExchangeCodeForToken::class => MockResponse::make([
+            'access_token' => 'test-access-token',
+            'refresh_token' => 'test-refresh-token',
+            'expires_in' => 604_800,
+        ]),
+        GetCurrentUser::class => MockResponse::make($userPayload),
+    ]);
+}
+
+it('returns the linked user and the access token when the discord account is connected', function (): void {
+    $user = User::factory()->create();
+
+    ExternalIdentity::factory()
+        ->morphFor(User::class)
+        ->create([
+            'model_id' => $user->id,
+            'provider' => IdentityProvider::Discord,
+            'external_account_id' => '123456789',
+        ]);
+
+    $connector = new DiscordOAuthConnector('client-id', 'client-secret', 'https://example.com/callback');
+    $connector->withMockClient(fakeDiscordActivityMockClient(['id' => '123456789', 'username' => 'testuser']));
+
+    $result = new AuthenticateActivityUser($connector, new FindConnectedUser)
+        ->execute('some-code');
+
+    expect($result)
+        ->toBeInstanceOf(ActivityAuthResult::class)
+        ->and($result->accessToken)->toBe('test-access-token')
+        ->and($result->user?->id)->toBe($user->id);
+});
+
+it('returns a null user with the access token still filled when the discord account has no linked user', function (): void {
+    $connector = new DiscordOAuthConnector('client-id', 'client-secret', 'https://example.com/callback');
+    $connector->withMockClient(fakeDiscordActivityMockClient(['id' => 'unlinked-discord-id', 'username' => 'ghost']));
+
+    $result = new AuthenticateActivityUser($connector, new FindConnectedUser)
+        ->execute('some-code');
+
+    expect($result->user)->toBeNull()
+        ->and($result->accessToken)->toBe('test-access-token');
+});
+
+it('throws when the token exchange fails', function (): void {
+    $connector = new DiscordOAuthConnector('client-id', 'client-secret', 'https://example.com/callback');
+    $connector->withMockClient(new MockClient([
+        ExchangeCodeForToken::class => MockResponse::make(['error' => 'invalid_grant'], 400),
+    ]));
+
+    new AuthenticateActivityUser($connector, new FindConnectedUser)
+        ->execute('bad-code');
+})->throws(OAuthFlowException::class);

--- a/app-modules/integration-discord/tests/Unit/Transport/Requests/ExchangeCodeForTokenTest.php
+++ b/app-modules/integration-discord/tests/Unit/Transport/Requests/ExchangeCodeForTokenTest.php
@@ -33,3 +33,17 @@ it('includes oauth parameters as form body', function (): void {
         'client_secret' => 'client-secret',
     ]);
 });
+
+it('omits redirect_uri from the body when null (Discord Activity flow)', function (): void {
+    $request = new ExchangeCodeForToken('code-123', 'client-id', 'client-secret');
+
+    $connector = new DiscordOAuthConnector('client-id', 'client-secret', 'https://example.com/callback');
+    $pendingRequest = new PendingRequest($connector, $request);
+
+    expect($pendingRequest->body()->all())->toBe([
+        'grant_type' => 'authorization_code',
+        'code' => 'code-123',
+        'client_id' => 'client-id',
+        'client_secret' => 'client-secret',
+    ]);
+});

--- a/app-modules/live/routes/live-routes.php
+++ b/app-modules/live/routes/live-routes.php
@@ -2,9 +2,14 @@
 
 declare(strict_types=1);
 
+use He4rt\Live\HlsProxyController;
 use He4rt\Live\IngestAuthController;
 use He4rt\Live\IngestWebhookController;
 use Illuminate\Support\Facades\Route;
 
 Route::post('live/ingest/auth', IngestAuthController::class)->name('live.ingest-auth');
 Route::post('live/ingest/webhook', IngestWebhookController::class)->name('live.ingest-webhook');
+
+Route::get('discord-activity/hls/{path}', HlsProxyController::class)
+    ->where('path', '.*')
+    ->name('live.discord-activity-hls');

--- a/app-modules/live/src/HlsProxyController.php
+++ b/app-modules/live/src/HlsProxyController.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Live;
+
+use GuzzleHttp\Cookie\CookieJar;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+
+/**
+ * Repassa o HLS do mediamtx pelo próprio domínio da app. Existe pra Discord Activity:
+ * `media-src 'self'` do iframe bloqueia vídeo de `config('live.hls_url')` (outro
+ * host/porta), então a Activity pede essa rota relativa em vez do mediamtx direto.
+ */
+final class HlsProxyController
+{
+    public function __invoke(Request $request, string $path): Response
+    {
+        $base = Str::before(config()->string('live.hls_url'), '/'.config()->string('live.path').'/');
+
+        $url = sprintf('%s/%s/%s', $base, config()->string('live.path'), $path);
+
+        // mediamtx faz um cookie-check anti-bot com redirect 302 antes de servir o HLS;
+        // sem cookie jar, o Guzzle não carrega o Set-Cookie entre os hops do redirect e
+        // o hook de auth do mediamtx rejeita a requisição seguinte. As sub-playlists
+        // (áudio/vídeo) vêm com `?session=...` no manifest — repassa a query também.
+        $upstream = Http::withOptions(['cookies' => new CookieJar])
+            ->get($url, $request->query->all());
+
+        $contentType = $upstream->header('Content-Type');
+
+        return response($upstream->body(), $upstream->status())
+            ->header('Content-Type', $contentType !== '' ? $contentType : 'application/octet-stream');
+    }
+}

--- a/app-modules/portal/resources/js/discord-activity.js
+++ b/app-modules/portal/resources/js/discord-activity.js
@@ -1,0 +1,75 @@
+import { DiscordSDK } from '@discord/embedded-app-sdk';
+
+const clientId = import.meta.env.VITE_DISCORD_CLIENT_ID;
+const discordSdk = new DiscordSDK(clientId);
+
+/**
+ * O iframe é sandboxed sem `allow-popups` (target="_blank" é bloqueado) e navegar a
+ * própria aba destrói a Activity — todo link daqui precisa abrir fora, pelo SDK.
+ */
+function interceptLinksToOpenExternally() {
+    const appHost = document.querySelector('meta[name="app-host"]')?.getAttribute('content');
+
+    if (!appHost) {
+        return;
+    }
+
+    document.addEventListener('click', (event) => {
+        const link = event.target.closest('a[href]');
+
+        if (!link) {
+            return;
+        }
+
+        const href = link.getAttribute('href');
+
+        if (!href || href.startsWith('#') || href.startsWith('javascript:')) {
+            return;
+        }
+
+        event.preventDefault();
+
+        const url = new URL(href, `https://${appHost}`).href;
+
+        discordSdk.commands.openExternalLink({ url });
+    });
+}
+
+async function bootstrapDiscordActivity() {
+    await discordSdk.ready();
+
+    const { code } = await discordSdk.commands.authorize({
+        client_id: clientId,
+        response_type: 'code',
+        scope: ['identify'],
+    });
+
+    const csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') ?? '';
+
+    const response = await fetch('/discord-activity/auth', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+            'X-CSRF-TOKEN': csrfToken,
+        },
+        body: JSON.stringify({ code }),
+    });
+
+    const { linked, access_token: accessToken } = await response.json();
+
+    await discordSdk.commands.authenticate({ access_token: accessToken });
+
+    if (!linked) {
+        window.dispatchEvent(new CustomEvent('discord-activity:not-linked'));
+
+        return;
+    }
+
+    // A sessão Laravel já foi estabelecida no backend (auth()->login) — recarrega
+    // pra a página renderizar como usuário autenticado e liberar o chat.
+    window.location.reload();
+}
+
+interceptLinksToOpenExternally();
+bootstrapDiscordActivity();

--- a/app-modules/portal/resources/views/components/layouts/activity.blade.php
+++ b/app-modules/portal/resources/views/components/layouts/activity.blade.php
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" class="dark">
+<head>
+    <meta charset="utf-8" />
+    <meta name="csrf-token" content="{{ csrf_token() }}" />
+    {{-- Só o host, sem scheme (que RewriteDiscordActivityAssetUrls apagaria) — o
+         discord-activity.js remonta a URL absoluta pra abrir links fora do iframe. --}}
+    <meta name="app-host" content="{{ request()->getHttpHost() }}" />
+    {{-- title, viewport, description, canonical, Open Graph, favicon e JSON-LD: laravel/head (App\Support\Seo\SiteHead + metadata das rotas em PortalServiceProvider) --}}
+    @head
+    @vite (['app-modules/he4rt/resources/css/theme.css', 'app-modules/portal/resources/js/discord-activity.js'])
+    @fluxAppearance
+</head>
+<body class="antialiased" style="margin: 0; background: #000">
+    {{ $slot }}
+    @fluxScripts
+</body>
+</html>

--- a/app-modules/portal/resources/views/live-activity.blade.php
+++ b/app-modules/portal/resources/views/live-activity.blade.php
@@ -1,0 +1,98 @@
+<div
+    wire:poll.10s="pulse"
+    aria-live="polite"
+    class="flex h-screen w-full flex-col bg-black"
+    x-data="{ notLinked: false }"
+    x-on:discord-activity:not-linked.window="notLinked = true"
+>
+    @vite('app-modules/portal/resources/js/live-player.js')
+
+    <div
+        x-show="notLinked"
+        x-cloak
+        class="flex items-center justify-between gap-3 bg-amber-500/10 px-4 py-2 text-xs text-amber-300"
+    >
+        <span>Vincule sua conta Discord em heartdevs.com para participar do chat.</span>
+        <a href="{{ route('filament.app.pages.profile') }}" target="_blank" rel="noopener" class="font-semibold underline">
+            Vincular conta
+        </a>
+    </div>
+
+    @if ($live === null)
+        <div class="flex h-full w-full flex-col items-center justify-center gap-2 p-6 text-center">
+            <p class="text-sm font-semibold text-white">Nenhuma live no ar agora</p>
+            <p class="max-w-sm text-xs text-white/60">
+                Esta página atualiza sozinha quando a transmissão começar.
+            </p>
+        </div>
+    @else
+        <div x-data="{ chatCollapsed: false }" class="flex h-full min-h-0 w-full">
+            <div class="relative h-full min-w-0 flex-1 overflow-hidden bg-black">
+                @if ($status->onAir)
+                    <video
+                        data-live-player
+                        data-hls-url="{{ route('live.discord-activity-hls', ['path' => 'index.m3u8']) }}"
+                        data-live-channel="{{ $live->id }}"
+                        controls
+                        autoplay
+                        muted
+                        playsinline
+                        class="h-full w-full bg-black object-contain"
+                    ></video>
+                @endif
+
+                <div
+                    data-live-waiting
+                    data-live-channel="{{ $live->id }}"
+                    @class([
+                        'absolute inset-0 flex flex-col items-center justify-center gap-2 bg-black p-6 text-center',
+                        'hidden' => $status->onAir,
+                    ])
+                >
+                    <p class="text-sm font-semibold text-white">Aguardando sinal</p>
+                    <p class="max-w-sm text-xs text-white/60">
+                        A transmissão volta sozinha assim que o sinal for restabelecido.
+                    </p>
+                </div>
+
+                <div class="pointer-events-none absolute inset-x-0 top-0 flex items-start justify-between gap-3 bg-gradient-to-b from-black/70 via-black/20 to-transparent p-3">
+                    <div class="pointer-events-auto flex items-center gap-2">
+                        @if ($status->onAir)
+                            <span class="flex w-fit items-center gap-1.5 rounded-full border border-red-500/40 bg-red-500/10 px-2 py-1 text-[11px] font-semibold text-red-400">
+                                <span class="relative flex h-1.5 w-1.5">
+                                    <span class="absolute inline-flex h-full w-full animate-ping rounded-full bg-red-500 opacity-75"></span>
+                                    <span class="relative inline-flex h-1.5 w-1.5 rounded-full bg-red-500"></span>
+                                </span>
+                                Ao vivo
+                            </span>
+                        @endif
+
+                        @if ($viewers > 0)
+                            <span class="rounded-full bg-black/40 px-2 py-1 text-[11px] font-medium text-white">{{ $viewers }} assistindo</span>
+                        @endif
+                    </div>
+                </div>
+            </div>
+
+            <div
+                class="h-full shrink-0 overflow-hidden"
+                :class="chatCollapsed ? 'w-10' : 'w-[18rem]'"
+            >
+                <div x-show="!chatCollapsed" class="h-full min-h-0 overflow-hidden">
+                    <livewire:portal.live-chat :live-id="$live->id" :key="$live->id" />
+                </div>
+
+                <button
+                    x-show="chatCollapsed"
+                    x-cloak
+                    @click="chatCollapsed = false"
+                    type="button"
+                    class="flex h-full w-full flex-col items-center justify-center gap-2 border-l border-white/10 bg-black/60 py-4 text-white/60 hover:text-white"
+                >
+                    <x-filament::icon icon="heroicon-o-chevron-left" class="h-4 w-4" />
+                    <span class="text-[10px] font-semibold [writing-mode:vertical-rl]">Chat</span>
+                </button>
+            </div>
+        </div>
+    @endif
+</div>

--- a/app-modules/portal/src/Live/LiveActivityPage.php
+++ b/app-modules/portal/src/Live/LiveActivityPage.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Portal\Live;
+
+use He4rt\Live\Actions\CheckLiveStatusAction;
+use He4rt\Live\Audience\Actions\RecordViewerHeartbeat;
+use He4rt\Live\Models\Live;
+use Illuminate\Contracts\View\View;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+/** Versão enxuta de LivePage servida em `/` quando aberta como Discord Activity. */
+#[Layout(name: 'portal::components.layouts.activity')]
+final class LiveActivityPage extends Component
+{
+    public int $viewers = 0;
+
+    public function pulse(): void
+    {
+        rescue(function (): void {
+            $live = Live::query()->current()->first();
+
+            if ($live !== null) {
+                $this->viewers = resolve(RecordViewerHeartbeat::class)->execute($live, session()->getId());
+            }
+        }, report: true);
+    }
+
+    public function render(CheckLiveStatusAction $status): View
+    {
+        $live = Live::query()->current()->first();
+
+        return view('portal::live-activity', [
+            'live' => $live,
+            'status' => $status->execute(),
+        ]);
+    }
+}

--- a/app-modules/portal/src/PortalServiceProvider.php
+++ b/app-modules/portal/src/PortalServiceProvider.php
@@ -4,15 +4,18 @@ declare(strict_types=1);
 
 namespace He4rt\Portal;
 
+use App\Http\Middleware\PrepareDiscordActivityContext;
 use He4rt\Portal\Articles\ArticlesPage;
 use He4rt\Portal\Home\HeroSection;
 use He4rt\Portal\Home\Homepage;
+use He4rt\Portal\Live\LiveActivityPage;
 use He4rt\Portal\Live\LiveChat;
 use He4rt\Portal\Live\LivePage;
 use He4rt\Portal\Retrospective\CommunityRetrospectivePage;
 use He4rt\Portal\ShortLink\ShortLinkRedirectController;
 use He4rt\Portal\Sitemap\SitemapController;
 use He4rt\Portal\SocialLinks\SocialLinksPage;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Head\HeadServiceProvider;
@@ -46,7 +49,15 @@ class PortalServiceProvider extends ServiceProvider
              * semi-estáticas cujo título/description são conhecidos de antemão.
              * Os defaults (App\Support\Seo\SiteHead) preenchem o resto.
              */
-            Route::get('/', Homepage::class)
+            // O ponto de entrada de uma Discord Activity é sempre `/` — o Discord não
+            // permite apontar pra outra rota. `frame_id` é o query param que o SDK
+            // sempre injeta na Activity; quando presente, serve LiveActivityPage.
+            Route::get('/', function (Request $request) {
+                $component = $request->filled('frame_id') ? LiveActivityPage::class : Homepage::class;
+
+                return resolve($component)->__invoke();
+            })
+                ->middleware(PrepareDiscordActivityContext::class)
                 ->name('home')
                 ->withHead(
                     // `exact` evita o sufixo " - He4rt Developers" duplicar a marca na home.

--- a/app/Http/Middleware/PrepareDiscordActivityContext.php
+++ b/app/Http/Middleware/PrepareDiscordActivityContext.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * O iframe da Activity carrega a partir de `discordsays.com`, terceiro para o documento
+ * top-level do Discord — cookie `SameSite=Lax` (padrão da app) não sobrevive nele, e sem
+ * sessão nem o Livewire funciona. Precisa rodar antes do StartSession (prioridade em
+ * bootstrap/app.php). `discord-activity.auth` entra na checagem porque o login de
+ * verdade acontece num fetch() separado, sem o `frame_id` da carga inicial da página.
+ */
+final class PrepareDiscordActivityContext
+{
+    /**
+     * @param  Closure(Request): (Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $isDiscordActivityContext = $request->filled('frame_id')
+            || $request->routeIs('discord-activity.auth');
+
+        if ($isDiscordActivityContext) {
+            config([
+                'session.same_site' => 'none',
+                'session.secure' => true,
+            ]);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Listeners/RewriteDiscordActivityAssetUrls.php
+++ b/app/Listeners/RewriteDiscordActivityAssetUrls.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Listeners;
+
+use Illuminate\Foundation\Http\Events\RequestHandled;
+
+/**
+ * A CSP do iframe da Activity só permite script/style/img da própria origem — URLs
+ * absolutas pro host da app violam isso. O Livewire injeta seu `<script>` num listener
+ * de `RequestHandled` que roda depois de toda a pipeline de middleware, então essa
+ * reescrita também precisa ser um listener (registrado depois do listener do Livewire —
+ * ver App\Providers\EventServiceProvider) pra pegar o HTML já completo.
+ */
+final class RewriteDiscordActivityAssetUrls
+{
+    public function handle(RequestHandled $event): void
+    {
+        if (!$event->request->filled('frame_id')) {
+            return;
+        }
+
+        $content = $event->response->getContent();
+
+        if (!is_string($content)) {
+            return;
+        }
+
+        $hosts = array_unique(array_filter([
+            $event->request->getHttpHost(),
+            $event->request->server->get('HTTP_HOST'),
+        ]));
+
+        if ($hosts === []) {
+            return;
+        }
+
+        $pattern = '#https?://(?:'.implode('|', array_map(
+            fn (string $host): string => preg_quote($host, '#'),
+            $hosts,
+        )).')#';
+
+        $event->response->setContent(preg_replace($pattern, '', $content));
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use App\Listeners\RewriteDiscordActivityAssetUrls;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
+use Illuminate\Foundation\Http\Events\RequestHandled;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 
 final class EventServiceProvider extends ServiceProvider
@@ -18,6 +20,11 @@ final class EventServiceProvider extends ServiceProvider
     protected $listen = [
         Registered::class => [
             SendEmailVerificationNotification::class,
+        ],
+        // Precisa rodar depois do listener do Livewire em RequestHandled — providers da
+        // app bootam depois dos pacotes, então isso já roda por último.
+        RequestHandled::class => [
+            RewriteDiscordActivityAssetUrls::class,
         ],
     ];
 

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -2,11 +2,13 @@
 
 declare(strict_types=1);
 
+use App\Http\Middleware\PrepareDiscordActivityContext;
 use App\Http\Middleware\SetApplicationLocale;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Http\Middleware\TrustProxies;
+use Illuminate\Session\Middleware\StartSession;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -16,14 +18,28 @@ return Application::configure(basePath: dirname(__DIR__))
         channels: __DIR__.'/../routes/channels.php',
         health: '/up',
     )->withMiddleware(static function (Middleware $middleware): void {
-        $middleware->replace(
-            TrustProxies::class,
-            Monicahq\Cloudflare\Http\Middleware\TrustProxies::class
-        );
+        // Local, testando via túnel (cloudflared/ngrok), a conexão chega via loopback,
+        // fora dos IPs publicados da Cloudflare: sem confiar em '*', o Laravel não vê
+        // X-Forwarded-Proto e gera url()/asset() em http://, que o túnel recusa.
+        if (env('APP_ENV') === 'local') {
+            $middleware->trustProxies(at: '*');
+        } else {
+            $middleware->replace(
+                TrustProxies::class,
+                Monicahq\Cloudflare\Http\Middleware\TrustProxies::class
+            );
+        }
 
         $middleware->web(append: [
             SetApplicationLocale::class,
         ]);
+
+        // Middleware de rota (não do grupo `web`), mas precisa rodar antes do
+        // StartSession pra afetar o cookie que ele cria.
+        $middleware->prependToPriorityList(
+            before: StartSession::class,
+            prepend: PrepareDiscordActivityContext::class,
+        );
     })
     ->withExceptions(static function (Exceptions $exceptions): void {})
     ->create();

--- a/docker/mediamtx/mediamtx.yml
+++ b/docker/mediamtx/mediamtx.yml
@@ -6,6 +6,11 @@ authHTTPExclude:
   - action: api
   - action: metrics
   - action: pprof
+  # Leitura já é sempre pública em AuthorizeMediaServerAction — chamar o hook aqui só
+  # cria round-trip redundante e, no servidor de dev single-threaded, um deadlock
+  # quando algo já está ocupando a única thread do Laravel esperando o mediamtx.
+  - action: read
+  - action: playback
 
 api: yes
 apiAddress: :9997

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "3.0.0",
             "license": "MIT",
             "dependencies": {
+                "@discord/embedded-app-sdk": "^2.5.0",
                 "laravel-echo": "^2.4.0",
                 "pusher-js": "^8.6.0"
             },
@@ -30,6 +31,22 @@
             },
             "engines": {
                 "node": "^24"
+            }
+        },
+        "node_modules/@discord/embedded-app-sdk": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@discord/embedded-app-sdk/-/embedded-app-sdk-2.5.0.tgz",
+            "integrity": "sha512-FNoe5PbSkoKEbqPubaBmq6tlEMOftMjR3gu55YrdrrKmBfKKM4i9P/Z+Zxl0RZdJcKviBwVcTyYMMPM/aGex/w==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/lodash.transform": "^4.6.6",
+                "@types/uuid": "^10.0.0",
+                "big-integer": "^1.6.48",
+                "decimal.js-light": "^2.5.0",
+                "eventemitter3": "^5.0.0",
+                "lodash.transform": "^4.6.0",
+                "uuid": "^11.0.0",
+                "zod": "^3.9.8"
             }
         },
         "node_modules/@emnapi/core": {
@@ -683,6 +700,27 @@
                 "vite": "^5.2.0 || ^6 || ^7 || ^8"
             }
         },
+        "node_modules/@types/lodash": {
+            "version": "4.17.25",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.25.tgz",
+            "integrity": "sha512-+K1NIO8I+F9/wNulfVvu23QYd0Pe9/OCqRrim4NoYIf1VoEDL90Ve4ClzpyqBLc7NpGGWRvYNCKZ1BE/Jpf8dQ==",
+            "license": "MIT"
+        },
+        "node_modules/@types/lodash.transform": {
+            "version": "4.6.9",
+            "resolved": "https://registry.npmjs.org/@types/lodash.transform/-/lodash.transform-4.6.9.tgz",
+            "integrity": "sha512-1iIn+l7Vrj8hsr2iZLtxRkcV9AtjTafIyxKO9DX2EEcdOgz3Op5dhwKQFhMJgdfIRbYHBUF+SU97Y6P+zyLXNg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/lodash": "*"
+            }
+        },
+        "node_modules/@types/uuid": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+            "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+            "license": "MIT"
+        },
         "node_modules/ansi-regex": {
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
@@ -707,6 +745,15 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/big-integer": {
+            "version": "1.6.52",
+            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+            "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+            "license": "Unlicense",
+            "engines": {
+                "node": ">=0.6"
             }
         },
         "node_modules/chalk": {
@@ -775,6 +822,12 @@
                 "node": ">=4"
             }
         },
+        "node_modules/decimal.js-light": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+            "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+            "license": "MIT"
+        },
         "node_modules/detect-libc": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -815,6 +868,12 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/eventemitter3": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+            "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+            "license": "MIT"
         },
         "node_modules/fdir": {
             "version": "6.5.0",
@@ -1257,6 +1316,12 @@
                 "yaml": "^2.9.0"
             }
         },
+        "node_modules/lodash.transform": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/lodash.transform/-/lodash.transform-4.6.0.tgz",
+            "integrity": "sha512-LO37ZnhmBVx0GvOU/caQuipEh4GN82TcWv3yHlebGDgOxbxiwwzW5Pcx2AcvpIv2WmvmSMoC492yQFNhy/l/UQ==",
+            "license": "MIT"
+        },
         "node_modules/magic-string": {
             "version": "0.30.21",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -1599,6 +1664,19 @@
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/uuid": {
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/esm/bin/uuid"
+            }
         },
         "node_modules/vite": {
             "version": "8.2.1",
@@ -2046,6 +2124,15 @@
             "license": "ISC",
             "engines": {
                 "node": "^20.19.0 || ^22.12.0 || >=23"
+            }
+        },
+        "node_modules/zod": {
+            "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
         ]
     },
     "dependencies": {
+        "@discord/embedded-app-sdk": "^2.5.0",
         "laravel-echo": "^2.4.0",
         "pusher-js": "^8.6.0"
     }

--- a/vite.config.js
+++ b/vite.config.js
@@ -15,6 +15,7 @@ export default defineConfig({
                 'app-modules/docs/resources/css/theme.css',
                 'app-modules/portal/resources/css/retrospective.css',
                 'app-modules/portal/resources/js/live-player.js',
+                'app-modules/portal/resources/js/discord-activity.js',
             ],
             refresh: true,
         }),


### PR DESCRIPTION
## Contexto

Em cima do MVP de live (#530), abre a mesma experiência (player + chat) como Discord
Activity — o mini-app embutido no painel de voz do Discord. Nenhum arquivo do #530 foi
alterado; tudo aqui é composição por cima dos componentes que já existem.

Duas descobertas moldaram a implementação:
- O ponto de entrada de uma Activity é sempre `/` — o Discord não permite apontar pra
  outra rota, então a detecção de contexto acontece na própria rota raiz do portal.
- O iframe roda a partir de `discordsays.com` (terceiro pro documento top-level do
  Discord) com CSP restrita a `'self'` — exigiu ajuste de sessão (`SameSite=None`) e
  reescrita de URLs absolutas pra relativas.

### Alterações

**Módulo `identity`**
- `FindConnectedUser`: resolve `User` a partir de identidade externa já vinculada, só
  leitura — diferente de `ResolveExternalIdentity`, nunca cria identidade.

**Módulo `integration-discord`**
- `redirectUri` de `ExchangeCodeForToken` vira opcional: o `authorize()` do SDK da
  Activity troca `code` por token sem `redirect_uri`, diferente do login web.
- `Activity/`: `AuthenticateActivityUser` (troca code → token → resolve User vinculado),
  `ActivityAuthResult` (DTO), `ActivityAuthController` + rota `POST /discord-activity/auth`,
  isolada das rotas de auth existentes.

**Módulo `live`**
- `HlsProxyController` + rota `GET /discord-activity/hls/{path}`: repassa o HLS do
  mediamtx pelo próprio domínio da app — a CSP do iframe só permite mídia da própria origem.
- `mediamtx.yml`: exclui `read`/`playback` do hook de auth HTTP — já eram sempre liberados
  no código; chamar o hook mesmo assim criava round-trip redundante e, no servidor de dev
  single-threaded, um deadlock real.

**Módulo `portal`**
- `LiveActivityPage` + `live-activity.blade.php` + layout `activity.blade.php`: versão
  enxuta da live (player + chat, sem navbar) servida dentro do iframe do Discord.
- `discord-activity.js`: bootstrap do `@discord/embedded-app-sdk` (`ready()` →
  `authorize()` → troca de código no backend → `authenticate()`), com interceptação de
  links pra abrir fora do iframe (sandboxed sem `allow-popups`).
- A rota `/` do `PortalServiceProvider` decide entre `Homepage` e `LiveActivityPage`
  conforme o query param `frame_id` que o SDK injeta.

**App (transversal)**
- `PrepareDiscordActivityContext` (middleware): ajusta `session.same_site` pra `none` no
  contexto da Activity — sem isso o cookie de sessão não sobrevive no iframe de terceiros.
- `RewriteDiscordActivityAssetUrls` (listener de `RequestHandled`): reescreve URLs
  absolutas pro próprio host como relativas na resposta — precisa rodar depois que o
  Livewire injeta seu script, que só acontece depois de toda a pipeline de middleware.
- `bootstrap/app.php`: `TrustProxies` confia em qualquer proxy só quando `APP_ENV=local`
  — necessário pra testar via túnel (cloudflared/ngrok), zero efeito em produção.

### Fora desta v1 (follow-up)

- Chat em tempo real dentro da Activity (Reverb roda numa porta separada, bloqueada pela
  mesma CSP — precisaria de um segundo túnel/proxy em produção). Hoje: manda mensagem,
  não vê a de quem está fora até recarregar.
- Fluxo de "vincular conta Discord" acontece fora do iframe (abre em navegador externo
  via `openExternalLink` do SDK).
- CORS de produção do HLS (mediamtx) pra origem real da Activity (`discordsays.com`
  varia por app).

### Plano de Testes

- [x] `vendor/bin/pint --dirty --format agent`
- [x] `vendor/bin/phpstan analyse --memory-limit=2G` — 0 erros
- [x] `php artisan test --compact` — 1730/1732 testes, 5926 assertions (as 2 falhas são
      pré-existentes em `CommunityRetrospectivePageTest`, não relacionadas — confirmado
      revertendo os arquivos desta PR e reproduzindo a mesma falha)
- [x] Testado manualmente dentro do Discord (Activity real, canal de voz): vídeo, envio
      de chat e vínculo de conta Discord funcionando

## Issues Relacionadas

Nenhuma issue vinculada.