### PR TITLE
feat(squads): squad_applications + ApplyToSquad gated no APTO (#360)

### DIFF
--- a/app-modules/squads/database/factories/SquadApplicationFactory.php
+++ b/app-modules/squads/database/factories/SquadApplicationFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Squads\Database\Factories;
+
+use He4rt\Identity\User\Models\User;
+use He4rt\Squads\Enums\ApplicationStatus;
+use He4rt\Squads\Models\Squad;
+use He4rt\Squads\Models\SquadApplication;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<SquadApplication>
+ */
+final class SquadApplicationFactory extends Factory
+{
+    protected $model = SquadApplication::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'squad_id' => Squad::factory(),
+            'user_id' => User::factory(),
+            'status' => ApplicationStatus::Pending,
+            'message' => fake()->sentence(),
+            'decided_by' => null,
+            'decided_at' => null,
+        ];
+    }
+}

--- a/app-modules/squads/database/migrations/2026_08_31_143516_create_squad_applications_table.php
+++ b/app-modules/squads/database/migrations/2026_08_31_143516_create_squad_applications_table.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('squad_applications', static function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('squad_id')->constrained('squads')->cascadeOnDelete();
+            $table->foreignUuid('user_id')->constrained('users')->cascadeOnDelete();
+            $table->string('status', 30)->default('pending');
+            $table->text('message')->nullable();
+            $table->foreignUuid('decided_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestampTz('decided_at')->nullable();
+            $table->timestampsTz();
+
+            $table->index(['squad_id', 'status']);
+        });
+
+        // At most one open application per person per squad. Decided rows (approved
+        // or rejected) fall out of the index, so re-applying after a rejection works.
+        DB::statement(
+            "CREATE UNIQUE INDEX squad_applications_pending_unique ON squad_applications (squad_id, user_id) WHERE status = 'pending'"
+        );
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('squad_applications');
+    }
+};

--- a/app-modules/squads/src/Actions/ApplyToSquad.php
+++ b/app-modules/squads/src/Actions/ApplyToSquad.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Squads\Actions;
+
+use He4rt\Identity\User\Models\User;
+use He4rt\Onboarding\Contracts\OnboardingCompletionGate;
+use He4rt\Onboarding\Enums\OnboardingType;
+use He4rt\Squads\Enums\ApplicationStatus;
+use He4rt\Squads\Exceptions\ApplicationAlreadyPending;
+use He4rt\Squads\Exceptions\NotAptForSquads;
+use He4rt\Squads\Models\Squad;
+use He4rt\Squads\Models\SquadApplication;
+use Illuminate\Database\UniqueConstraintViolationException;
+
+/**
+ * Opens a candidacy to a squad, the one flow this module conducts.
+ *
+ * Entry is gated on APTO: the applicant must have completed the `Squads`
+ * onboarding. The gate is read from `onboarding`; this module never owns that
+ * state. Whoever catches `NotAptForSquads` points the person at the onboarding.
+ *
+ * The captain's decision is a separate Action; here the application is only
+ * opened, always as `pending`.
+ */
+final readonly class ApplyToSquad
+{
+    public function __construct(
+        private OnboardingCompletionGate $onboardingGate,
+    ) {}
+
+    public function handle(User $applicant, Squad $squad, ?string $message = null): SquadApplication
+    {
+        throw_unless(
+            $this->onboardingGate->isCompleted($applicant, OnboardingType::Squads),
+            NotAptForSquads::for($applicant),
+        );
+
+        try {
+            // The "one pending application per squad" rule is the partial unique
+            // index, not a prior SELECT: two simultaneous applications would both
+            // read "none pending" and both insert. The insert decides; a rejected
+            // one falls out of the index, so re-applying later is allowed.
+            /** @var SquadApplication $application */
+            $application = SquadApplication::query()->create([
+                'squad_id' => $squad->id,
+                'user_id' => $applicant->id,
+                'status' => ApplicationStatus::Pending,
+                'message' => $message,
+            ]);
+        } catch (UniqueConstraintViolationException) {
+            throw ApplicationAlreadyPending::for($squad, $applicant);
+        }
+
+        return $application;
+    }
+}

--- a/app-modules/squads/src/Enums/ApplicationStatus.php
+++ b/app-modules/squads/src/Enums/ApplicationStatus.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Squads\Enums;
+
+enum ApplicationStatus: string
+{
+    case Pending = 'pending';
+    case Approved = 'approved';
+    case Rejected = 'rejected';
+}

--- a/app-modules/squads/src/Exceptions/ApplicationAlreadyPending.php
+++ b/app-modules/squads/src/Exceptions/ApplicationAlreadyPending.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Squads\Exceptions;
+
+use Exception;
+use He4rt\Identity\User\Models\User;
+use He4rt\Squads\Models\Squad;
+
+final class ApplicationAlreadyPending extends Exception
+{
+    public static function for(Squad $squad, User $applicant): self
+    {
+        return new self(
+            sprintf('User "%s" already has a pending application to squad "%s".', $applicant->id, $squad->id)
+        );
+    }
+}

--- a/app-modules/squads/src/Exceptions/NotAptForSquads.php
+++ b/app-modules/squads/src/Exceptions/NotAptForSquads.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Squads\Exceptions;
+
+use Exception;
+use He4rt\Identity\User\Models\User;
+
+final class NotAptForSquads extends Exception
+{
+    public static function for(User $subject): self
+    {
+        return new self(
+            sprintf('User "%s" must complete the Squads onboarding before applying to a squad.', $subject->id)
+        );
+    }
+}

--- a/app-modules/squads/src/Models/SquadApplication.php
+++ b/app-modules/squads/src/Models/SquadApplication.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Squads\Models;
+
+use Carbon\CarbonInterface;
+use He4rt\Identity\User\Models\User;
+use He4rt\Squads\Database\Factories\SquadApplicationFactory;
+use He4rt\Squads\Enums\ApplicationStatus;
+use Illuminate\Database\Eloquent\Attributes\Table;
+use Illuminate\Database\Eloquent\Attributes\UseFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property string $id
+ * @property string $squad_id
+ * @property string $user_id
+ * @property ApplicationStatus $status
+ * @property string|null $message
+ * @property string|null $decided_by
+ * @property CarbonInterface|null $decided_at
+ * @property CarbonInterface|null $created_at
+ * @property CarbonInterface|null $updated_at
+ */
+#[UseFactory(factoryClass: SquadApplicationFactory::class)]
+#[Table(name: 'squad_applications')]
+final class SquadApplication extends Model
+{
+    /** @use HasFactory<SquadApplicationFactory> */
+    use HasFactory;
+    use HasUuids;
+
+    protected $fillable = [
+        'squad_id',
+        'user_id',
+        'status',
+        'message',
+        'decided_by',
+        'decided_at',
+    ];
+
+    /**
+     * @return BelongsTo<Squad, $this>
+     */
+    public function squad(): BelongsTo
+    {
+        return $this->belongsTo(Squad::class);
+    }
+
+    /**
+     * The applicant.
+     *
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * The leader who approved or rejected it; null while pending.
+     *
+     * @return BelongsTo<User, $this>
+     */
+    public function decidedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'decided_by');
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'status' => ApplicationStatus::class,
+            'decided_at' => 'datetime',
+        ];
+    }
+}

--- a/app-modules/squads/tests/Feature/ApplyToSquadTest.php
+++ b/app-modules/squads/tests/Feature/ApplyToSquadTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Identity\User\Models\User;
+use He4rt\Onboarding\Enums\OnboardingStatus;
+use He4rt\Onboarding\Enums\OnboardingType;
+use He4rt\Onboarding\Models\Onboarding;
+use He4rt\Squads\Actions\ApplyToSquad;
+use He4rt\Squads\Enums\ApplicationStatus;
+use He4rt\Squads\Exceptions\ApplicationAlreadyPending;
+use He4rt\Squads\Exceptions\NotAptForSquads;
+use He4rt\Squads\Models\Squad;
+use He4rt\Squads\Models\SquadApplication;
+
+test('an apt person opens a pending application', function (): void {
+    $squad = Squad::factory()->create();
+    $applicant = User::factory()->create();
+
+    Onboarding::factory()->completed()->create([
+        'user_id' => $applicant->id,
+        'type' => OnboardingType::Squads,
+    ]);
+
+    $application = resolve(ApplyToSquad::class)->handle(
+        applicant: $applicant,
+        squad: $squad,
+        message: 'Quero somar no back-end.',
+    );
+
+    expect($application->status)->toBe(ApplicationStatus::Pending)
+        ->and($application->decided_by)->toBeNull()
+        ->and($application->decided_at)->toBeNull();
+
+    $this->assertDatabaseHas('squad_applications', [
+        'squad_id' => $squad->id,
+        'user_id' => $applicant->id,
+        'status' => ApplicationStatus::Pending->value,
+        'message' => 'Quero somar no back-end.',
+    ]);
+});
+
+test('a person who is not apt is blocked and sent to the onboarding', function (?OnboardingType $type, ?OnboardingStatus $status): void {
+    $squad = Squad::factory()->create();
+    $applicant = User::factory()->create();
+
+    if ($type instanceof OnboardingType) {
+        Onboarding::factory()->create([
+            'user_id' => $applicant->id,
+            'type' => $type,
+            'status' => $status,
+        ]);
+    }
+
+    resolve(ApplyToSquad::class)->handle(
+        applicant: $applicant,
+        squad: $squad,
+    );
+})->with([
+    'no onboarding at all' => [null, null],
+    'squads onboarding in progress' => [OnboardingType::Squads, OnboardingStatus::InProgress],
+    'only the welcome onboarding completed' => [OnboardingType::Welcome, OnboardingStatus::Completed],
+])->throws(NotAptForSquads::class);
+
+test('a second pending application to the same squad is blocked', function (): void {
+    $squad = Squad::factory()->create();
+    $applicant = User::factory()->create();
+
+    Onboarding::factory()->completed()->create([
+        'user_id' => $applicant->id,
+        'type' => OnboardingType::Squads,
+    ]);
+
+    SquadApplication::factory()->create([
+        'squad_id' => $squad->id,
+        'user_id' => $applicant->id,
+        'status' => ApplicationStatus::Pending,
+    ]);
+
+    resolve(ApplyToSquad::class)->handle(
+        applicant: $applicant,
+        squad: $squad,
+    );
+})->throws(ApplicationAlreadyPending::class);
+
+test('a rejected application does not block a new one', function (): void {
+    $squad = Squad::factory()->create();
+    $applicant = User::factory()->create();
+
+    Onboarding::factory()->completed()->create([
+        'user_id' => $applicant->id,
+        'type' => OnboardingType::Squads,
+    ]);
+
+    SquadApplication::factory()->create([
+        'squad_id' => $squad->id,
+        'user_id' => $applicant->id,
+        'status' => ApplicationStatus::Rejected,
+        'decided_at' => now(),
+    ]);
+
+    $application = resolve(ApplyToSquad::class)->handle(
+        applicant: $applicant,
+        squad: $squad,
+    );
+
+    expect($application->status)->toBe(ApplicationStatus::Pending)
+        ->and(SquadApplication::query()->where('user_id', $applicant->id)->count())->toBe(2);
+});
+
+test('a pending application in another squad does not block this one', function (): void {
+    $applicant = User::factory()->create();
+
+    Onboarding::factory()->completed()->create([
+        'user_id' => $applicant->id,
+        'type' => OnboardingType::Squads,
+    ]);
+
+    SquadApplication::factory()->create([
+        'user_id' => $applicant->id,
+        'status' => ApplicationStatus::Pending,
+    ]);
+
+    $application = resolve(ApplyToSquad::class)->handle(
+        applicant: $applicant,
+        squad: Squad::factory()->create(),
+    );
+
+    expect($application->status)->toBe(ApplicationStatus::Pending);
+});


### PR DESCRIPTION
Materializa a candidatura a um squad, o único fluxo que o módulo conduz, gated no APTO do onboarding.

- Migration `squad_applications`: `status` (default `pending`), `message`, `decided_by`, `decided_at`, `INDEX (squad_id, status)` e o partial `UNIQUE (squad_id, user_id) WHERE status = 'pending'`
- Model `SquadApplication` (PHPDoc `@property`, `#[Table]`, `#[UseFactory]`, casts) + `SquadApplicationFactory` + enum `ApplicationStatus` (`pending`/`approved`/`rejected`)
- Action `ApplyToSquad`: lê `OnboardingCompletionGate::isCompleted($user, OnboardingType::Squads)` e barra quem não é APTO com `NotAptForSquads`, cuja mensagem já nomeia o onboarding exigido para a UI direcionar
- Candidatura pendente duplicada cai no índice parcial e vira `ApplicationAlreadyPending`

## Sobre a duplicata pendente

Não tem `SELECT` antes do insert: duas candidaturas simultâneas leriam "nenhuma pendente" e inseririam as duas. Quem decide é o índice parcial, e a Action traduz a violação para a exception de domínio. Como candidatura recusada sai do índice, candidatar-se de novo depois continua valendo (tem teste pra isso).

## Fora de escopo (por dependência)

- Aprovar/recusar (`DecideApplication`) é a #361, do @reag-dev, que sobe em cima desta branch
- Exclusividade de um squad ativo por pessoa é a #362, incluindo a validação amigável dentro da `ApplyToSquad`

## Plano de testes
- [x] `ApplyToSquadTest.php`: APTO abre `pending` com mensagem, não-APTO barrado (sem onboarding, onboarding em progresso, só o Welcome concluído), duplicata pendente barrada, candidatura recusada não bloqueia nova, pendente em outro squad não bloqueia. 7/7 verdes
- [x] Suite de `app-modules/squads`: 47/47 verdes
- [x] `make check` (rector + pint + phpstan) limpo

Closes #360
