### PR TITLE
fix(squads): serialize captain-seat mutations (#527)

### DIFF
--- a/app-modules/squads/CONTEXT.md
+++ b/app-modules/squads/CONTEXT.md
@@ -53,6 +53,10 @@ not blocking.)
 
 ## State & audit
 
+Every role mutation locks its `squads` row with `FOR UPDATE` before any `squad_members` row. This
+per-squad mutex serializes role changes and prevents reverse lock ordering with membership-event
+foreign keys, while mutations in different squads remain independent.
+
 - `squads` — squad state (`status`, `objective`, `slug`).
 - `squad_members` — current standing per (squad, user): `role`, `joined_at`, `left_at`.
 - `squad_membership_events` — append-only trail: `action` (`join`/`leave`/`promote`/`demote`/…),

--- a/app-modules/squads/src/Actions/AssignCaptain.php
+++ b/app-modules/squads/src/Actions/AssignCaptain.php
@@ -34,9 +34,12 @@ final readonly class AssignCaptain
         throw_unless($actor->isAdmin(), AuthorizationException::class);
 
         return DB::transaction(function () use ($squad, $subject, $actor, $reason): SquadMember {
-            // Locking the subject's row serializes concurrent assignments of the same
-            // person: the loser re-reads the incumbent after the winner commits and
-            // short-circuits below, instead of appending a phantom pair of events.
+            // Captain-seat mutations lock the squad before any membership row.
+            Squad::query()
+                ->whereKey($squad->id)
+                ->lockForUpdate()
+                ->firstOrFail();
+
             $member = SquadMember::query()
                 ->where('squad_id', $squad->id)
                 ->where('user_id', $subject->id)
@@ -46,7 +49,9 @@ final readonly class AssignCaptain
 
             throw_if($member === null, NotAnActiveSquadMember::for($squad, $subject));
 
-            $incumbent = $squad->captain()->first();
+            $incumbent = $squad->captain()
+                ->lockForUpdate()
+                ->first();
 
             if ($incumbent?->is($member)) {
                 return $member;

--- a/app-modules/squads/src/Actions/AssignCaptain.php
+++ b/app-modules/squads/src/Actions/AssignCaptain.php
@@ -31,10 +31,10 @@ final readonly class AssignCaptain
 
     public function handle(User $actor, Squad $squad, User $subject, ?string $reason = null): SquadMember
     {
+        // Admin authority is global, so waiting for a squad lock cannot make this check stale.
         throw_unless($actor->isAdmin(), AuthorizationException::class);
 
         return DB::transaction(function () use ($squad, $subject, $actor, $reason): SquadMember {
-            // Captain-seat mutations lock the squad before any membership row.
             Squad::query()
                 ->whereKey($squad->id)
                 ->lockForUpdate()

--- a/app-modules/squads/src/Actions/MarkExMember.php
+++ b/app-modules/squads/src/Actions/MarkExMember.php
@@ -29,9 +29,15 @@ final readonly class MarkExMember
 
     public function handle(User $actor, Squad $squad, User $subject, ?string $reason = null): SquadMember
     {
-        $this->squadPolicy->authorize($actor, $squad);
-
         return DB::transaction(function () use ($squad, $subject, $actor, $reason): SquadMember {
+            // Captain-seat mutations lock the squad before any membership row.
+            Squad::query()
+                ->whereKey($squad->id)
+                ->lockForUpdate()
+                ->firstOrFail();
+
+            $this->squadPolicy->authorize($actor, $squad);
+
             $member = SquadMember::query()
                 ->where('squad_id', $squad->id)
                 ->where('user_id', $subject->id)

--- a/app-modules/squads/src/Actions/MarkExMember.php
+++ b/app-modules/squads/src/Actions/MarkExMember.php
@@ -30,12 +30,13 @@ final readonly class MarkExMember
     public function handle(User $actor, Squad $squad, User $subject, ?string $reason = null): SquadMember
     {
         return DB::transaction(function () use ($squad, $subject, $actor, $reason): SquadMember {
-            // Captain-seat mutations lock the squad before any membership row.
             Squad::query()
                 ->whereKey($squad->id)
                 ->lockForUpdate()
                 ->firstOrFail();
 
+            // Squad authority can change while waiting. Check the latest committed role;
+            // denied actors briefly hold this lock until the transaction rolls back.
             $this->squadPolicy->authorize($actor, $squad);
 
             $member = SquadMember::query()

--- a/app-modules/squads/src/Actions/PromoteToSubCaptain.php
+++ b/app-modules/squads/src/Actions/PromoteToSubCaptain.php
@@ -77,6 +77,11 @@ final readonly class PromoteToSubCaptain
             $action,
             $reason,
         ): SquadMember {
+            Squad::query()
+                ->whereKey($squad->id)
+                ->lockForUpdate()
+                ->firstOrFail();
+
             $member = SquadMember::query()
                 ->where('squad_id', $squad->id)
                 ->where('user_id', $subject->id)

--- a/app-modules/squads/tests/Feature/CaptainSeatConcurrencyTest.php
+++ b/app-modules/squads/tests/Feature/CaptainSeatConcurrencyTest.php
@@ -2,417 +2,255 @@
 
 declare(strict_types=1);
 
-namespace He4rt\Squads\Tests\Feature;
-
-use He4rt\Identity\User\Models\User;
 use He4rt\Squads\Enums\MembershipAction;
 use He4rt\Squads\Enums\SquadRole;
-use He4rt\Squads\Models\Squad;
 use He4rt\Squads\Models\SquadMember;
 use He4rt\Squads\Models\SquadMembershipEvent;
+use He4rt\Squads\Tests\Support\CaptainSeatTestEnvironment;
+use He4rt\Squads\Tests\Support\WithoutDatabaseTransactions;
 use Illuminate\Auth\Access\AuthorizationException;
-use Illuminate\Database\Connection;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Sleep;
-use PHPUnit\Framework\Attributes\Group;
-use Symfony\Component\Process\Process;
-use Tests\TestCase;
 
-#[Group(name: 'feature')]
-final class CaptainSeatConcurrencyTest extends TestCase
-{
-    use RefreshDatabase;
+require_once __DIR__.'/../Support/CaptainSeatTestEnvironment.php';
+require_once __DIR__.'/../Support/WithoutDatabaseTransactions.php';
 
-    /** @var list<string> */
-    protected $connectionsToTransact = [];
+uses(WithoutDatabaseTransactions::class);
 
-    /** @var list<string> */
-    private array $squadIds = [];
+beforeEach(function (): void {
+    config(['he4rt.admins' => 'captain-seat-admin']);
 
-    /** @var list<string> */
-    private array $userIds = [];
+    // No lazy callback exists without transaction connections, so migrate eagerly.
+    $this->refreshTestDatabase();
+    $this->captainSeat = new CaptainSeatTestEnvironment();
+    $this->admin = $this->captainSeat->createUser(['username' => 'captain-seat-admin']);
+});
 
-    protected function tearDown(): void
-    {
-        if ($this->app !== null) {
-            DB::table('squads')->whereIn('id', $this->squadIds)->delete();
-            DB::table('users')->whereIn('id', $this->userIds)->delete();
-            DB::purge('captain-seat-lock-holder');
-        }
+afterEach(function (): void {
+    $this->captainSeat->cleanUp();
+});
 
-        parent::tearDown();
+test('two assignments in the same squad are serialized', function (): void {
+    $incumbent = $this->captainSeat->createUser();
+    $firstCandidate = $this->captainSeat->createUser();
+    $secondCandidate = $this->captainSeat->createUser();
+    $squad = $this->captainSeat->createSquad();
+
+    $this->captainSeat->createMembership($squad, $incumbent, SquadRole::Captain);
+    $this->captainSeat->createMembership($squad, $firstCandidate, SquadRole::Member);
+    $this->captainSeat->createMembership($squad, $secondCandidate, SquadRole::Member);
+
+    $holder = $this->captainSeat->holdSquadLock($squad);
+    $first = $this->captainSeat->startWorker('assign', $this->admin, $squad, $firstCandidate);
+    $second = null;
+
+    try {
+        $this->captainSeat->waitUntilBlocked($first);
+
+        $second = $this->captainSeat->startWorker('assign', $this->admin, $squad, $secondCandidate);
+        $this->captainSeat->waitUntilBlocked($second);
+
+        $holder->commit();
+
+        $this->captainSeat->waitUntilSuccessful($first);
+        $this->captainSeat->waitUntilSuccessful($second);
+    } finally {
+        $this->captainSeat->release($holder);
+        $this->captainSeat->stop($first);
+        $this->captainSeat->stop($second);
     }
 
-    public function test_two_assignments_in_the_same_squad_are_serialized(): void
-    {
-        config(['he4rt.admins' => 'captain-seat-admin']);
+    $captain = SquadMember::query()
+        ->where('squad_id', $squad->id)
+        ->where('role', SquadRole::Captain)
+        ->sole();
+    $intermediateCaptain = $captain->user_id === $firstCandidate->id ? $secondCandidate : $firstCandidate;
 
-        $admin = $this->createUser(['username' => 'captain-seat-admin']);
-        $incumbent = $this->createUser();
-        $firstCandidate = $this->createUser();
-        $secondCandidate = $this->createUser();
-        $squad = $this->createSquad();
+    $this->assertDatabaseHas('squad_membership_events', [
+        'squad_id' => $squad->id,
+        'user_id' => $incumbent->id,
+        'action' => MembershipAction::Demote->value,
+        'from_role' => SquadRole::Captain->value,
+        'to_role' => SquadRole::Member->value,
+    ]);
+    $this->assertDatabaseHas('squad_membership_events', [
+        'squad_id' => $squad->id,
+        'user_id' => $intermediateCaptain->id,
+        'action' => MembershipAction::CaptainAssigned->value,
+        'from_role' => SquadRole::Member->value,
+        'to_role' => SquadRole::Captain->value,
+    ]);
+    $this->assertDatabaseHas('squad_membership_events', [
+        'squad_id' => $squad->id,
+        'user_id' => $intermediateCaptain->id,
+        'action' => MembershipAction::Demote->value,
+        'from_role' => SquadRole::Captain->value,
+        'to_role' => SquadRole::Member->value,
+    ]);
+    $this->assertDatabaseHas('squad_membership_events', [
+        'squad_id' => $squad->id,
+        'user_id' => $captain->user_id,
+        'action' => MembershipAction::CaptainAssigned->value,
+        'from_role' => SquadRole::Member->value,
+        'to_role' => SquadRole::Captain->value,
+    ]);
+    $this->assertSame(4, SquadMembershipEvent::query()->where('squad_id', $squad->id)->count());
+});
 
-        $this->createMembership($squad, $incumbent, SquadRole::Captain);
-        $this->createMembership($squad, $firstCandidate, SquadRole::Member);
-        $this->createMembership($squad, $secondCandidate, SquadRole::Member);
+test('assignment and captain exit use the latest committed roles', function (): void {
+    $incumbent = $this->captainSeat->createUser();
+    $successor = $this->captainSeat->createUser();
+    $squad = $this->captainSeat->createSquad();
 
-        $holder = $this->lockSquad($squad);
-        $first = $this->startWorker('assign', $admin, $squad, $firstCandidate);
-        $second = null;
+    $this->captainSeat->createMembership($squad, $incumbent, SquadRole::Captain);
+    $this->captainSeat->createMembership($squad, $successor, SquadRole::Member);
 
-        try {
-            $this->assertWorkerIsBlocked($first);
+    $holder = $this->captainSeat->holdSquadLock($squad);
+    $assignment = $this->captainSeat->startWorker('assign', $this->admin, $squad, $successor);
+    $exit = null;
 
-            $second = $this->startWorker('assign', $admin, $squad, $secondCandidate);
-            $this->assertWorkerIsBlocked($second);
+    try {
+        $this->captainSeat->waitUntilBlocked($assignment);
 
-            $holder->commit();
+        $exit = $this->captainSeat->startWorker('mark_ex', $this->admin, $squad, $incumbent);
+        $this->captainSeat->waitUntilBlocked($exit);
 
-            $this->assertWorkerSucceeded($first);
-            $this->assertWorkerSucceeded($second);
-        } finally {
-            $this->releaseHolder($holder);
-            $this->stopWorker($first);
+        $holder->commit();
 
-            if ($second instanceof Process) {
-                $this->stopWorker($second);
-            }
-        }
-
-        $captain = SquadMember::query()
-            ->where('squad_id', $squad->id)
-            ->where('role', SquadRole::Captain)
-            ->sole();
-        $intermediateCaptain = $captain->user_id === $firstCandidate->id ? $secondCandidate : $firstCandidate;
-
-        $this->assertDatabaseHas('squad_membership_events', [
-            'squad_id' => $squad->id,
-            'user_id' => $incumbent->id,
-            'action' => MembershipAction::Demote->value,
-            'from_role' => SquadRole::Captain->value,
-            'to_role' => SquadRole::Member->value,
-        ]);
-        $this->assertDatabaseHas('squad_membership_events', [
-            'squad_id' => $squad->id,
-            'user_id' => $intermediateCaptain->id,
-            'action' => MembershipAction::CaptainAssigned->value,
-            'from_role' => SquadRole::Member->value,
-            'to_role' => SquadRole::Captain->value,
-        ]);
-        $this->assertDatabaseHas('squad_membership_events', [
-            'squad_id' => $squad->id,
-            'user_id' => $intermediateCaptain->id,
-            'action' => MembershipAction::Demote->value,
-            'from_role' => SquadRole::Captain->value,
-            'to_role' => SquadRole::Member->value,
-        ]);
-        $this->assertDatabaseHas('squad_membership_events', [
-            'squad_id' => $squad->id,
-            'user_id' => $captain->user_id,
-            'action' => MembershipAction::CaptainAssigned->value,
-            'from_role' => SquadRole::Member->value,
-            'to_role' => SquadRole::Captain->value,
-        ]);
-        $this->assertSame(4, SquadMembershipEvent::query()->where('squad_id', $squad->id)->count());
+        $this->captainSeat->waitUntilSuccessful($assignment);
+        $this->captainSeat->waitUntilSuccessful($exit);
+    } finally {
+        $this->captainSeat->release($holder);
+        $this->captainSeat->stop($assignment);
+        $this->captainSeat->stop($exit);
     }
 
-    public function test_assignment_and_captain_exit_use_the_latest_committed_roles(): void
-    {
-        config(['he4rt.admins' => 'captain-seat-admin']);
+    $this->assertDatabaseHas('squad_members', [
+        'squad_id' => $squad->id,
+        'user_id' => $incumbent->id,
+        'role' => SquadRole::ExMember->value,
+    ]);
+    $this->assertDatabaseHas('squad_members', [
+        'squad_id' => $squad->id,
+        'user_id' => $successor->id,
+        'role' => SquadRole::Captain->value,
+    ]);
+    $this->assertDatabaseHas('squad_membership_events', [
+        'squad_id' => $squad->id,
+        'user_id' => $incumbent->id,
+        'action' => MembershipAction::Leave->value,
+        'from_role' => SquadRole::Member->value,
+        'to_role' => SquadRole::ExMember->value,
+    ]);
+    $this->assertSame(3, SquadMembershipEvent::query()->where('squad_id', $squad->id)->count());
+});
 
-        $admin = $this->createUser(['username' => 'captain-seat-admin']);
-        $incumbent = $this->createUser();
-        $successor = $this->createUser();
-        $squad = $this->createSquad();
+test('a waiting action rechecks the actors committed role', function (): void {
+    $captain = $this->captainSeat->createUser();
+    $successor = $this->captainSeat->createUser();
+    $subject = $this->captainSeat->createUser();
+    $squad = $this->captainSeat->createSquad();
 
-        $this->createMembership($squad, $incumbent, SquadRole::Captain);
-        $this->createMembership($squad, $successor, SquadRole::Member);
+    $this->captainSeat->createMembership($squad, $captain, SquadRole::Captain);
+    $this->captainSeat->createMembership($squad, $successor, SquadRole::Member);
+    $this->captainSeat->createMembership($squad, $subject, SquadRole::Member);
 
-        $holder = $this->lockSquad($squad);
-        $assignment = $this->startWorker('assign', $admin, $squad, $successor);
-        $exit = null;
+    $holder = $this->captainSeat->holdSquadLock($squad);
+    $assignment = $this->captainSeat->startWorker('assign', $this->admin, $squad, $successor);
+    $exit = null;
 
-        try {
-            $this->assertWorkerIsBlocked($assignment);
+    try {
+        $this->captainSeat->waitUntilBlocked($assignment);
 
-            $exit = $this->startWorker('mark_ex', $admin, $squad, $incumbent);
-            $this->assertWorkerIsBlocked($exit);
+        $exit = $this->captainSeat->startWorker('mark_ex', $captain, $squad, $subject);
+        $this->captainSeat->waitUntilBlocked($exit);
 
-            $holder->commit();
+        $holder->commit();
 
-            $this->assertWorkerSucceeded($assignment);
-            $this->assertWorkerSucceeded($exit);
-        } finally {
-            $this->releaseHolder($holder);
-            $this->stopWorker($assignment);
-
-            if ($exit instanceof Process) {
-                $this->stopWorker($exit);
-            }
-        }
-
-        $this->assertDatabaseHas('squad_members', [
-            'squad_id' => $squad->id,
-            'user_id' => $incumbent->id,
-            'role' => SquadRole::ExMember->value,
-        ]);
-        $this->assertDatabaseHas('squad_members', [
-            'squad_id' => $squad->id,
-            'user_id' => $successor->id,
-            'role' => SquadRole::Captain->value,
-        ]);
-        $this->assertDatabaseHas('squad_membership_events', [
-            'squad_id' => $squad->id,
-            'user_id' => $incumbent->id,
-            'action' => MembershipAction::Leave->value,
-            'from_role' => SquadRole::Member->value,
-            'to_role' => SquadRole::ExMember->value,
-        ]);
-        $this->assertSame(3, SquadMembershipEvent::query()->where('squad_id', $squad->id)->count());
+        $this->captainSeat->waitUntilSuccessful($assignment);
+        $this->captainSeat->waitUntilFailedWith($exit, AuthorizationException::class);
+    } finally {
+        $this->captainSeat->release($holder);
+        $this->captainSeat->stop($assignment);
+        $this->captainSeat->stop($exit);
     }
 
-    public function test_a_waiting_action_rechecks_the_actors_committed_role(): void
-    {
-        config(['he4rt.admins' => 'captain-seat-admin']);
+    $this->assertDatabaseHas('squad_members', [
+        'squad_id' => $squad->id,
+        'user_id' => $subject->id,
+        'role' => SquadRole::Member->value,
+    ]);
+    $this->assertDatabaseMissing('squad_membership_events', [
+        'squad_id' => $squad->id,
+        'user_id' => $subject->id,
+        'action' => MembershipAction::Leave->value,
+    ]);
+});
 
-        $admin = $this->createUser(['username' => 'captain-seat-admin']);
-        $captain = $this->createUser();
-        $successor = $this->createUser();
-        $subject = $this->createUser();
-        $squad = $this->createSquad();
+test('assignments in different squads do not share a mutex', function (): void {
+    $firstIncumbent = $this->captainSeat->createUser();
+    $firstCandidate = $this->captainSeat->createUser();
+    $secondIncumbent = $this->captainSeat->createUser();
+    $secondCandidate = $this->captainSeat->createUser();
+    $firstSquad = $this->captainSeat->createSquad();
+    $secondSquad = $this->captainSeat->createSquad();
 
-        $this->createMembership($squad, $captain, SquadRole::Captain);
-        $this->createMembership($squad, $successor, SquadRole::Member);
-        $this->createMembership($squad, $subject, SquadRole::Member);
+    $this->captainSeat->createMembership($firstSquad, $firstIncumbent, SquadRole::Captain);
+    $this->captainSeat->createMembership($firstSquad, $firstCandidate, SquadRole::Member);
+    $this->captainSeat->createMembership($secondSquad, $secondIncumbent, SquadRole::Captain);
+    $this->captainSeat->createMembership($secondSquad, $secondCandidate, SquadRole::Member);
 
-        $holder = $this->lockSquad($squad);
-        $assignment = $this->startWorker('assign', $admin, $squad, $successor);
-        $exit = null;
+    $holder = $this->captainSeat->holdSquadLock($firstSquad);
+    $first = $this->captainSeat->startWorker('assign', $this->admin, $firstSquad, $firstCandidate);
+    $second = null;
 
-        try {
-            $this->assertWorkerIsBlocked($assignment);
+    try {
+        $this->captainSeat->waitUntilBlocked($first);
 
-            $exit = $this->startWorker('mark_ex', $captain, $squad, $subject);
-            $this->assertWorkerIsBlocked($exit);
+        $second = $this->captainSeat->startWorker('assign', $this->admin, $secondSquad, $secondCandidate);
+        $this->captainSeat->waitUntilSuccessful($second);
 
-            $holder->commit();
-
-            $this->assertWorkerSucceeded($assignment);
-            $this->assertWorkerFailedWith($exit, AuthorizationException::class);
-        } finally {
-            $this->releaseHolder($holder);
-            $this->stopWorker($assignment);
-
-            if ($exit instanceof Process) {
-                $this->stopWorker($exit);
-            }
-        }
-
-        $this->assertDatabaseHas('squad_members', [
-            'squad_id' => $squad->id,
-            'user_id' => $subject->id,
-            'role' => SquadRole::Member->value,
-        ]);
-        $this->assertDatabaseMissing('squad_membership_events', [
-            'squad_id' => $squad->id,
-            'user_id' => $subject->id,
-            'action' => MembershipAction::Leave->value,
-        ]);
+        $holder->commit();
+        $this->captainSeat->waitUntilSuccessful($first);
+    } finally {
+        $this->captainSeat->release($holder);
+        $this->captainSeat->stop($first);
+        $this->captainSeat->stop($second);
     }
 
-    public function test_assignments_in_different_squads_do_not_share_a_mutex(): void
-    {
-        config(['he4rt.admins' => 'captain-seat-admin']);
+    $this->assertSame($firstCandidate->id, $firstSquad->captain()->firstOrFail()->user_id);
+    $this->assertSame($secondCandidate->id, $secondSquad->captain()->firstOrFail()->user_id);
+});
 
-        $admin = $this->createUser(['username' => 'captain-seat-admin']);
-        $firstIncumbent = $this->createUser();
-        $firstCandidate = $this->createUser();
-        $secondIncumbent = $this->createUser();
-        $secondCandidate = $this->createUser();
-        $firstSquad = $this->createSquad();
-        $secondSquad = $this->createSquad();
+test('sub-captain promotion uses the same squad lock as captain assignment', function (): void {
+    $incumbent = $this->captainSeat->createUser();
+    $subject = $this->captainSeat->createUser();
+    $squad = $this->captainSeat->createSquad();
 
-        $this->createMembership($firstSquad, $firstIncumbent, SquadRole::Captain);
-        $this->createMembership($firstSquad, $firstCandidate, SquadRole::Member);
-        $this->createMembership($secondSquad, $secondIncumbent, SquadRole::Captain);
-        $this->createMembership($secondSquad, $secondCandidate, SquadRole::Member);
+    $this->captainSeat->createMembership($squad, $incumbent, SquadRole::Captain);
+    $this->captainSeat->createMembership($squad, $subject, SquadRole::Member);
 
-        $holder = $this->lockSquad($firstSquad);
-        $first = $this->startWorker('assign', $admin, $firstSquad, $firstCandidate);
-        $second = null;
+    $holder = $this->captainSeat->holdMembershipLock($squad, $subject);
+    $promotion = $this->captainSeat->startWorker('promote', $this->admin, $squad, $subject);
+    $assignment = null;
 
-        try {
-            $this->assertWorkerIsBlocked($first);
+    try {
+        $this->captainSeat->waitUntilBlocked($promotion);
 
-            $second = $this->startWorker('assign', $admin, $secondSquad, $secondCandidate);
-            $this->assertWorkerSucceeded($second);
+        $assignment = $this->captainSeat->startWorker('assign', $this->admin, $squad, $subject);
+        $this->captainSeat->waitUntilBlocked($assignment);
 
-            $holder->commit();
-            $this->assertWorkerSucceeded($first);
-        } finally {
-            $this->releaseHolder($holder);
-            $this->stopWorker($first);
+        $holder->commit();
 
-            if ($second instanceof Process) {
-                $this->stopWorker($second);
-            }
-        }
-
-        $this->assertSame($firstCandidate->id, $firstSquad->captain()->firstOrFail()->user_id);
-        $this->assertSame($secondCandidate->id, $secondSquad->captain()->firstOrFail()->user_id);
+        $this->captainSeat->waitUntilSuccessful($promotion);
+        $this->captainSeat->waitUntilSuccessful($assignment);
+    } finally {
+        $this->captainSeat->release($holder);
+        $this->captainSeat->stop($promotion);
+        $this->captainSeat->stop($assignment);
     }
 
-    /** @param array<string, mixed> $attributes */
-    private function createUser(array $attributes = []): User
-    {
-        $user = User::factory()->create($attributes);
-        $this->userIds[] = $user->id;
-
-        return $user;
-    }
-
-    private function createSquad(): Squad
-    {
-        $squad = Squad::factory()->create();
-        $this->squadIds[] = $squad->id;
-
-        return $squad;
-    }
-
-    private function createMembership(Squad $squad, User $user, SquadRole $role): void
-    {
-        SquadMember::factory()->create([
-            'squad_id' => $squad->id,
-            'user_id' => $user->id,
-            'role' => $role,
-        ]);
-    }
-
-    private function lockSquad(Squad $squad): Connection
-    {
-        $default = config('database.default');
-        config(['database.connections.captain-seat-lock-holder' => config('database.connections.'.$default)]);
-
-        $connection = DB::connection('captain-seat-lock-holder');
-        $connection->beginTransaction();
-        $connection->table('squads')->where('id', $squad->id)->lockForUpdate()->first();
-
-        return $connection;
-    }
-
-    private function startWorker(string $action, User $actor, Squad $squad, User $subject): Process
-    {
-        $payload = json_encode([
-            'action' => $action,
-            'actor_id' => $actor->id,
-            'squad_id' => $squad->id,
-            'subject_id' => $subject->id,
-            'admin_username' => config('he4rt.admins'),
-        ], JSON_THROW_ON_ERROR);
-
-        $process = new Process(
-            [PHP_BINARY, base_path('app-modules/squads/tests/Support/captain-seat-worker.php'), $payload],
-            base_path(),
-            [
-                'APP_ENV' => 'testing',
-                'DB_DATABASE' => DB::connection()->getDatabaseName(),
-                'DB_URL' => false,
-            ],
-        );
-        $process->setTimeout(10);
-        $process->start();
-
-        return $process;
-    }
-
-    private function assertWorkerIsBlocked(Process $process): void
-    {
-        $pid = $this->waitForWorkerPid($process);
-        $deadline = microtime(as_float: true) + 5;
-
-        do {
-            $blockerCount = (int) DB::selectOne(
-                'select cardinality(pg_blocking_pids(?)) as blocker_count',
-                [$pid],
-            )->blocker_count;
-
-            if ($blockerCount > 0) {
-                return;
-            }
-
-            if (!$process->isRunning()) {
-                break;
-            }
-
-            Sleep::usleep(10_000);
-        } while (microtime(as_float: true) < $deadline);
-
-        self::fail("Worker {$pid} did not wait for the squad lock.\n{$process->getOutput()}\n{$process->getErrorOutput()}");
-    }
-
-    private function waitForWorkerPid(Process $process): int
-    {
-        $deadline = microtime(as_float: true) + 5;
-
-        do {
-            if (preg_match('/^\{"pid":(\d+)\}$/m', $process->getOutput(), $matches) === 1) {
-                return (int) $matches[1];
-            }
-
-            if (!$process->isRunning()) {
-                break;
-            }
-
-            Sleep::usleep(10_000);
-        } while (microtime(as_float: true) < $deadline);
-
-        self::fail("Worker did not report its PostgreSQL PID.\n{$process->getOutput()}\n{$process->getErrorOutput()}");
-    }
-
-    private function assertWorkerSucceeded(Process $process): void
-    {
-        $result = $this->workerResult($process);
-
-        $this->assertTrue(
-            $result['ok'],
-            sprintf('%s: %s', $result['exception'] ?? 'Worker failed', $result['message'] ?? 'No message'),
-        );
-    }
-
-    private function assertWorkerFailedWith(Process $process, string $exception): void
-    {
-        $result = $this->workerResult($process);
-
-        $this->assertFalse($result['ok']);
-        $this->assertSame($exception, $result['exception'] ?? null, $result['message'] ?? 'No message');
-    }
-
-    /** @return array<string, mixed> */
-    private function workerResult(Process $process): array
-    {
-        $process->wait();
-        $this->assertTrue($process->isSuccessful(), $process->getErrorOutput());
-
-        $lines = array_values(array_filter(explode("\n", mb_trim($process->getOutput()))));
-
-        return json_decode($lines[array_key_last($lines)], associative: true, flags: JSON_THROW_ON_ERROR);
-    }
-
-    private function releaseHolder(Connection $connection): void
-    {
-        if ($connection->transactionLevel() > 0) {
-            $connection->rollBack();
-        }
-
-        $connection->disconnect();
-    }
-
-    private function stopWorker(Process $process): void
-    {
-        if ($process->isRunning()) {
-            $process->stop(1);
-        }
-    }
-}
+    $this->assertDatabaseHas('squad_members', [
+        'squad_id' => $squad->id,
+        'user_id' => $subject->id,
+        'role' => SquadRole::Captain->value,
+    ]);
+});

--- a/app-modules/squads/tests/Feature/CaptainSeatConcurrencyTest.php
+++ b/app-modules/squads/tests/Feature/CaptainSeatConcurrencyTest.php
@@ -1,0 +1,418 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Squads\Tests\Feature;
+
+use He4rt\Identity\User\Models\User;
+use He4rt\Squads\Enums\MembershipAction;
+use He4rt\Squads\Enums\SquadRole;
+use He4rt\Squads\Models\Squad;
+use He4rt\Squads\Models\SquadMember;
+use He4rt\Squads\Models\SquadMembershipEvent;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Database\Connection;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Sleep;
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\Component\Process\Process;
+use Tests\TestCase;
+
+#[Group(name: 'feature')]
+final class CaptainSeatConcurrencyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @var list<string> */
+    protected $connectionsToTransact = [];
+
+    /** @var list<string> */
+    private array $squadIds = [];
+
+    /** @var list<string> */
+    private array $userIds = [];
+
+    protected function tearDown(): void
+    {
+        if ($this->app !== null) {
+            DB::table('squads')->whereIn('id', $this->squadIds)->delete();
+            DB::table('users')->whereIn('id', $this->userIds)->delete();
+            DB::purge('captain-seat-lock-holder');
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_two_assignments_in_the_same_squad_are_serialized(): void
+    {
+        config(['he4rt.admins' => 'captain-seat-admin']);
+
+        $admin = $this->createUser(['username' => 'captain-seat-admin']);
+        $incumbent = $this->createUser();
+        $firstCandidate = $this->createUser();
+        $secondCandidate = $this->createUser();
+        $squad = $this->createSquad();
+
+        $this->createMembership($squad, $incumbent, SquadRole::Captain);
+        $this->createMembership($squad, $firstCandidate, SquadRole::Member);
+        $this->createMembership($squad, $secondCandidate, SquadRole::Member);
+
+        $holder = $this->lockSquad($squad);
+        $first = $this->startWorker('assign', $admin, $squad, $firstCandidate);
+        $second = null;
+
+        try {
+            $this->assertWorkerIsBlocked($first);
+
+            $second = $this->startWorker('assign', $admin, $squad, $secondCandidate);
+            $this->assertWorkerIsBlocked($second);
+
+            $holder->commit();
+
+            $this->assertWorkerSucceeded($first);
+            $this->assertWorkerSucceeded($second);
+        } finally {
+            $this->releaseHolder($holder);
+            $this->stopWorker($first);
+
+            if ($second instanceof Process) {
+                $this->stopWorker($second);
+            }
+        }
+
+        $captain = SquadMember::query()
+            ->where('squad_id', $squad->id)
+            ->where('role', SquadRole::Captain)
+            ->sole();
+        $intermediateCaptain = $captain->user_id === $firstCandidate->id ? $secondCandidate : $firstCandidate;
+
+        $this->assertDatabaseHas('squad_membership_events', [
+            'squad_id' => $squad->id,
+            'user_id' => $incumbent->id,
+            'action' => MembershipAction::Demote->value,
+            'from_role' => SquadRole::Captain->value,
+            'to_role' => SquadRole::Member->value,
+        ]);
+        $this->assertDatabaseHas('squad_membership_events', [
+            'squad_id' => $squad->id,
+            'user_id' => $intermediateCaptain->id,
+            'action' => MembershipAction::CaptainAssigned->value,
+            'from_role' => SquadRole::Member->value,
+            'to_role' => SquadRole::Captain->value,
+        ]);
+        $this->assertDatabaseHas('squad_membership_events', [
+            'squad_id' => $squad->id,
+            'user_id' => $intermediateCaptain->id,
+            'action' => MembershipAction::Demote->value,
+            'from_role' => SquadRole::Captain->value,
+            'to_role' => SquadRole::Member->value,
+        ]);
+        $this->assertDatabaseHas('squad_membership_events', [
+            'squad_id' => $squad->id,
+            'user_id' => $captain->user_id,
+            'action' => MembershipAction::CaptainAssigned->value,
+            'from_role' => SquadRole::Member->value,
+            'to_role' => SquadRole::Captain->value,
+        ]);
+        $this->assertSame(4, SquadMembershipEvent::query()->where('squad_id', $squad->id)->count());
+    }
+
+    public function test_assignment_and_captain_exit_use_the_latest_committed_roles(): void
+    {
+        config(['he4rt.admins' => 'captain-seat-admin']);
+
+        $admin = $this->createUser(['username' => 'captain-seat-admin']);
+        $incumbent = $this->createUser();
+        $successor = $this->createUser();
+        $squad = $this->createSquad();
+
+        $this->createMembership($squad, $incumbent, SquadRole::Captain);
+        $this->createMembership($squad, $successor, SquadRole::Member);
+
+        $holder = $this->lockSquad($squad);
+        $assignment = $this->startWorker('assign', $admin, $squad, $successor);
+        $exit = null;
+
+        try {
+            $this->assertWorkerIsBlocked($assignment);
+
+            $exit = $this->startWorker('mark_ex', $admin, $squad, $incumbent);
+            $this->assertWorkerIsBlocked($exit);
+
+            $holder->commit();
+
+            $this->assertWorkerSucceeded($assignment);
+            $this->assertWorkerSucceeded($exit);
+        } finally {
+            $this->releaseHolder($holder);
+            $this->stopWorker($assignment);
+
+            if ($exit instanceof Process) {
+                $this->stopWorker($exit);
+            }
+        }
+
+        $this->assertDatabaseHas('squad_members', [
+            'squad_id' => $squad->id,
+            'user_id' => $incumbent->id,
+            'role' => SquadRole::ExMember->value,
+        ]);
+        $this->assertDatabaseHas('squad_members', [
+            'squad_id' => $squad->id,
+            'user_id' => $successor->id,
+            'role' => SquadRole::Captain->value,
+        ]);
+        $this->assertDatabaseHas('squad_membership_events', [
+            'squad_id' => $squad->id,
+            'user_id' => $incumbent->id,
+            'action' => MembershipAction::Leave->value,
+            'from_role' => SquadRole::Member->value,
+            'to_role' => SquadRole::ExMember->value,
+        ]);
+        $this->assertSame(3, SquadMembershipEvent::query()->where('squad_id', $squad->id)->count());
+    }
+
+    public function test_a_waiting_action_rechecks_the_actors_committed_role(): void
+    {
+        config(['he4rt.admins' => 'captain-seat-admin']);
+
+        $admin = $this->createUser(['username' => 'captain-seat-admin']);
+        $captain = $this->createUser();
+        $successor = $this->createUser();
+        $subject = $this->createUser();
+        $squad = $this->createSquad();
+
+        $this->createMembership($squad, $captain, SquadRole::Captain);
+        $this->createMembership($squad, $successor, SquadRole::Member);
+        $this->createMembership($squad, $subject, SquadRole::Member);
+
+        $holder = $this->lockSquad($squad);
+        $assignment = $this->startWorker('assign', $admin, $squad, $successor);
+        $exit = null;
+
+        try {
+            $this->assertWorkerIsBlocked($assignment);
+
+            $exit = $this->startWorker('mark_ex', $captain, $squad, $subject);
+            $this->assertWorkerIsBlocked($exit);
+
+            $holder->commit();
+
+            $this->assertWorkerSucceeded($assignment);
+            $this->assertWorkerFailedWith($exit, AuthorizationException::class);
+        } finally {
+            $this->releaseHolder($holder);
+            $this->stopWorker($assignment);
+
+            if ($exit instanceof Process) {
+                $this->stopWorker($exit);
+            }
+        }
+
+        $this->assertDatabaseHas('squad_members', [
+            'squad_id' => $squad->id,
+            'user_id' => $subject->id,
+            'role' => SquadRole::Member->value,
+        ]);
+        $this->assertDatabaseMissing('squad_membership_events', [
+            'squad_id' => $squad->id,
+            'user_id' => $subject->id,
+            'action' => MembershipAction::Leave->value,
+        ]);
+    }
+
+    public function test_assignments_in_different_squads_do_not_share_a_mutex(): void
+    {
+        config(['he4rt.admins' => 'captain-seat-admin']);
+
+        $admin = $this->createUser(['username' => 'captain-seat-admin']);
+        $firstIncumbent = $this->createUser();
+        $firstCandidate = $this->createUser();
+        $secondIncumbent = $this->createUser();
+        $secondCandidate = $this->createUser();
+        $firstSquad = $this->createSquad();
+        $secondSquad = $this->createSquad();
+
+        $this->createMembership($firstSquad, $firstIncumbent, SquadRole::Captain);
+        $this->createMembership($firstSquad, $firstCandidate, SquadRole::Member);
+        $this->createMembership($secondSquad, $secondIncumbent, SquadRole::Captain);
+        $this->createMembership($secondSquad, $secondCandidate, SquadRole::Member);
+
+        $holder = $this->lockSquad($firstSquad);
+        $first = $this->startWorker('assign', $admin, $firstSquad, $firstCandidate);
+        $second = null;
+
+        try {
+            $this->assertWorkerIsBlocked($first);
+
+            $second = $this->startWorker('assign', $admin, $secondSquad, $secondCandidate);
+            $this->assertWorkerSucceeded($second);
+
+            $holder->commit();
+            $this->assertWorkerSucceeded($first);
+        } finally {
+            $this->releaseHolder($holder);
+            $this->stopWorker($first);
+
+            if ($second instanceof Process) {
+                $this->stopWorker($second);
+            }
+        }
+
+        $this->assertSame($firstCandidate->id, $firstSquad->captain()->firstOrFail()->user_id);
+        $this->assertSame($secondCandidate->id, $secondSquad->captain()->firstOrFail()->user_id);
+    }
+
+    /** @param array<string, mixed> $attributes */
+    private function createUser(array $attributes = []): User
+    {
+        $user = User::factory()->create($attributes);
+        $this->userIds[] = $user->id;
+
+        return $user;
+    }
+
+    private function createSquad(): Squad
+    {
+        $squad = Squad::factory()->create();
+        $this->squadIds[] = $squad->id;
+
+        return $squad;
+    }
+
+    private function createMembership(Squad $squad, User $user, SquadRole $role): void
+    {
+        SquadMember::factory()->create([
+            'squad_id' => $squad->id,
+            'user_id' => $user->id,
+            'role' => $role,
+        ]);
+    }
+
+    private function lockSquad(Squad $squad): Connection
+    {
+        $default = config('database.default');
+        config(['database.connections.captain-seat-lock-holder' => config('database.connections.'.$default)]);
+
+        $connection = DB::connection('captain-seat-lock-holder');
+        $connection->beginTransaction();
+        $connection->table('squads')->where('id', $squad->id)->lockForUpdate()->first();
+
+        return $connection;
+    }
+
+    private function startWorker(string $action, User $actor, Squad $squad, User $subject): Process
+    {
+        $payload = json_encode([
+            'action' => $action,
+            'actor_id' => $actor->id,
+            'squad_id' => $squad->id,
+            'subject_id' => $subject->id,
+            'admin_username' => config('he4rt.admins'),
+        ], JSON_THROW_ON_ERROR);
+
+        $process = new Process(
+            [PHP_BINARY, base_path('app-modules/squads/tests/Support/captain-seat-worker.php'), $payload],
+            base_path(),
+            [
+                'APP_ENV' => 'testing',
+                'DB_DATABASE' => DB::connection()->getDatabaseName(),
+                'DB_URL' => false,
+            ],
+        );
+        $process->setTimeout(10);
+        $process->start();
+
+        return $process;
+    }
+
+    private function assertWorkerIsBlocked(Process $process): void
+    {
+        $pid = $this->waitForWorkerPid($process);
+        $deadline = microtime(as_float: true) + 5;
+
+        do {
+            $blockerCount = (int) DB::selectOne(
+                'select cardinality(pg_blocking_pids(?)) as blocker_count',
+                [$pid],
+            )->blocker_count;
+
+            if ($blockerCount > 0) {
+                return;
+            }
+
+            if (!$process->isRunning()) {
+                break;
+            }
+
+            Sleep::usleep(10_000);
+        } while (microtime(as_float: true) < $deadline);
+
+        self::fail("Worker {$pid} did not wait for the squad lock.\n{$process->getOutput()}\n{$process->getErrorOutput()}");
+    }
+
+    private function waitForWorkerPid(Process $process): int
+    {
+        $deadline = microtime(as_float: true) + 5;
+
+        do {
+            if (preg_match('/^\{"pid":(\d+)\}$/m', $process->getOutput(), $matches) === 1) {
+                return (int) $matches[1];
+            }
+
+            if (!$process->isRunning()) {
+                break;
+            }
+
+            Sleep::usleep(10_000);
+        } while (microtime(as_float: true) < $deadline);
+
+        self::fail("Worker did not report its PostgreSQL PID.\n{$process->getOutput()}\n{$process->getErrorOutput()}");
+    }
+
+    private function assertWorkerSucceeded(Process $process): void
+    {
+        $result = $this->workerResult($process);
+
+        $this->assertTrue(
+            $result['ok'],
+            sprintf('%s: %s', $result['exception'] ?? 'Worker failed', $result['message'] ?? 'No message'),
+        );
+    }
+
+    private function assertWorkerFailedWith(Process $process, string $exception): void
+    {
+        $result = $this->workerResult($process);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame($exception, $result['exception'] ?? null, $result['message'] ?? 'No message');
+    }
+
+    /** @return array<string, mixed> */
+    private function workerResult(Process $process): array
+    {
+        $process->wait();
+        $this->assertTrue($process->isSuccessful(), $process->getErrorOutput());
+
+        $lines = array_values(array_filter(explode("\n", mb_trim($process->getOutput()))));
+
+        return json_decode($lines[array_key_last($lines)], associative: true, flags: JSON_THROW_ON_ERROR);
+    }
+
+    private function releaseHolder(Connection $connection): void
+    {
+        if ($connection->transactionLevel() > 0) {
+            $connection->rollBack();
+        }
+
+        $connection->disconnect();
+    }
+
+    private function stopWorker(Process $process): void
+    {
+        if ($process->isRunning()) {
+            $process->stop(1);
+        }
+    }
+}

--- a/app-modules/squads/tests/Support/CaptainSeatTestEnvironment.php
+++ b/app-modules/squads/tests/Support/CaptainSeatTestEnvironment.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Squads\Tests\Support;
+
+use He4rt\Identity\User\Models\User;
+use He4rt\Squads\Enums\SquadRole;
+use He4rt\Squads\Models\Squad;
+use He4rt\Squads\Models\SquadMember;
+use Illuminate\Database\Connection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Sleep;
+use RuntimeException;
+use Symfony\Component\Process\Process;
+
+final class CaptainSeatTestEnvironment
+{
+    /** @var list<string> */
+    private array $squadIds = [];
+
+    /** @var list<string> */
+    private array $userIds = [];
+
+    public function cleanUp(): void
+    {
+        DB::table('squads')->whereIn('id', $this->squadIds)->delete();
+        DB::table('users')->whereIn('id', $this->userIds)->delete();
+        DB::purge('captain-seat-lock-holder');
+    }
+
+    /** @param array<string, mixed> $attributes */
+    public function createUser(array $attributes = []): User
+    {
+        $user = User::factory()->create($attributes);
+        $this->userIds[] = $user->id;
+
+        return $user;
+    }
+
+    public function createSquad(): Squad
+    {
+        $squad = Squad::factory()->create();
+        $this->squadIds[] = $squad->id;
+
+        return $squad;
+    }
+
+    public function createMembership(Squad $squad, User $user, SquadRole $role): void
+    {
+        SquadMember::factory()->create([
+            'squad_id' => $squad->id,
+            'user_id' => $user->id,
+            'role' => $role,
+        ]);
+    }
+
+    public function holdSquadLock(Squad $squad): Connection
+    {
+        $connection = $this->lockHolderConnection();
+        $connection->table('squads')->where('id', $squad->id)->lockForUpdate()->first();
+
+        return $connection;
+    }
+
+    public function holdMembershipLock(Squad $squad, User $user): Connection
+    {
+        $connection = $this->lockHolderConnection();
+        $connection->table('squad_members')
+            ->where('squad_id', $squad->id)
+            ->where('user_id', $user->id)
+            ->lockForUpdate()
+            ->first();
+
+        return $connection;
+    }
+
+    public function startWorker(string $action, User $actor, Squad $squad, User $subject): Process
+    {
+        $payload = json_encode([
+            'action' => $action,
+            'actor_id' => $actor->id,
+            'squad_id' => $squad->id,
+            'subject_id' => $subject->id,
+            'admin_username' => config('he4rt.admins'),
+        ], JSON_THROW_ON_ERROR);
+
+        $process = new Process(
+            [PHP_BINARY, base_path('app-modules/squads/tests/Support/captain-seat-worker.php'), $payload],
+            base_path(),
+            [
+                'APP_ENV' => 'testing',
+                'DB_DATABASE' => DB::connection()->getDatabaseName(),
+                'DB_URL' => false,
+            ],
+        );
+        $process->setTimeout(10);
+        $process->start();
+
+        return $process;
+    }
+
+    public function waitUntilBlocked(Process $process): void
+    {
+        $pid = $this->waitForWorkerPid($process);
+        $deadline = microtime(as_float: true) + 5;
+
+        do {
+            $blockerCount = (int) DB::selectOne(
+                'select cardinality(pg_blocking_pids(?)) as blocker_count',
+                [$pid],
+            )->blocker_count;
+
+            if ($blockerCount > 0) {
+                return;
+            }
+
+            if (!$process->isRunning()) {
+                break;
+            }
+
+            Sleep::usleep(10_000);
+        } while (microtime(as_float: true) < $deadline);
+
+        throw new RuntimeException("Worker {$pid} did not wait for the expected database lock.\n{$process->getOutput()}\n{$process->getErrorOutput()}");
+    }
+
+    public function waitUntilSuccessful(Process $process): void
+    {
+        $result = $this->workerResult($process);
+
+        if (!$result['ok']) {
+            throw new RuntimeException(sprintf(
+                '%s: %s',
+                $result['exception'] ?? 'Worker failed',
+                $result['message'] ?? 'No message',
+            ));
+        }
+    }
+
+    /** @param class-string $exception */
+    public function waitUntilFailedWith(Process $process, string $exception): void
+    {
+        $result = $this->workerResult($process);
+
+        if ($result['ok'] || ($result['exception'] ?? null) !== $exception) {
+            throw new RuntimeException(sprintf(
+                'Expected %s, received %s: %s',
+                $exception,
+                $result['exception'] ?? 'successful result',
+                $result['message'] ?? 'No message',
+            ));
+        }
+    }
+
+    public function release(Connection $connection): void
+    {
+        if ($connection->transactionLevel() > 0) {
+            $connection->rollBack();
+        }
+
+        $connection->disconnect();
+    }
+
+    public function stop(?Process $process): void
+    {
+        if ($process?->isRunning()) {
+            $process->stop(1);
+        }
+    }
+
+    private function lockHolderConnection(): Connection
+    {
+        $default = config('database.default');
+        config(['database.connections.captain-seat-lock-holder' => config('database.connections.'.$default)]);
+
+        $connection = DB::connection('captain-seat-lock-holder');
+        $connection->beginTransaction();
+
+        return $connection;
+    }
+
+    private function waitForWorkerPid(Process $process): int
+    {
+        $deadline = microtime(as_float: true) + 5;
+
+        do {
+            if (preg_match('/^\{"pid":(\d+)\}$/m', $process->getOutput(), $matches) === 1) {
+                return (int) $matches[1];
+            }
+
+            if (!$process->isRunning()) {
+                break;
+            }
+
+            Sleep::usleep(10_000);
+        } while (microtime(as_float: true) < $deadline);
+
+        throw new RuntimeException("Worker did not report its PostgreSQL PID.\n{$process->getOutput()}\n{$process->getErrorOutput()}");
+    }
+
+    /** @return array{ok: bool, exception?: class-string, message?: string} */
+    private function workerResult(Process $process): array
+    {
+        $process->wait();
+
+        if (!$process->isSuccessful()) {
+            throw new RuntimeException($process->getErrorOutput());
+        }
+
+        $lines = array_values(array_filter(explode("\n", mb_trim($process->getOutput()))));
+
+        return json_decode($lines[array_key_last($lines)], associative: true, flags: JSON_THROW_ON_ERROR);
+    }
+}

--- a/app-modules/squads/tests/Support/WithoutDatabaseTransactions.php
+++ b/app-modules/squads/tests/Support/WithoutDatabaseTransactions.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Squads\Tests\Support;
+
+trait WithoutDatabaseTransactions
+{
+    /**
+     * Worker connections cannot see fixtures inside the test transaction.
+     *
+     * @var list<string>
+     */
+    protected $connectionsToTransact = [];
+}

--- a/app-modules/squads/tests/Support/captain-seat-worker.php
+++ b/app-modules/squads/tests/Support/captain-seat-worker.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Identity\User\Models\User;
+use He4rt\Squads\Actions\AssignCaptain;
+use He4rt\Squads\Actions\MarkExMember;
+use He4rt\Squads\Models\Squad;
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Support\Facades\DB;
+
+require dirname(__DIR__, 4).'/vendor/autoload.php';
+
+$app = require dirname(__DIR__, 4).'/bootstrap/app.php';
+$app->make(Kernel::class)->bootstrap();
+
+/** @var array{action: string, actor_id: string, squad_id: string, subject_id: string, admin_username: string} $payload */
+$payload = json_decode($argv[1] ?? '', associative: true, flags: JSON_THROW_ON_ERROR);
+
+config(['he4rt.admins' => $payload['admin_username']]);
+
+fwrite(STDOUT, json_encode([
+    'pid' => (int) DB::selectOne('select pg_backend_pid() as pid')->pid,
+], JSON_THROW_ON_ERROR).PHP_EOL);
+fflush(STDOUT);
+
+try {
+    $actor = User::query()->findOrFail($payload['actor_id']);
+    $squad = Squad::query()->findOrFail($payload['squad_id']);
+    $subject = User::query()->findOrFail($payload['subject_id']);
+
+    match ($payload['action']) {
+        'assign' => resolve(AssignCaptain::class)->handle($actor, $squad, $subject),
+        'mark_ex' => resolve(MarkExMember::class)->handle($actor, $squad, $subject),
+        default => throw new InvalidArgumentException('Unsupported action: '.$payload['action']),
+    };
+
+    $result = ['ok' => true];
+} catch (Throwable $throwable) {
+    $result = [
+        'ok' => false,
+        'exception' => $throwable::class,
+        'message' => $throwable->getMessage(),
+    ];
+}
+
+fwrite(STDOUT, json_encode($result, JSON_THROW_ON_ERROR).PHP_EOL);

--- a/app-modules/squads/tests/Support/captain-seat-worker.php
+++ b/app-modules/squads/tests/Support/captain-seat-worker.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use He4rt\Identity\User\Models\User;
 use He4rt\Squads\Actions\AssignCaptain;
 use He4rt\Squads\Actions\MarkExMember;
+use He4rt\Squads\Actions\PromoteToSubCaptain;
 use He4rt\Squads\Models\Squad;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Support\Facades\DB;
@@ -32,6 +33,7 @@ try {
     match ($payload['action']) {
         'assign' => resolve(AssignCaptain::class)->handle($actor, $squad, $subject),
         'mark_ex' => resolve(MarkExMember::class)->handle($actor, $squad, $subject),
+        'promote' => resolve(PromoteToSubCaptain::class)->handle($actor, $squad, $subject),
         default => throw new InvalidArgumentException('Unsupported action: '.$payload['action']),
     };
 


### PR DESCRIPTION
Closes #527

Parent: #342

## What changed

- `AssignCaptain` agora usa a linha de `squads` como mutex da cadeira de capitão com `FOR UPDATE`.
- A ordem de locks ficou explícita e consistente: squad primeiro, depois as memberships afetadas.
- O candidato e o capitão atual são lidos sob lock antes das transições e dos eventos.
- `MarkExMember` usa o mesmo mutex antes de autorizar e travar a membership do subject.
- A autorização de `MarkExMember` agora enxerga o papel confirmado mais recente do actor depois de esperar pelo mutex.
- O índice parcial único de capitão continua ativo como defesa em profundidade.
- A implementação não captura `23505`; ela remove a corrida que expunha a `QueryException`.

## Concurrency

Duas atribuições concorrentes na mesma squad passam pela mesma linha de `squads`. A segunda transação espera a primeira confirmar, relê o capitão atual e registra a sequência real de `from_role` e `to_role`.

`AssignCaptain` concorrente com `MarkExMember` segue a mesma ordem de locks. Isso evita a leitura de role desatualizado e também elimina o deadlock entre a linha da membership e o lock exigido pela referência à squad no evento.

Squads diferentes travam linhas diferentes, então continuam independentes.

Os testes usam processos PHP e conexões PostgreSQL separados. Um lock de preparação força a sobreposição real, e `pg_blocking_pids()` confirma que cada worker espera pelo mutex correto sem depender apenas de sleeps.

## Verification

- `vendor/bin/pest --compact --parallel app-modules/squads/tests/Feature/CaptainSeatConcurrencyTest.php`: 4 testes, 30 assertions.
- Testes focados de concorrência, `AssignCaptain`, `MarkExMember` e `SquadMember`: 19 testes, 63 assertions.
- `vendor/bin/pest --compact app-modules/squads/tests`: 65 testes, 162 assertions.
- `make test`: 991 testes, 3125 assertions.
- `make test-pint`: passou.
- `make test-rector`: passou, sem alterações.
- `make phpstan`: passou, sem erros.
- `git diff --check`: passou.