### PR TITLE
feat(activity): cria tabela activity_user_reactions (#541)

### DIFF
--- a/app-modules/activity/database/migrations/2026_09_04_000001_create_activity_user_reactions_table.php
+++ b/app-modules/activity/database/migrations/2026_09_04_000001_create_activity_user_reactions_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('activity_user_reactions', static function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('user_id')->constrained('users');
+            $table->foreignUuid('timeline_id')->constrained('activity_timeline')->cascadeOnDelete();
+            // TODO(#540): trocar pelo comment gerado por TimelineReaction::stringifyCases() quando o enum existir.
+            $table->string('reaction')->comment('like|love|laugh|celebrate|fire|sad');
+            $table->timestampsTz();
+
+            $table->unique(['user_id', 'timeline_id'], 'activity_user_reactions_user_timeline_unique');
+            $table->index(['timeline_id', 'reaction'], 'activity_user_reactions_timeline_reaction_index');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('activity_user_reactions');
+    }
+};


### PR DESCRIPTION
## Contexto

Primeira fatia (S1) do subsistema de **reações por usuário** da timeline web (épico #539), que substitui o ícone estático de reação por um sistema real com 6 reações fixas, exclusivo da web e sem tocar no agregado do Discord.

Esta fatia cria só a fundação de dados: a tabela que guarda **uma reação por usuário por post**. Ela nasce vazia — model, Action e UI vêm nas próximas fatias (S2 em diante), que dependem desta.

### Alterações

- Nova migration `2026_09_04_000001_create_activity_user_reactions_table.php` em `app-modules/activity/database/migrations/`.
- Colunas: `id` (uuid, PK), `user_id` (FK → `users`), `timeline_id` (FK → `activity_timeline`, `cascadeOnDelete`), `reaction` (string), `timestampsTz`.
- `unique(user_id, timeline_id)` nomeado `activity_user_reactions_user_timeline_unique` — no máximo uma reação por usuário por post, garantida no banco.
- `index(timeline_id, reaction)` nomeado `activity_user_reactions_timeline_reaction_index` — suporta o agregado de contagem por reação sem full scan.
- `down()` com `Schema::dropIfExists`.
- **Não** inclui `reactable_type`/`reactable_id` (não é polimórfica — FK direta, decisão do épico) nem `tenant_id` (fora de escopo desta entrega).

**Nota temporária:** o `->comment()` da coluna `reaction` usa uma string literal (`'like|love|laugh|celebrate|fire|sad'`) em vez de `TimelineReaction::stringifyCases()`, porque o enum `TimelineReaction` (S2, #540) ainda não existe. Há um `TODO(#540)` no arquivo. Como esta é uma branch de etapa isolada pode simplesmente editar a migration antes de rodar um migrate, e adicionar a alteração.

---

## Plano de Testes

- [x] Executar `composer check` (rector + pint + phpstan) — verde.
- [x] Aplicar o schema equivalente da migration via `psql` direto contra o Postgres local (container `heartdevs-db`) e confirmar as colunas, FK e índices exatamente como especificado.
- [x] Inserir duas linhas com o mesmo par `(user_id, timeline_id)` — banco rejeita por violação de `unique constraint`.
- [x] Apagar a linha de `activity_timeline` referenciada — a linha de reação correspondente é removida via `ON DELETE CASCADE`.
- [x] `DROP TABLE` (equivalente ao `down()`) — tabela removida sem erro, banco restaurado ao estado original.
- [ ] Rodar `php artisan migrate` / `migrate:rollback` de fato via Artisan.

---

## Evidências

Sem impacto visual — mudança é só de schema de banco.

---

## Issues Relacionadas

Closes #541
Related to #539
