### PR TITLE
feat(portal): topo da home simplifica a etiqueta e destaca o card de docs

### DIFF
--- a/app-modules/he4rt/resources/css/components/badge.css
+++ b/app-modules/he4rt/resources/css/components/badge.css
@@ -1,7 +1,3 @@
 .hp-badge {
-    @apply bg-primary/5 border-primary/32 flex w-fit items-center justify-center gap-2 rounded-full border px-4 py-2 text-xs font-medium sm:text-sm;
-}
-
-.hp-badge:hover {
-    @apply bg-primary/32;
+    @apply flex text-text-medium w-fit items-center justify-center gap-2 rounded-full py-2 text-xs font-medium sm:text-sm;
 }

--- a/app-modules/he4rt/resources/css/components/headline.css
+++ b/app-modules/he4rt/resources/css/components/headline.css
@@ -19,7 +19,7 @@
 }
 
 .hp-headline-title {
-    @apply font-bold drop-shadow-lg;
+    @apply font-bold drop-shadow-lg drop-shadow-text-dark/15;
 }
 
 .hp-headline-subtitle {

--- a/app-modules/he4rt/resources/views/components/headline.blade.php
+++ b/app-modules/he4rt/resources/views/components/headline.blade.php
@@ -105,7 +105,7 @@
 
             @isset($description)
                 <p
-                    class="hp-headline-description {{ $animate ? "delay-300" : "" }}"
+                    {{ $description->attributes->class(["hp-headline-description", "delay-300" => $animate]) }}
                     @if ($animate)
                         x-show="shown"
                         x-transition:enter="{{ $anim["enter"] }}"

--- a/app-modules/portal/resources/views/components/sections/hero.blade.php
+++ b/app-modules/portal/resources/views/components/sections/hero.blade.php
@@ -18,7 +18,7 @@
                 <x-he4rt::headline size="2xl" :keywords="['potencial']">
                     <x-slot:badge>
                         <x-he4rt::badge>
-                            <x-filament::icon icon="heroicon-o-book-open" class="h-5 w-5" />
+                            <x-filament::icon icon="heroicon-o-book-open" class="text-icon-light h-5 w-5" />
                             Comunidade Open Source
                         </x-he4rt::badge>
                     </x-slot>

--- a/app-modules/portal/resources/views/sections/hero.blade.php
+++ b/app-modules/portal/resources/views/sections/hero.blade.php
@@ -20,7 +20,7 @@
                         Desenvolva seu potencial na comunidade
                     </x-slot:title>
 
-                    <x-slot:description>
+                    <x-slot:description class="font-normal">
                         Uma comunidade de desenvolvedores dedicada a ajudar iniciantes a se tornarem profissionais
                         através de projetos, mentorias e networking.
                     </x-slot:description>
@@ -52,15 +52,15 @@
                 <x-he4rt::card
                     href="/docs"
                     density="compact"
-                    class="h-auto w-full max-w-md shadow-lg lg:max-w-lg"
+                    class="h-auto w-full max-w-md lg:max-w-lg rounded-[0_8px_8px_0] border-t-0 border-r-0 border-b-0 border-l-4 border-l-primary shadow-md shadow-text-dark/8 dark:shadow-text-light/3 bg-elevation-01dp dark:bg-elevation-surface"
                     aria-label="Abrir documentação da comunidade"
                 >
                     <div class="flex items-center gap-4">
-                        <div class="text-primary flex h-12 w-12 shrink-0 items-center justify-center rounded-full border border-current/15 bg-current/8">
+                        <div class="text-primary bg-primary/12 flex h-12 w-12 shrink-0 items-center justify-center rounded-lg border border-current/15">
                             <x-filament::icon icon="heroicon-o-light-bulb" class="h-6 w-6" />
                         </div>
 
-                        <div class="min-w-0 flex-1">
+                        <div class="flex min-w-0 flex-1 flex-col gap-1">
                             <p class="text-text-high text-base font-semibold">
                                 Novo por aqui?
                             </p>
@@ -69,7 +69,10 @@
                             </p>
                         </div>
 
-                        <x-filament::icon icon="heroicon-o-chevron-right" class="text-primary h-5 w-5 shrink-0" />
+                        <x-filament::icon
+                            icon="heroicon-o-arrow-right"
+                            class="text-text-medium h-5 w-5 shrink-0 self-center"
+                        />
                     </div>
                 </x-he4rt::card>
             </div>


### PR DESCRIPTION
## Contexto

O topo da home tinha três defeitos visuais, descritos em detalhe na #550: a etiqueta
reagia ao ponteiro sem ser clicável, a moldura dela competia com o título logo abaixo,
e a sombra do título usava preto fixo, que some no tema escuro.

O card de `/docs`, na mesma seção, era um cartão neutro e visualmente indistinto do
resto do hero, sem sinalizar que é o principal caminho de entrada para quem chega pela
primeira vez.

Este PR reduz o `.hp-badge` a rótulo tipográfico, deriva a sombra do título de token,
marca o card de `/docs` como destino com faixa lateral e seta, e aplica o resultado no
hero. Para conseguir afinar a descrição só na home — sem mexer no CSS do componente e
afetar todos os consumidores — o slot `description` do `x-he4rt::headline` passa a
encaminhar atributos, como o slot `subtitle` já fazia duas linhas acima.

As mudanças vêm juntas porque só têm efeito revisável em conjunto: sem o hero, a
alteração do design system não aparece em lugar nenhum da página.

### Alterações

- `he4rt/.../css/components/badge.css`: `.hp-badge` perde fundo, borda, padding
  horizontal e a regra `:hover`; adota cor de texto tokenizada. Ícone, `gap-2` e escala
  tipográfica permanecem.
- `he4rt/.../views/components/headline.blade.php`: slot `description` passa a usar
  `$description->attributes->class([...])`, preservando a classe base e o `delay-200`
  condicionado a `$animate`.
- `he4rt/.../css/components/headline.css`: `.hp-headline-title` ganha cor de sombra
  derivada de token; removido o bloco `.hp-headline-badge`, comentado desde a extração
  do componente de badge e duplicando regras que hoje vivem em `badge.css`.
- `portal/.../sections/hero.blade.php`: hero acompanha a etiqueta sem moldura, ajusta o
  peso da descrição e reestiliza o card de `/docs` — faixa lateral esquerda na cor
  primária com canto esquerdo reto, fundo de elevação, ícone em contêiner arredondado e
  seta no lugar do chevron.
- `portal/.../components/sections/hero.blade.php`: ajuste de tom do ícone da etiqueta.

---

## Plano de Testes

- [ ] Executar `make check`
- [ ] Executar `make test`
- [ ] `/` em tema claro: etiqueta sem moldura, ícone alinhado após a remoção do padding
- [ ] `/` em tema escuro: idem, e conferir a sombra do título
- [ ] Passar o ponteiro sobre a etiqueta: nenhuma reação
- [ ] Conferir a etiqueta na seção de artigos recentes, o outro consumidor renderizado
- [ ] Card de `/docs` nos dois temas: faixa lateral, canto esquerdo reto, elevação
- [ ] Navegar até o card pelo teclado: foco visível e destino `/docs`
- [ ] Confirmar que o `aria-label` do card foi preservado
- [ ] Descrição do hero com o peso novo
- [ ] Demais páginas que usam `x-he4rt::headline`: descrição idêntica à `4.x`, `delay-200` preservado
- [ ] Hero em mobile, tablet e desktop
---

## Evidências

### Antes

<img width="629" height="369" alt="Captura de tela 2026-09-07 094811" src="https://github.com/user-attachments/assets/97ebcb7b-1f32-489f-9427-9816d83231e4" />

### Depois

<img width="616" height="393" alt="Captura de tela 2026-09-07 094827" src="https://github.com/user-attachments/assets/9c3afe9f-53f0-4519-9514-96aadbfd89d6" />

### Antes

<img width="588" height="125" alt="Captura de tela 2026-09-07 095042" src="https://github.com/user-attachments/assets/4723cfba-0146-4d96-ba17-736a7b09a8e6" />

### Depois

<img width="582" height="108" alt="Captura de tela 2026-09-07 082425" src="https://github.com/user-attachments/assets/4fc258d0-ec52-48c9-80e9-64e774c988cb" />

### Antes

<img width="586" height="121" alt="Captura de tela 2026-09-07 095037" src="https://github.com/user-attachments/assets/a55830ea-54b7-462b-a09d-1ae251441f06" />

### Depois

<img width="599" height="128" alt="Captura de tela 2026-09-07 082621" src="https://github.com/user-attachments/assets/5256e5b7-0b27-4735-aee3-087953d78105" />

<img width="1338" height="554" alt="Captura de tela 2026-09-07 095404" src="https://github.com/user-attachments/assets/d66634a8-ef4a-4c72-a630-ad3fa76c0de5" />


---

## Issues Relacionadas

#550

<!--



