### PR TITLE
feat(portal): refinamento visual da pagina de artigos

### DIFF
--- a/app-modules/portal/resources/views/articles.blade.php
+++ b/app-modules/portal/resources/views/articles.blade.php
@@ -15,68 +15,74 @@
 <div x-data="articlesFeed(@js($feedItems))" class="pb-20">
     <x-portal::articles.opening-band :stats="$stats" />
 
-    <div class="hp-page grid gap-7 lg:grid-cols-[minmax(0,1fr)_320px]">
-        <div class="min-w-0">
-            @if ($articles === [])
-                {{-- O catálogo é preenchido pelo sync; até a primeira rodada rodar, a
-                     página diz o que houve em vez de fingir que ninguém escreveu. --}}
-                <div class="border-outline-low bg-elevation-01dp flex flex-col items-center gap-3 rounded-lg border border-dashed p-12 text-center">
-                    <p class="text-text-high text-sm font-semibold">Ainda não há artigos por aqui.</p>
-                    <p class="text-text-medium max-w-sm text-xs">
-                        O acervo da comunidade é publicado no dev.to. Enquanto ele não aparece aqui, vá direto
-                        para a organização.
-                    </p>
-                    <x-he4rt::button href="https://dev.to/he4rt" target="_blank" rel="noopener" size="sm">
-                        Abrir no dev.to
-                    </x-he4rt::button>
-                </div>
-            @else
-            @if ($highlight)
+    <div class="hp-page">
+        @if ($articles !== [] && $highlight)
+            {{-- Mesmas colunas do grid abaixo, só para o destaque herdar a largura
+                 da coluna de artigos em vez de ocupar a página inteira. --}}
+            <div class="grid lg:grid-cols-[minmax(0,1fr)_320px] lg:gap-7">
                 <x-portal::articles.featured :article="$highlight" />
-            @endif
-
-            <x-portal::articles.toolbar :topics="$topics" :total="count($articles)" />
-
-            {{-- A grade é o padrão do servidor; o Alpine só troca para lista. Assim a
-                 página nasce com layout correto mesmo antes (ou sem) o JS. --}}
-            <div
-                class="grid gap-4 [grid-template-columns:repeat(auto-fill,minmax(260px,1fr))]"
-                x-bind:class="view === 'list' ? 'is-list !grid-cols-1' : ''"
-            >
-                @foreach ($articles as $index => $article)
-                    <x-portal::articles.card :article="$article" :index="$index" />
-                @endforeach
-            </div>
-
-            <div
-                x-show="visibleCount === 0"
-                x-cloak
-                style="display: none"
-                class="border-outline-low bg-elevation-01dp mt-4 flex flex-col items-center gap-3 rounded-lg border border-dashed p-10 text-center"
-            >
-                <p class="text-text-high text-sm font-semibold">Nenhum artigo com essa combinação.</p>
-                <p class="text-text-medium max-w-sm text-xs">
-                    O tema e a pessoa selecionados não se cruzam no acervo. As duas listas seguem ativas — dá para
-                    trocar o recorte sem sair daqui.
-                </p>
-                <button
-                    type="button"
-                    x-on:click="clearAll()"
-                    class="from-primary to-secondary text-text-light cursor-pointer rounded-md bg-gradient-to-br px-4 py-2 text-xs font-semibold transition-all duration-300 hover:scale-[1.02] active:scale-95"
-                >
-                    limpar tudo
-                </button>
-            </div>
-            @endif
-        </div>
-
-        {{-- No telefone a coluna de pessoas vai para baixo do feed: empilhar 17 linhas
-             acima dos cards custaria a dobra inteira. --}}
-        @if ($authors !== [])
-            <div class="order-last lg:sticky lg:top-4 lg:order-none lg:self-start">
-                <x-portal::articles.author-rail :authors="$authors" />
             </div>
         @endif
+
+        <div class="grid gap-7 lg:grid-cols-[minmax(0,1fr)_320px]">
+            <div class="min-w-0">
+                @if ($articles === [])
+                    {{-- O catálogo é preenchido pelo sync; até a primeira rodada rodar, a
+                         página diz o que houve em vez de fingir que ninguém escreveu. --}}
+                    <div class="border-outline-low bg-elevation-01dp flex flex-col items-center gap-3 rounded-lg border border-dashed p-12 text-center">
+                        <p class="text-text-high text-sm font-semibold">Ainda não há artigos por aqui.</p>
+                        <p class="text-text-medium max-w-sm text-xs">
+                            O acervo da comunidade é publicado no dev.to. Enquanto ele não aparece aqui, vá direto
+                            para a organização.
+                        </p>
+                        <x-he4rt::button href="https://dev.to/he4rt" target="_blank" rel="noopener" size="sm">
+                            Abrir no dev.to
+                        </x-he4rt::button>
+                    </div>
+                @else
+                <x-portal::articles.toolbar :topics="$topics" :total="count($articles)" />
+
+                {{-- A grade é o padrão do servidor; o Alpine só troca para lista. Assim a
+                     página nasce com layout correto mesmo antes (ou sem) o JS. --}}
+                <div
+                    class="grid gap-4 [grid-template-columns:repeat(auto-fill,minmax(260px,1fr))]"
+                    x-bind:class="view === 'list' ? 'is-list !grid-cols-1' : ''"
+                >
+                    @foreach ($articles as $index => $article)
+                        <x-portal::articles.card :article="$article" :index="$index" />
+                    @endforeach
+                </div>
+
+                <div
+                    x-show="visibleCount === 0"
+                    x-cloak
+                    style="display: none"
+                    class="border-outline-low bg-elevation-01dp mt-4 flex flex-col items-center gap-3 rounded-lg border border-dashed p-10 text-center"
+                >
+                    <p class="text-text-high text-sm font-semibold">Nenhum artigo com essa combinação.</p>
+                    <p class="text-text-medium max-w-sm text-xs">
+                        O tema e a pessoa selecionados não se cruzam no acervo. As duas listas seguem ativas — dá para
+                        trocar o recorte sem sair daqui.
+                    </p>
+                    <button
+                        type="button"
+                        x-on:click="clearAll()"
+                        class="from-primary to-secondary text-text-light cursor-pointer rounded-md bg-gradient-to-br px-4 py-2 text-xs font-semibold transition-all duration-300 hover:scale-[1.02] active:scale-95"
+                    >
+                        limpar tudo
+                    </button>
+                </div>
+                @endif
+            </div>
+
+            {{-- No telefone a coluna de pessoas vai para baixo do feed: empilhar 17 linhas
+                 acima dos cards custaria a dobra inteira. --}}
+            @if ($authors !== [])
+                <div class="order-last lg:sticky lg:top-4 lg:order-0 lg:mt-8 lg:self-start">
+                    <x-portal::articles.author-rail :authors="$authors" />
+                </div>
+            @endif
+        </div>
     </div>
 
     {{-- Componente class-based: o Livewire 4 exige @assets/@script para JS de componente.

--- a/app-modules/portal/resources/views/components/articles/author-rail.blade.php
+++ b/app-modules/portal/resources/views/components/articles/author-rail.blade.php
@@ -10,12 +10,9 @@
 @endphp
 
 <aside class="flex flex-col gap-3" aria-labelledby="articles-authors-heading">
-    <div class="flex items-baseline justify-between gap-2">
-        <h2 id="articles-authors-heading" class="text-text-medium font-mono text-xs tracking-[0.2em] uppercase">
-            Quem escreve
-        </h2>
-        <span class="text-text-low font-mono text-[0.65rem]">artigos · reações</span>
-    </div>
+    <h2 id="articles-authors-heading" class="text-text-medium font-mono text-xs tracking-[0.2em] uppercase">
+        Quem escreve
+    </h2>
 
     {{-- Volume e alcance divergem no acervo: quem publicou uma vez pode ter mais
          reações que quem publicou quatro. Por isso as duas ordens são oferecidas. --}}
@@ -35,29 +32,41 @@
         @endforeach
     </div>
 
-    <ul class="flex flex-col">
-        @foreach ($authors as $author)
-            <li x-bind:style="{ order: authorSort === 'reactions' ? {{ $reactionRank[$author->username] }} : {{ $loop->index }} }">
-                <button
-                    type="button"
-                    x-on:click="toggleAuthor(@js($author->username))"
-                    x-bind:aria-pressed="author === @js($author->username) ? 'true' : 'false'"
-                    x-bind:class="{ 'bg-primary/16': author === @js($author->username) }"
-                    class="hover:bg-primary/10 text-text-high flex w-full cursor-pointer items-center gap-2.5 rounded-md px-2 py-1.5 text-start transition-colors duration-200"
-                >
-                    <x-portal::articles.author-avatar :name="$author->name" :avatar="$author->avatar" size="size-7" />
-                    <span class="min-w-0 flex-1 truncate text-xs font-medium">{{ $author->name }}</span>
-                    <span class="text-text-medium shrink-0 font-mono text-xs tabular-nums">
-                        {{ $author->articleCount }}
-                        <span class="text-text-low mx-0.5" aria-hidden="true">·</span>
-                        {{ $author->reactions }}
-                    </span>
-                </button>
-            </li>
-        @endforeach
-    </ul>
+    <div class="text-text-low mt-2 flex items-center justify-end gap-2 pe-2 font-medium text-[0.7rem]">
+        <span class="flex w-14 items-center justify-end gap-1">
+            <x-heroicon-o-document-text class="size-3" />
+            artigos
+        </span>
+        <span class="flex w-14 items-center justify-end gap-1">
+            <x-heroicon-o-heart class="text-primary dark:text-purple-400 size-3" />
+            reações
+        </span>
+    </div>
 
-    <p class="text-text-low border-outline-low border-t pt-3 font-mono text-[0.65rem]">
-        {{ count($authors) }} pessoas no acervo
-    </p>
+    <div class="bg-elevation-02dp flex flex-col gap-2 rounded-lg p-3">
+        <ul class="flex flex-col">
+            @foreach ($authors as $author)
+                <li x-bind:style="{ order: authorSort === 'reactions' ? {{ $reactionRank[$author->username] }} : {{ $loop->index }} }">
+                    <button
+                        type="button"
+                        x-on:click="toggleAuthor(@js($author->username))"
+                        x-bind:aria-pressed="author === @js($author->username) ? 'true' : 'false'"
+                        x-bind:class="{ 'bg-primary/16': author === @js($author->username) }"
+                        class="hover:bg-primary/10 text-text-high flex w-full cursor-pointer items-center gap-2.5 rounded-md px-2 py-1.5 text-start transition-colors duration-200"
+                    >
+                        <x-portal::articles.author-avatar :name="$author->name" :avatar="$author->avatar" size="size-7" />
+                        <span class="min-w-0 flex-1 truncate text-xs font-medium">{{ $author->name }}</span>
+                        <span class="flex shrink-0 items-center gap-0.5 font-mono font-medium text-xs tabular-nums">
+                            <span class="text-text-low w-14 text-end">{{ $author->articleCount }}</span>
+                            <span class="text-primary dark:text-purple-400 w-14 text-end">{{ $author->reactions }}</span>
+                        </span>
+                    </button>
+                </li>
+            @endforeach
+        </ul>
+
+        <p class="text-text-low border-outline-low border-t pt-3 font-mono text-[0.65rem]">
+            {{ count($authors) }} pessoas no acervo
+        </p>
+    </div>
 </aside>

--- a/app-modules/portal/resources/views/components/articles/card.blade.php
+++ b/app-modules/portal/resources/views/components/articles/card.blade.php
@@ -5,34 +5,24 @@
 
 <article
     x-show="isVisible({{ $index }})"
-    class="border-outline-low bg-elevation-01dp hover:border-primary relative flex flex-col gap-3 rounded-lg border p-4 transition-[border-color,transform] duration-300 hover:scale-[1.02] motion-reduce:transition-none motion-reduce:hover:scale-100 [.is-list_&]:flex-row [.is-list_&]:items-start [.is-list_&]:gap-4 [.is-list_&]:hover:scale-100"
+    class="bg-elevation-02dp border-primary/16 has-[a:focus-visible]:ring-primary relative flex flex-col overflow-hidden rounded-l-none rounded-r-lg border-l-2 shadow-sm shadow-text-high/8 transition-[background-color,box-shadow,transform] duration-200 ease-out hover:-translate-y-0.75 hover:bg-elevation-03dp hover:shadow-md has-[a:focus-visible]:ring-2 motion-reduce:transition-none motion-reduce:hover:translate-y-0 [.is-list_&]:flex-row"
 >
-    @if ($article->coverImage)
-        <img
-            src="{{ $article->coverImage }}"
-            alt=""
-            loading="lazy"
-            decoding="async"
-            class="aspect-video w-full shrink-0 rounded-sm object-cover [.is-list_&]:w-28"
-        />
-    @else
-        <x-portal::articles.cover-fallback class="aspect-video w-full shrink-0 rounded-sm [.is-list_&]:w-28" />
-    @endif
-
-    <div class="flex min-w-0 flex-1 flex-col gap-2">
-        @if ($article->tags !== [])
-            <ul class="flex flex-wrap gap-1.5">
-                @foreach (array_slice($article->tags, 0, 2) as $tag)
-                    <li
-                        class="border-primary/32 bg-primary/5 text-text-medium rounded-lg border px-2 py-0.5 font-mono text-[0.65rem]"
-                    >
-                        #{{ $tag }}
-                    </li>
-                @endforeach
-            </ul>
+    <div class="shrink-0 [.is-list_&]:w-40 sm:[.is-list_&]:w-56">
+        @if ($article->coverImage)
+            <img
+                src="{{ $article->coverImage }}"
+                alt=""
+                loading="lazy"
+                decoding="async"
+                class="aspect-video w-full object-cover [.is-list_&]:aspect-auto [.is-list_&]:h-full"
+            />
+        @else
+            <x-portal::articles.cover-fallback class="aspect-video w-full [.is-list_&]:aspect-auto [.is-list_&]:h-full" />
         @endif
+    </div>
 
-        <h3 class="text-text-high line-clamp-3 text-sm leading-snug font-semibold">
+    <div class="flex min-w-0 flex-1 flex-col px-4 pt-3.5 pb-4">
+        <h3 class="text-text-high line-clamp-3 text-sm leading-snug font-medium">
             <a
                 href="{{ $article->url }}"
                 target="_blank"
@@ -44,17 +34,38 @@
         </h3>
 
         {{-- A descrição já vem truncada da fonte; o clamp evita que o "…" dela pareça quebra de layout. --}}
-        <p class="text-text-medium line-clamp-2 text-xs leading-relaxed">{{ $article->description }}</p>
+        <p class="text-text-medium mt-1 line-clamp-2 text-xs leading-relaxed">{{ $article->description }}</p>
 
-        <div class="text-text-medium mt-auto flex flex-wrap items-center gap-x-3 gap-y-1 pt-1 text-[0.7rem]">
-            <span class="flex min-w-0 items-center gap-1.5">
-                <x-portal::articles.author-avatar :name="$article->authorName" :avatar="$article->authorAvatar" size="size-4" />
-                <span class="text-text-high truncate font-medium">{{ $article->authorName }}</span>
-            </span>
-            <span class="ms-auto flex items-center gap-2.5 font-mono tabular-nums">
-                <span title="reações">♥ {{ $article->reactions }}</span>
-                <span title="comentários">💬 {{ $article->comments }}</span>
-                <span title="tempo de leitura">{{ $article->readingMinutes }} min</span>
+        @if ($article->tags !== [])
+            <ul class="mt-2.5 flex flex-wrap gap-1.5">
+                @foreach (array_slice($article->tags, 0, 2) as $tag)
+                    <li
+                        class="bg-text-high/6 text-text-medium rounded-md px-2 py-1 font-mono text-[0.75rem] leading-none"
+                    >
+                        #{{ $tag }}
+                    </li>
+                @endforeach
+            </ul>
+        @endif
+
+        {{-- O pt-4 garante respiro claro entre as tags e o rodapé; o mt-auto alinha o rodapé entre cards de alturas diferentes. --}}
+        <div class="mt-auto flex items-center gap-2 pt-4 text-[0.7rem] font-medium">
+            <x-portal::articles.author-avatar :name="$article->authorName" :avatar="$article->authorAvatar" size="size-4" />
+            <span class="text-text-medium truncate font-medium">{{ $article->authorName }}</span>
+
+            <span class="text-text-medium ms-auto flex shrink-0 items-center gap-2.5 font-mono tabular-nums">
+                <span title="reações" class="flex items-center gap-1">
+                    <x-heroicon-o-heart class="text-icon-medium size-3.5" />
+                    {{ $article->reactions }}
+                </span>
+                <span title="comentários" class="flex items-center gap-1">
+                    <x-heroicon-o-chat-bubble-left-ellipsis class="text-icon-medium size-3.5" />
+                    {{ $article->comments }}
+                </span>
+                <span title="tempo de leitura" class="flex items-center gap-1">
+                    <x-heroicon-o-clock class="text-icon-medium size-3.5" />
+                    {{ $article->readingMinutes }} min
+                </span>
             </span>
         </div>
     </div>

--- a/app-modules/portal/resources/views/components/articles/featured.blade.php
+++ b/app-modules/portal/resources/views/components/articles/featured.blade.php
@@ -3,7 +3,7 @@
 {{-- Acima da grade e na largura dela: o destaque abre a listagem em vez de
      disputar a primeira dobra com o título da página. --}}
 <article
-    class="border-outline-low bg-elevation-01dp hover:border-primary relative mb-6 flex flex-col gap-5 rounded-lg border p-4 transition-colors duration-300 sm:flex-row sm:items-center"
+    class="bg-elevation-01dp shadow-sm shadow-text-high/8 hover:bg-elevation-02dp hover:shadow-md relative mb-6 flex flex-col gap-5 rounded-lg p-4 transition-[background-color,box-shadow,transform] duration-300 hover:scale-[1.02] motion-reduce:transition-none motion-reduce:hover:scale-100 sm:flex-row sm:items-center"
 >
     @if ($article->coverImage)
         <img
@@ -19,9 +19,9 @@
 
     <div class="flex min-w-0 flex-col gap-2.5">
         <span
-            class="border-primary/32 bg-primary/5 text-text-high w-fit rounded-full border px-3 py-1 font-mono text-[0.65rem] tracking-wide"
+            class="bg-primary/5 text-text-medium w-fit rounded-full px-3 py-1 font-mono text-[0.65rem] tracking-wide"
         >
-            ★ destaque · mais reagido dos últimos 12 meses
+            <span class="text-primary">★</span> destaque · mais reagido dos últimos 12 meses
         </span>
 
         <h2 class="text-text-high line-clamp-2 text-xl leading-snug font-semibold lg:text-2xl">
@@ -39,14 +39,25 @@
             <p class="text-text-medium line-clamp-2 max-w-2xl text-sm leading-relaxed">{{ $article->description }}</p>
         @endif
 
-        <div class="text-text-medium flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
-            <span class="flex items-center gap-2">
+        <div class="mt-auto flex flex-wrap items-center gap-x-3 gap-y-1 rounded-lg px-4 py-3 text-[0.7rem] font-medium">
+            <span class="flex min-w-0 items-center gap-1.5">
                 <x-portal::articles.author-avatar :name="$article->authorName" :avatar="$article->authorAvatar" size="size-5" />
-                <span class="text-text-high font-medium">{{ $article->authorName }}</span>
+                <span class="text-text-medium truncate font-medium">{{ $article->authorName }}</span>
             </span>
-            <span class="font-mono tabular-nums">♥ {{ $article->reactions }}</span>
-            <span class="font-mono tabular-nums">{{ $article->readingMinutes }} min</span>
-            <span class="font-mono">{{ $article->publishedLabel() }}</span>
+            <span class="text-text-medium ms-auto flex items-center gap-2.5 font-mono tabular-nums">
+                <span title="reações" class="flex items-center gap-1">
+                    <x-heroicon-o-heart class="text-icon-medium size-3.5" />
+                    {{ $article->reactions }}
+                </span>
+                <span title="tempo de leitura" class="flex items-center gap-1">
+                    <x-heroicon-o-clock class="text-icon-medium size-3.5" />
+                    {{ $article->readingMinutes }} min
+                </span>
+                <span title="publicado em" class="flex items-center gap-1">
+                    <x-heroicon-o-calendar class="text-icon-medium size-3.5" />
+                    {{ $article->publishedLabel() }}
+                </span>
+            </span>
         </div>
     </div>
 </article>

--- a/app-modules/portal/resources/views/components/articles/toolbar.blade.php
+++ b/app-modules/portal/resources/views/components/articles/toolbar.blade.php
@@ -6,13 +6,13 @@
 {{-- Barra de controle do acervo. Fica sticky dentro da coluna de artigos: como o
      containing block de um grid item é a própria área da grid, promovê-la a filha
      direta do grid faria o sticky morrer em silêncio. --}}
-<div class="bg-elevation-surface/93 border-outline-low sticky top-0 z-30 -mx-1 mb-4 border-b px-1 pt-2 pb-3 backdrop-blur-xl">
+<div class="bg-elevation-surface/93 sticky top-0 z-30 -mx-1 mt-10 mb-4 px-1 pt-2 pb-3 backdrop-blur-xl">
     <div class="flex flex-wrap items-center gap-x-3 gap-y-2">
         <h2 class="text-text-medium font-mono text-xs tracking-[0.2em] uppercase">Artigos</h2>
 
         <x-portal::articles.topics-panel :topics="$topics" :total="$total" />
 
-        <span class="text-text-low font-mono text-xs">↓ mais recentes</span>
+        <span class="text-text-medium font-mono text-xs">↓ mais recentes</span>
 
         <p class="text-text-medium ms-auto font-mono text-xs tabular-nums" aria-live="polite">
             <span class="text-text-high font-semibold" x-text="visibleCount">{{ $total }}</span>
@@ -39,7 +39,7 @@
     </div>
 
     {{-- Segunda linha: só existe quando há recorte ativo. --}}
-    <div class="mt-2 flex flex-wrap items-center gap-2" x-show="hasFilters" x-cloak style="display: none">
+    <div class="mt-4 flex flex-wrap items-center gap-2" x-show="hasFilters" x-cloak style="display: none">
         <template x-if="author">
             <button
                 type="button"

--- a/app-modules/portal/resources/views/components/articles/topics-panel.blade.php
+++ b/app-modules/portal/resources/views/components/articles/topics-panel.blade.php
@@ -32,7 +32,7 @@
              e apaga o `display: none` que o x-show escreve, deixando o painel aberto
              no load. Com objeto o Alpine escreve só a propriedade ligada. --}}
         x-bind:style="{ maxHeight: topicsMaxHeight + 'px' }"
-        class="border-outline-low bg-elevation-02dp absolute start-0 top-full z-50 mt-2 w-[min(22rem,calc(100vw-3rem))] overflow-y-auto overscroll-contain rounded-lg border p-2 shadow-lg shadow-black/20"
+        class="border-outline-low bg-elevation-05dp absolute inset-s-0 top-full z-50 mt-2 w-[min(22rem,calc(100vw-3rem))] overflow-y-auto overscroll-contain rounded-lg border p-2 shadow-lg shadow-text-high/18"
         style="scrollbar-width: thin"
     >
         <p class="text-text-medium px-2 pt-1 pb-2 font-mono text-[0.65rem] tracking-[0.15em] uppercase">


### PR DESCRIPTION
## Contexto

A listagem de `/artigos` tinha quatro problemas visuais, detalhados na issue #552: borda
uniforme em todos os cartões sem hierarquia entre eles, números da coluna de autores
ilegíveis sem procurar a legenda, emoji nas métricas e um menu de temas que se
confundia com o conteúdo atrás.

Este PR troca borda por elevação como linguagem de profundidade, sangra a capa até a
margem do cartão, move as tags para baixo da descrição, alinha os números da coluna de
autores em colunas rotuladas e sobe o menu de temas na escala de elevação. Os emojis
das métricas viram heroicons, que herdam cor de token e têm a mesma forma em qualquer
sistema.

O destaque também sai de dentro da coluna da esquerda e passa a nascer de um grid com
as mesmas colunas da listagem, deixando a hieraquia e a pagina mais limpa.

Nada muda no comportamento: `articlesFeed` (Alpine), filtros, ordenação, estados vazios
e o DTO `Article` seguem intactos.

### Alterações

- `articles.blade.php`: destaque extraído para um wrapper com as mesmas colunas do grid
  principal, renderizado só quando há artigos e destaque; coluna de autores com offset
  superior para alinhar com a barra de controle.
- `articles/card.blade.php` e `articles/featured.blade.php`: borda dá lugar a elevação,
  com o hover subindo o nível em vez de escalar o cartão; capa sangrada, sem raio nem
  padding próprios; faixa lateral esquerda; tags abaixo da descrição; métricas com
  heroicons; anel de foco no cartão via `has-[a:focus-visible]`. O destaque passa
  também a exibir a data de publicação.
- `articles/author-rail.blade.php`: legenda sai do canto superior direito e vai para
  cima das colunas que rotula, com ícone; artigos e reações ganham colunas de largura
  fixa; a lista recebe um painel de elevação em volta.
- `articles/toolbar.blade.php`: sai a borda inferior, entra margem no topo para
  acomodar o destaque na linha própria; rótulo de ordenação sobe de contraste e a
  segunda linha se afasta mais da primeira.
- `articles/topics-panel.blade.php`: painel sobe para o topo da escala de elevação e
  troca a sombra preta literal por token.

---

## Plano de Testes

- [ ] Executar `make check`
- [ ] Executar `make test`
- [ ] `/artigos` em tema claro e em tema escuro
- [ ] Largura do destaque contra a coluna de artigos em ≥1024px
- [ ] Alternar entre grade e lista, conferindo a capa nas duas orientações
- [ ] Cartão com capa e cartão sem capa (`cover-fallback`)
- [ ] Cartão com tags e cartão sem tags
- [ ] Navegar por teclado até o link de um cartão e confirmar o anel de foco
- [ ] Abrir o menu de temas perto da borda direita: ancorado ao gatilho, sem vazar da viewport
- [ ] Alternar a ordenação da coluna de autores entre artigos e reações
- [ ] Estado sem artigos: destaque não renderiza e a mensagem aparece
- [ ] Estado sem autores: coluna lateral não renderiza
- [ ] Filtrar por tema e por pessoa até zerar: mensagem de combinação vazia e botão "limpar tudo"
- [ ] Com `prefers-reduced-motion` ativo, o hover não desloca o cartão
- [ ] Barra de controle sticky ao rolar a listagem
- [ ] Empilhamento em mobile: destaque, listagem, coluna de autores por último

---

## Evidências

### Antes

<img width="1343" height="668" alt="Captura de tela 2026-09-07 111607" src="https://github.com/user-attachments/assets/178dc5c4-c111-4c52-bafa-aad3a3bed55f" />

### Depois

<img width="1365" height="680" alt="Captura de tela 2026-09-07 111630" src="https://github.com/user-attachments/assets/e432642a-422e-4288-9a13-6c680549ade0" />

### Antes

<img width="1362" height="668" alt="Captura de tela 2026-09-07 111705" src="https://github.com/user-attachments/assets/ac8c721e-7212-4645-bb8c-f5fff93664e4" />

### Depois

<img width="1365" height="671" alt="Captura de tela 2026-09-07 111652" src="https://github.com/user-attachments/assets/c60e429f-9a2f-423b-833e-7e8ef440fba5" />

### Antes

<img width="976" height="377" alt="Captura de tela 2026-09-07 112425" src="https://github.com/user-attachments/assets/353c0f9f-6bfa-488e-9d4b-8cc168bb39e8" />

### Depois

<img width="966" height="357" alt="Captura de tela 2026-09-07 112437" src="https://github.com/user-attachments/assets/12d592ff-7612-4c79-a010-36087de6411a" />

### Antes
<img width="354" height="422" alt="Captura de tela 2026-09-01 221626" src="https://github.com/user-attachments/assets/c86851ba-a0e9-401a-8653-6a0eb3235746" />

### Depois
<img width="356" height="534" alt="Captura de tela 2026-09-07 112734" src="https://github.com/user-attachments/assets/8827509e-6688-4c32-b7b6-a2f991cfc789" />





---

## Issues Relacionadas

#552 