### PR TITLE
feat(events): galeria de fotos dos encontros da comunidade

### DIFF
--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -15,7 +15,7 @@ This is a modular monorepo (`internachi/modular`). Each bounded context lives un
 | Bot Discord         | `app-modules/bot-discord/`         | Discord bot runtime (Laracord websocket, slash commands, event handlers)                                                   |
 | Integration Discord | `app-modules/integration-discord/` | Discord platform transport (REST API via Saloon), OAuth, ETL                                                               |
 | Identity            | `app-modules/identity/`            | Users, tenants, external identities, authentication                                                                        |
-| Events              | `app-modules/events/`              | Event participation lifecycle — enrollment, check-in, attendance, XP dispatch                                              |
+| Events              | `app-modules/events/`              | Event participation lifecycle — enrollment, check-in, attendance, XP dispatch; community photo gallery (albums)           |
 | Gamification        | `app-modules/gamification/`        | Character progression — XP, levels, badges, seasons, daily bonuses                                                         |
 | Panel Admin         | `app-modules/panel-admin/`         | Filament admin panel — dashboards, resources, moderation UI, marketing                                                     |
 | Integration Twitch  | `app-modules/integration-twitch/`  | Twitch platform transport (Helix API via Saloon), OAuth, EventSub webhooks                                                 |
@@ -70,6 +70,7 @@ This is a modular monorepo (`internachi/modular`). Each bounded context lives un
 - **Integration GitHub** depends on Identity (OAuth user resolution; future `Character` seam via `ExternalIdentity`). It never imports from Activity, Economy, Moderation or any Bot/runtime module — it only emits the `GithubContributionRecorded` domain event. The community presentation (in `portal`) and the allowlist admin UI (in `panel-admin`) depend on it, never the reverse.
 - **Identity** has no upstream dependencies on other contexts listed here.
 - **Events** depends on Identity (reads Users and Tenants). Publishes domain events consumed by Gamification.
+- **Events (Gallery)** owns photo albums and their media. It renders no UI and registers no route: `portal` owns the public `/galeria` edge and `panel-admin` owns the album CRUD and photo curation — both depend on `events`, never the reverse.
 - **Gamification** depends on Identity (Character belongs to User). Listens to Events domain events for XP.
 - **Onboarding** depends on Identity (User, tenant scoping, GitHub `ExternalIdentity` link) and listens to `integration-github`'s `GithubPullRequestApproved` domain event (reads the `challenge` repos in the allowlist). It never imports from `squads` — `squads` is a consumer of its completion gate, never the reverse.
 - **Squads** depends on Onboarding (reads the `Squads`-completion gate, "APTO") and Identity (users/tenants). It never imports from presentation; the panels depend on it.

--- a/app-modules/events/CONTEXT.md
+++ b/app-modules/events/CONTEXT.md
@@ -4,6 +4,8 @@
 
 Manages event participation lifecycle: enrollment, check-in, attendance tracking, and XP reward dispatching. Covers in-person meetups, workshops, and multi-day conferences.
 
+Also owns the community **Gallery** (sub-domain `Gallery/`): photo albums from past gatherings, published on the portal at `/galeria`.
+
 ## Glossary
 
 | Term                       | Definition                                                                                                                                                                                                                  | Not to be confused with                                                                                 |
@@ -20,6 +22,9 @@ Manages event participation lifecycle: enrollment, check-in, attendance tracking
 | **Transition**             | An auditable state change on an enrollment. Every transition is recorded with actor, timestamp, and reason. Written by application code (Actions), never by database triggers.                                              |                                                                                                         |
 | **No-show**                | Terminal state for a participant who confirmed but never checked in. Assigned automatically by a scheduled job after the event ends. No systemic consequences in MVP (future: may affect eligibility).                      |                                                                                                         |
 | **Application**            | An enrollment method where the participant submits a dynamic form (JSONB schema defined in policy) and waits for organizer approval. Results in `pending → confirmed` or `pending → rejected`.                              | "Submission" (CFP) — application is for participation, submission is for presenting (out of MVP scope). |
+| **Album**                  | A curated set of photos from one gathering. Has a slug, title, date (`happened_at`), optional location/description and an optional link to an Event. Exists in `draft` until `published_at` is set. Public only when published **and** it has at least one photo.                | "Event" — an album may exist for a gathering that was never an Event record (pub, confraternização). |
+| **Photo**                  | One media item in an album's `photos` collection (Spatie Media Library). Ordered by `order_column`; carries `caption` and `highlight` as custom properties. Conversions: `thumb` (640×480 crop) and `large` (max 1920).                                                            | "Media" — the storage row; Photo is the domain reading of it.                                          |
+| **Highlight**              | A photo flagged by the organizer to represent the album on the gallery listing. When none is flagged, the first three photos by order stand in.                                                                                                                                 | "Cover" — the single first highlight, used for `og:image`.                                              |
 
 ## State Machine — Enrollment
 
@@ -60,6 +65,7 @@ checked_in
 - **Events → Gamification**: Events dispatches domain events (`EnrollmentConfirmed`, `ParticipantCheckedIn`, `ParticipantAttended`). Gamification listens and awards XP. Events does not know how XP works.
 - **Bot Discord → Events**: Bot dispatches domain events (e.g., `CheckInRequested`). Events module listens and processes. Bot is transport, Events owns the rules.
 - **Events → Identity**: Events reads User and Tenant models. No writes to Identity.
+- **Portal / Panel Admin → Events (Gallery)**: `portal` renders `/galeria` from `Album` read models; `panel-admin` owns the album CRUD and photo curation. Events registers no route and renders no UI for the gallery.
 
 ## Out of Scope (MVP)
 
@@ -72,3 +78,5 @@ checked_in
 - Agenda / schedule display
 - Paid events / payment integration
 - No-show penalties
+- Home photo carousel (issue #504, phase 2) — the gallery lives only at `/galeria`
+- Photos linked to a specific enrollment or participant

--- a/app-modules/events/database/factories/AlbumFactory.php
+++ b/app-modules/events/database/factories/AlbumFactory.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Events\Database\Factories;
+
+use He4rt\Events\Event\Models\Event;
+use He4rt\Events\Gallery\Models\Album;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Str;
+
+/** @extends Factory<Album> */
+final class AlbumFactory extends Factory
+{
+    protected $model = Album::class;
+
+    public function definition(): array
+    {
+        $title = mb_rtrim(fake()->unique()->sentence(3), '.');
+
+        return [
+            'event_id' => null,
+            'slug' => Str::slug($title),
+            'title' => Str::title($title),
+            'location' => fake()->optional()->city(),
+            'happened_at' => fake()->dateTimeBetween('-2 years', 'now'),
+            'description' => fake()->optional()->sentence(),
+            'published_at' => null,
+        ];
+    }
+
+    public function published(): static
+    {
+        return $this->state(fn (): array => [
+            'published_at' => now()->subMinute(),
+        ]);
+    }
+
+    public function forEvent(Event $event): static
+    {
+        return $this->state(fn (): array => [
+            'event_id' => $event->id,
+        ]);
+    }
+
+    /**
+     * Exige Storage::fake('public') no teste: as fotos vão para o disco da
+     * collection.
+     */
+    public function withPhotos(int $count = 3): static
+    {
+        return $this->afterCreating(static function (Album $album) use ($count): void {
+            foreach (range(1, $count) as $index) {
+                $album
+                    ->addMedia(UploadedFile::fake()->image("foto-{$index}.jpg", 1_600, 1_200))
+                    ->toMediaCollection(Album::PHOTOS);
+            }
+        });
+    }
+}

--- a/app-modules/events/database/factories/AlbumFactory.php
+++ b/app-modules/events/database/factories/AlbumFactory.php
@@ -37,6 +37,13 @@ final class AlbumFactory extends Factory
         ]);
     }
 
+    public function scheduled(): static
+    {
+        return $this->state(fn (): array => [
+            'published_at' => now()->addDay(),
+        ]);
+    }
+
     public function forEvent(Event $event): static
     {
         return $this->state(fn (): array => [
@@ -51,7 +58,7 @@ final class AlbumFactory extends Factory
     public function withPhotos(int $count = 3): static
     {
         return $this->afterCreating(static function (Album $album) use ($count): void {
-            foreach (range(1, $count) as $index) {
+            for ($index = 1; $index <= $count; $index++) {
                 $album
                     ->addMedia(UploadedFile::fake()->image("foto-{$index}.jpg", 1_600, 1_200))
                     ->toMediaCollection(Album::PHOTOS);

--- a/app-modules/events/database/migrations/2026_09_07_230256_create_events_albums_table.php
+++ b/app-modules/events/database/migrations/2026_09_07_230256_create_events_albums_table.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('events_albums', static function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('event_id')->nullable()->constrained('events')->nullOnDelete();
+            $table->string('slug', 120);
+            $table->string('title', 200);
+            $table->string('location')->nullable();
+            $table->date('happened_at');
+            $table->text('description')->nullable();
+            $table->timestampTz('published_at')->nullable();
+            $table->timestampsTz();
+
+            $table->unique('slug', 'idx_events_albums_slug');
+            $table->index(['published_at', 'happened_at'], 'idx_events_albums_public_order');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('events_albums');
+    }
+};

--- a/app-modules/events/docs/adr/0009-galeria-como-subdominio-de-events.md
+++ b/app-modules/events/docs/adr/0009-galeria-como-subdominio-de-events.md
@@ -1,12 +1,12 @@
 ---
 type: adr
-title: "Galeria de fotos como sub-domínio de Events"
+title: 'Galeria de fotos como sub-domínio de Events'
 module: events
 status: accepted
 date: 2026-09-07
 author: danielhe4rt
 related:
-  plan: events/2026-09-07-galeria-de-fotos
+    plan: events/2026-09-07-galeria-de-fotos
 ---
 
 # 0009 — Galeria de fotos como sub-domínio de Events
@@ -28,8 +28,8 @@ domínio: um módulo novo, o `portal` (que só renderiza) ou o `events`.
 - As fotos são a coleção `photos` do Spatie Media Library no próprio `Album`.
   Legenda e destaque são `custom_properties` da media, lidos pelo DTO `Photo`.
   Não existe tabela `events_photos`.
-- Um álbum só é público quando `published_at` está no passado **e** tem ao
-  menos uma foto. Rascunho e álbum vazio respondem 404 no portal.
+- Um álbum só é público quando `published_at` não está no futuro (o instante
+  atual conta) **e** tem ao menos uma foto. Rascunho e álbum vazio respondem 404 no portal.
 - Events não registra rota nem UI. O `portal` é dono da borda pública
   (`/galeria`, `/galeria/{slug}`) e o `panel-admin` do CRUD e da curadoria,
   no mesmo desenho do ADR-0004 de `marketing`.

--- a/app-modules/events/docs/adr/0009-galeria-como-subdominio-de-events.md
+++ b/app-modules/events/docs/adr/0009-galeria-como-subdominio-de-events.md
@@ -1,0 +1,56 @@
+---
+type: adr
+title: "Galeria de fotos como sub-domínio de Events"
+module: events
+status: accepted
+date: 2026-09-07
+author: danielhe4rt
+related:
+  plan: events/2026-09-07-galeria-de-fotos
+---
+
+# 0009 — Galeria de fotos como sub-domínio de Events
+
+## Contexto
+
+A issue #504 pede uma galeria pública com fotos dos encontros da comunidade.
+As fotos nascem em eventos, mas nem todo encontro fotografado vira um registro
+de `Event` (pub, confraternização, visita). Havia três lugares possíveis para o
+domínio: um módulo novo, o `portal` (que só renderiza) ou o `events`.
+
+## Decisão
+
+- A galeria vive em `app-modules/events/src/Gallery/`, como sub-domínio de
+  Events, seguindo a estratégia de agrupamento por sub-domínio já usada em
+  `identity` e `moderation`.
+- `Album` é entidade própria, com `event_id` **opcional** (`nullOnDelete`).
+  Apagar o evento não apaga o álbum.
+- As fotos são a coleção `photos` do Spatie Media Library no próprio `Album`.
+  Legenda e destaque são `custom_properties` da media, lidos pelo DTO `Photo`.
+  Não existe tabela `events_photos`.
+- Um álbum só é público quando `published_at` está no passado **e** tem ao
+  menos uma foto. Rascunho e álbum vazio respondem 404 no portal.
+- Events não registra rota nem UI. O `portal` é dono da borda pública
+  (`/galeria`, `/galeria/{slug}`) e o `panel-admin` do CRUD e da curadoria,
+  no mesmo desenho do ADR-0004 de `marketing`.
+
+## Consequências
+
+- **Positivas**: reaproveita o media library já configurado (disco `public`,
+  conversões em fila), zero tabela nova além de `events_albums`, e o vínculo
+  com `Event` fica disponível para pré-preencher local e data no painel.
+- **Negativas**: a tabela `media` guarda `model_id` como texto. Comparar com o
+  `uuid` de `events_albums` em `whereHas`/`withCount` exige o cast feito em
+  `PhotosRelation`. Qualquer outro dono com UUID vai precisar do mesmo cast.
+- **Fila**: as conversões `thumb`/`large` rodam em fila. Sem worker, o portal
+  serve o original até a conversão existir (`PhotoView` faz o fallback).
+
+## Alternativas descartadas
+
+- **Módulo `gallery` separado**: mais um módulo para um agregado só, sem
+  regra de negócio própria além de publicação.
+- **Fotos no `Event`**: obrigaria criar `Event` para todo encontro
+  fotografado, com política de inscrição e tudo, só para guardar fotos.
+- **Tabela `events_photos` própria**: duplicaria o que a `media` já guarda
+  (ordem, nome, tamanho, conversões) e perderia o `SpatieMediaLibraryFileUpload`
+  do Filament.

--- a/app-modules/events/docs/plans/2026-09-07-galeria-de-fotos.md
+++ b/app-modules/events/docs/plans/2026-09-07-galeria-de-fotos.md
@@ -1,0 +1,1227 @@
+---
+type: plan
+title: 'Galeria de fotos: álbuns por evento no portal e no admin'
+module: events
+status: proposed
+date: 2026-09-07
+author: danielhe4rt
+related:
+    issue: https://github.com/he4rt/heartdevs.com/issues/504
+---
+
+# Galeria de fotos — plano de implementação
+
+## Goal
+
+Entregar a issue #504 com a leitura que a discussão convergiu e as decisões fechadas em 2026-09-07:
+
+| Decisão                    | Escolha                                                                                        |
+| -------------------------- | ---------------------------------------------------------------------------------------------- |
+| Onde aparece               | Só `/galeria` pública, com link "Galeria" na navbar. A Home não muda nesta entrega.             |
+| Onde mora o domínio        | Sub-domínio `Gallery/` dentro de `app-modules/events` (namespace `He4rt\Events\Gallery`).      |
+| Álbum × Evento             | `Album` é entidade própria com `event_id` **opcional** apontando para `Event`.                 |
+| Gestão                     | Painel admin (`panel-admin`), CRUD de álbum + upload em lote via `SpatieMediaLibraryFileUpload`. |
+| Volume e curadoria         | Equipe sobe tudo do evento. Cada foto pode ser marcada como **destaque**; o card do álbum mostra os destaques. |
+| Armazenamento              | Disco `public` local, como todo `HasMedia` do repo. Conversões `thumb` e `large` em WebP, **em fila**. |
+| Lightbox                   | Alpine escrito à mão dentro de `@assets`, zero dependência npm (padrão do `articles.blade.php`). |
+
+Referências de padrão que este plano copia, por ordem de importância:
+
+- `app-modules/marketing/docs/adr/0004-borda-http-no-portal.md` — domínio puro, rota no portal, CRUD no admin.
+- `app-modules/identity/src/User/Concerns/HasProfileImages.php` + `Enums/ProfileImage.php` — collection, conversão, fallback de URL.
+- Commit `bbd0d2ec` (fix de capa/avatar) — armadilhas de `imageAspectRatio()` e teto de upload do PHP.
+- `app-modules/panel-admin/src/Filament/Resources/Events/**` — anatomia de Resource, Schemas, Tables, RelationManagers.
+- `app-modules/portal/src/Articles/**` + `resources/views/articles.blade.php` — página full-page Livewire, read model, Alpine em `@assets`.
+
+## Arquitetura
+
+```text
+  ┌────────────────────────┐   Livewire/Filament   ┌──────────────────────────────┐
+  │  panel-admin           │ ────────────────────► │  events (domínio)            │
+  │  AlbumResource         │   Album::create()     │  Gallery/                    │
+  │  PhotosRelationManager │   CuratePhoto         │   Models/Album (HasMedia)    │
+  └────────────────────────┘                       │   Enums/PhotoConversion      │
+                                                   │   DTOs/Photo                 │
+  ┌────────────────────────┐   read model          │   Actions/CuratePhoto        │
+  │  portal                │ ────────────────────► │                              │
+  │  GET /galeria          │   Album::published()  │  events_albums ──0..1──► events│
+  │  GET /galeria/{slug}   │   ->withPhotos()      │        │ morphMany            │
+  │  AlbumFeed → DTOs      │                       │      media (spatie)          │
+  └────────────────────────┘                       └──────────────┬───────────────┘
+                                                                  │ disco public
+                                                   ┌──────────────▼───────────────┐
+                                                   │ storage/app/public/{media}/  │
+                                                   │   original.jpg               │
+                                                   │   conversions/*-thumb.webp   │
+                                                   │   conversions/*-large.webp   │
+                                                   └──────────────────────────────┘
+```
+
+Regras de dependência que mudam: `portal` passa a depender de `events` (apresentação depende de domínio, permitido). `events` continua sem importar de `portal` nem de `panel-admin`.
+
+## Pipeline do upload
+
+```text
+  [Admin]              [Filament]                 [Spatie]                    [Fila]
+     │                     │                         │                          │
+  arrasta 40 jpg ────► SpatieMediaLibraryFileUpload  │                          │
+                       valida mime + maxSize ──────► addMediaFromString()       │
+                       (min(10 MB, php.ini))         toMediaCollection('photos')│
+                                                     order_column = posição     │
+                                                     custom_properties = {}     │
+                                                     dispatch PerformConversions ─► thumb 640×480 webp (Crop)
+                                                                                 ─► large 1920 webp (Max)
+  [Admin] marca destaque + legenda ──► CuratePhoto ─► custom_properties {highlight: true, caption: "..."}
+
+  [Portal] ────────► Album::published()->withPhotos() ─► AlbumFeed ─► PhotoView
+                     thumb pronto?  sim → getUrl('thumb')
+                                    não → getUrl() (original, até a fila rodar)
+```
+
+## Estados do álbum
+
+```text
+  [rascunho] ──published_at preenchido──► [publicado] ──published_at = null──► [rascunho]
+       │                                        │
+       └── invisível no portal                  └── visível em /galeria se tiver ≥ 1 foto
+                                                    (sem foto: some da lista e /galeria/{slug} dá 404)
+```
+
+## Telas
+
+### `/galeria` (lista de álbuns)
+
+```text
+  ┌─────────────────────────────────────────────────────────────────┐
+  │ [navbar]  Artigos · Redes · Galeria(ativo)                       │
+  ├─────────────────────────────────────────────────────────────────┤
+  │  ◦ Galeria                                                       │
+  │  O que acontece quando a gente sai do Discord.                   │
+  │  Alguns registros dos nossos encontros. Tem palestra, tem        │
+  │  workshop — e tem muita conversa fora da tela.                   │
+  ├─────────────────────────────────────────────────────────────────┤
+  │ ┌───────────────────────────────────────────────────────────┐   │
+  │ │ Pub #2            ┌──────┐ ┌──────┐ ┌──────┐ ┌ ─ ─ ┐      │   │
+  │ │ Curitiba          │thumb │ │thumb │ │thumb │   +28        │   │
+  │ │ Agosto de 2025    │legend│ │legend│ │legend│ └ ─ ─ ┘      │   │
+  │ │ [31 fotos]        └──────┘ └──────┘ └──────┘              │   │
+  │ └───────────────────────────────────────────────────────────┘   │
+  │ ┌───────────────────────────────────────────────────────────┐   │
+  │ │ Pub #1  · São Paulo · Março de 2025 · [24 fotos] ...      │   │
+  │ └───────────────────────────────────────────────────────────┘   │
+  │  (mobile: coluna única, 3 thumbs em linha, card inteiro é link)  │
+  └─────────────────────────────────────────────────────────────────┘
+```
+
+### `/galeria/{slug}` (álbum + lightbox)
+
+```text
+  ┌─────────────────────────────────────────────────────────────────┐
+  │ ← Galeria                                                        │
+  │ Pub #2                                                           │
+  │ Curitiba · Agosto de 2025 · 31 fotos · [evento: Pub #2 ↗]*       │
+  │ Descrição do álbum.                                              │
+  ├─────────────────────────────────────────────────────────────────┤
+  │ ┌────┐ ┌────┐ ┌────┐ ┌────┐        grid auto-fill 220px         │
+  │ │    │ │    │ │    │ │    │        loading=lazy, thumb webp      │
+  │ └────┘ └────┘ └────┘ └────┘                                      │
+  │ ┌────┐ ┌────┐ ┌────┐ ┌────┐                                      │
+  └─────────────────────────────────────────────────────────────────┘
+        │ clique / Enter em uma foto
+        ▼
+  ┌─────────────────────────────────────────────────────────────────┐
+  │ [x]                                                     12 / 31  │
+  │        ◄     ┌───────────────────────────┐     ►                 │
+  │              │        large webp         │                       │
+  │              └───────────────────────────┘                       │
+  │              Legenda da foto                                     │
+  │  teclas: ← → Esc · swipe no touch · URL ?foto=12 (replaceState)  │
+  └─────────────────────────────────────────────────────────────────┘
+  * só quando event_id preenchido. Não há rota pública de evento hoje: renderizar
+    como texto, sem link, até existir.
+```
+
+### Admin: `EditAlbum`
+
+```text
+  ┌─────────────────────────────────────────────────────────────────┐
+  │ Álbum: Pub #2                       [Salvar]  [Excluir]          │
+  ├─────────────────────────────────────────────────────────────────┤
+  │ Título ______________________   Slug ____________________        │
+  │ Evento (opcional) [Select ▾]    Aconteceu em [__/__/____]        │
+  │ Local __________________________                                 │
+  │ Descrição ______________________________________________          │
+  │ Publicado em [__/__/____ __:__]  (vazio = rascunho)              │
+  │ Fotos                                                            │
+  │ ┌──┐┌──┐┌──┐┌──┐┌──┐┌──┐┌──┐┌──┐  arraste até 100 · 10 MB cada  │
+  │ └──┘└──┘└──┘└──┘└──┘└──┘└──┘└──┘  reordenável                     │
+  ├─────────────────────────────────────────────────────────────────┤
+  │ Fotos (RelationManager)                          ⇅ reordenar     │
+  │ ┌────┬─────────┬──────────────────────┬──────────┬────────────┐  │
+  │ │thumb│ Destaque│ Legenda              │ Tamanho  │ Enviada em │  │
+  │ │ ▣  │  [x]    │ [Lightning talks    ] │ 2,1 MB   │ 03/09 14:02│  │
+  │ │ ▣  │  [ ]    │ [                   ] │ 1,8 MB   │ 03/09 14:02│  │
+  │ └────┴─────────┴──────────────────────┴──────────┴────────────┘  │
+  └─────────────────────────────────────────────────────────────────┘
+```
+
+## Fluxo de curadoria
+
+```text
+USER (admin)                          SYSTEM
+  │                                       │
+  │ 👆 Novo álbum, preenche título        │
+  │ ─────────────────────────────────►    │ slug sugerido via Str::slug (só se vazio)
+  │ 👆 escolhe Evento "Pub #2"            │
+  │ ─────────────────────────────────►    │ afterStateUpdated: preenche local e data
+  │                                       │ se os campos estiverem vazios
+  │ 👆 arrasta 40 fotos                   │
+  │ ─────────────────────────────────►    │ ⚙️ valida mime/tamanho, salva média,
+  │                                       │    enfileira conversões
+  │ 👆 Salvar                             │
+  │ ─────────────────────────────────►    │ ✓ Album criado (rascunho)
+  │                                       │
+  │ 👆 RelationManager: marca 3 destaques │
+  │    e escreve legendas                 │
+  │ ─────────────────────────────────►    │ CuratePhoto grava custom_properties
+  │ 👆 Publicado em = agora, Salvar       │
+  │ ─────────────────────────────────►    │ ✓ /galeria passa a listar o álbum
+```
+
+---
+
+## Comandos
+
+Rodar antes de escrever código, nesta ordem. Sempre pelo MCP `lerd` (regra da sessão), nunca `php artisan` direto no shell.
+
+```bash
+php artisan make:migration create_events_albums_table --module=events --no-interaction
+php artisan make:factory AlbumFactory --no-interaction   # mover para app-modules/events/database/factories/
+php artisan make:test --pest AlbumTest --no-interaction  # mover para app-modules/events/tests/Feature/Gallery/
+```
+
+Resource, páginas e RelationManager do Filament são criados à mão espelhando `app-modules/panel-admin/src/Filament/Resources/Events/`. O gerador do Filament grava em `app/Filament`, namespace que este repo não usa.
+
+---
+
+## Fase 1 — Domínio (`app-modules/events`)
+
+### Passo 1.1: Migration `events_albums`
+
+- [ ] Criar a migration via artisan com `--module=events`.
+
+**Context.** Não existe nenhuma tabela de álbum ou foto no repo. A tabela segue o estilo de `2026_05_16_200001_create_events_table.php`: UUID como PK, `timestampsTz()`, índices nomeados com prefixo `idx_`. O vínculo com `events` é opcional e não pode apagar o álbum quando o evento some (`nullOnDelete`). A tabela `media` do Spatie já existe (`database/migrations/2025_11_05_135059_create_media_table.php`) com `model_id` string, compatível com UUID.
+
+```php
+// app-modules/events/database/migrations/2026_09_07_000000_create_events_albums_table.php
+Schema::create('events_albums', static function (Blueprint $table): void {
+    $table->uuid('id')->primary();
+    $table->foreignUuid('event_id')->nullable()->constrained('events')->nullOnDelete();
+    $table->string('slug', 120);
+    $table->string('title', 200);
+    $table->string('location')->nullable();
+    $table->date('happened_at');
+    $table->text('description')->nullable();
+    $table->timestampTz('published_at')->nullable();
+    $table->timestampsTz();
+
+    $table->unique('slug', 'idx_events_albums_slug');
+    $table->index(['published_at', 'happened_at'], 'idx_events_albums_public_order');
+});
+```
+
+`happened_at` é `date` de propósito: a UI mostra "Agosto de 2025", não hora. `date` não tem variante Tz e não sofre o bug de ±3h.
+
+**Expected behavior.**
+
+```gherkin
+Feature: Tabela de álbuns
+    Scenario: Evento apagado não leva o álbum junto
+        Given um álbum vinculado ao evento "Pub #2"
+        When o evento é apagado
+        Then o álbum continua existindo com event_id nulo
+
+    Scenario: Slug é único
+        Given um álbum com slug "pub-2"
+        When outro álbum tenta usar o slug "pub-2"
+        Then o banco rejeita a inserção
+```
+
+### Passo 1.2: Enum `PhotoConversion`
+
+- [ ] Criar `app-modules/events/src/Gallery/Enums/PhotoConversion.php`.
+
+**Context.** `ProfileImage` prova que variação de imagem é dado, não subclasse. As duas conversões da galeria nascem num enum que é a única fonte de nome, dimensão e `Fit`. Por regra do repo todo enum novo implementa os contratos do Filament no mesmo commit.
+
+```php
+namespace He4rt\Events\Gallery\Enums;
+
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasDescription;
+use Filament\Support\Contracts\HasLabel;
+use Spatie\Image\Enums\Fit;
+
+enum PhotoConversion: string implements HasColor, HasDescription, HasLabel
+{
+    case Thumb = 'thumb';
+    case Large = 'large';
+
+    /** @return list<string> */
+    public static function mimeTypes(): array
+    {
+        return ['image/jpeg', 'image/png', 'image/webp'];
+    }
+
+    public static function maxKilobytes(): int
+    {
+        return 10_240;
+    }
+
+    public function width(): int
+    {
+        return match ($this) {
+            self::Thumb => 640,
+            self::Large => 1_920,
+        };
+    }
+
+    public function height(): int
+    {
+        return match ($this) {
+            self::Thumb => 480,
+            self::Large => 1_920,
+        };
+    }
+
+    public function fit(): Fit
+    {
+        return match ($this) {
+            self::Thumb => Fit::Crop,
+            self::Large => Fit::Max,
+        };
+    }
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Thumb => __('events::enums.photo_conversion.thumb'),
+            self::Large => __('events::enums.photo_conversion.large'),
+        };
+    }
+
+    public function getColor(): string
+    {
+        return match ($this) {
+            self::Thumb => 'gray',
+            self::Large => 'primary',
+        };
+    }
+
+    public function getDescription(): ?string
+    {
+        return match ($this) {
+            self::Thumb => __('events::enums.photo_conversion.thumb_description'),
+            self::Large => __('events::enums.photo_conversion.large_description'),
+        };
+    }
+}
+```
+
+GIF fica fora. Foto de evento não é animação, e aceitar GIF exigiria o caminho "servido sem conversão" do perfil.
+
+Adicionar ao `app-modules/events/lang/{en,pt_BR}/enums.php` a chave `photo_conversion` com `thumb`, `large`, `thumb_description`, `large_description`.
+
+### Passo 1.3: DTO `Photo` e action `CuratePhoto`
+
+- [ ] Criar `app-modules/events/src/Gallery/DTOs/Photo.php`.
+- [ ] Criar `app-modules/events/src/Gallery/DTOs/CuratePhotoData.php`.
+- [ ] Criar `app-modules/events/src/Gallery/Actions/CuratePhoto.php`.
+
+**Context.** Legenda e destaque vivem em `custom_properties` do `Media`, como o `focal_y` do perfil. Para não espalhar as strings `caption` e `highlight` pelo admin e pelo portal, as chaves ficam em um único dono: o DTO `Photo`. ADR-0003 do módulo manda toda escrita passar por Action.
+
+```php
+namespace He4rt\Events\Gallery\DTOs;
+
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+final readonly class Photo
+{
+    public const string CAPTION = 'caption';
+
+    public const string HIGHLIGHT = 'highlight';
+
+    public function __construct(
+        public int $id,
+        public string $uuid,
+        public ?string $caption,
+        public bool $highlight,
+        public int $position,
+    ) {}
+
+    public static function fromMedia(Media $media): self
+    {
+        $caption = $media->getCustomProperty(self::CAPTION);
+
+        return new self(
+            id: (int) $media->getKey(),
+            uuid: (string) $media->uuid,
+            caption: is_string($caption) && $caption !== '' ? $caption : null,
+            highlight: (bool) $media->getCustomProperty(self::HIGHLIGHT, false),
+            position: (int) ($media->order_column ?? 0),
+        );
+    }
+}
+```
+
+```php
+namespace He4rt\Events\Gallery\DTOs;
+
+final readonly class CuratePhotoData
+{
+    public function __construct(
+        public ?string $caption,
+        public bool $highlight,
+    ) {}
+}
+```
+
+```php
+namespace He4rt\Events\Gallery\Actions;
+
+use He4rt\Events\Gallery\DTOs\CuratePhotoData;
+use He4rt\Events\Gallery\DTOs\Photo;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+final class CuratePhoto
+{
+    public function handle(Media $media, CuratePhotoData $data): Media
+    {
+        $caption = $data->caption !== null ? mb_trim($data->caption) : null;
+
+        $media
+            ->setCustomProperty(Photo::CAPTION, $caption !== '' ? $caption : null)
+            ->setCustomProperty(Photo::HIGHLIGHT, $data->highlight);
+
+        $media->save();
+
+        return $media;
+    }
+}
+```
+
+URL e conversão não entram no DTO de domínio. Quem monta URL é o portal (Passo 3.2), porque a URL depende do fallback para o original enquanto a fila não rodou.
+
+**Expected behavior.**
+
+```gherkin
+Feature: Curadoria de foto
+    Scenario: Marcar destaque com legenda
+        Given uma foto sem propriedades
+        When CuratePhoto recebe caption "Lightning talks" e highlight true
+        Then custom_properties tem caption "Lightning talks" e highlight true
+
+    Scenario: Legenda em branco vira nula
+        When CuratePhoto recebe caption "   " e highlight false
+        Then custom_properties.caption é null
+```
+
+### Passo 1.4: Model `Album`
+
+- [ ] Criar `app-modules/events/src/Gallery/Models/Album.php`.
+- [ ] Criar `app-modules/events/database/factories/AlbumFactory.php`.
+
+**Context.** Único `HasMedia` do módulo `events`. Copia o desenho de `HasProfileImages`: collection no disco `public`, mime restrito, conversões registradas dentro da collection. Diferença: conversões ficam **em fila** (default `queue_conversions_by_default = true`, sem `nonQueued()`), porque um upload de 40 fotos síncrono estouraria o request. O portal cai no original enquanto a conversão não existe.
+
+```php
+namespace He4rt\Events\Gallery\Models;
+
+use Carbon\Carbon;
+use He4rt\Events\Database\Factories\AlbumFactory;
+use He4rt\Events\Event\Models\Event;
+use He4rt\Events\Gallery\DTOs\Photo;
+use He4rt\Events\Gallery\Enums\PhotoConversion;
+use Illuminate\Database\Eloquent\Attributes\Table;
+use Illuminate\Database\Eloquent\Attributes\UseFactory;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Support\Collection;
+use Spatie\MediaLibrary\HasMedia;
+use Spatie\MediaLibrary\InteractsWithMedia;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+/**
+ * @property string $id
+ * @property string|null $event_id
+ * @property string $slug
+ * @property string $title
+ * @property string|null $location
+ * @property Carbon $happened_at
+ * @property string|null $description
+ * @property Carbon|null $published_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read int|null $photos_count
+ */
+#[UseFactory(AlbumFactory::class)]
+#[Table(name: 'events_albums')]
+final class Album extends Model implements HasMedia
+{
+    /** @use HasFactory<AlbumFactory> */
+    use HasFactory;
+    use HasUuids;
+    use InteractsWithMedia;
+
+    public const string PHOTOS = 'photos';
+
+    public const int CARD_HIGHLIGHTS = 3;
+
+    protected $fillable = [
+        'event_id', 'slug', 'title', 'location', 'happened_at', 'description', 'published_at',
+    ];
+
+    public function registerMediaCollections(): void
+    {
+        $this->addMediaCollection(self::PHOTOS)
+            ->useDisk('public')
+            ->acceptsMimeTypes(PhotoConversion::mimeTypes())
+            ->registerMediaConversions(function (?Media $media = null): void {
+                foreach (PhotoConversion::cases() as $conversion) {
+                    $this->addMediaConversion($conversion->value)
+                        ->fit($conversion->fit(), $conversion->width(), $conversion->height())
+                        ->format('webp');
+                }
+            });
+    }
+
+    /** @return BelongsTo<Event, $this> */
+    public function event(): BelongsTo
+    {
+        return $this->belongsTo(Event::class);
+    }
+
+    /**
+     * Só as fotos, já na ordem do admin. Existe além de getMedia() para
+     * withCount('photos') e eager loading na listagem.
+     *
+     * @return MorphMany<Media, $this>
+     */
+    public function photos(): MorphMany
+    {
+        return $this->media()
+            ->where('collection_name', self::PHOTOS)
+            ->orderBy('order_column');
+    }
+
+    /** @return Collection<int, Media> */
+    public function highlights(): Collection
+    {
+        $photos = $this->getMedia(self::PHOTOS);
+
+        $flagged = $photos->filter(
+            fn (Media $media): bool => (bool) $media->getCustomProperty(Photo::HIGHLIGHT, false),
+        );
+
+        return $flagged->isNotEmpty() ? $flagged->values() : $photos->take(self::CARD_HIGHLIGHTS)->values();
+    }
+
+    public function cover(): ?Media
+    {
+        return $this->highlights()->first();
+    }
+
+    public function isPublished(): bool
+    {
+        return $this->published_at !== null && $this->published_at->isPast();
+    }
+
+    /** @param  Builder<self>  $query */
+    protected function scopePublished(Builder $query): void
+    {
+        $query->whereNotNull('published_at')->where('published_at', '<=', now());
+    }
+
+    /** @param  Builder<self>  $query */
+    protected function scopeWithPhotos(Builder $query): void
+    {
+        $query->whereHas('photos');
+    }
+
+    /** @param  Builder<self>  $query */
+    protected function scopeChronological(Builder $query): void
+    {
+        $query->orderByDesc('happened_at')->orderByDesc('created_at');
+    }
+
+    /** @return array<string, mixed> */
+    protected function casts(): array
+    {
+        return [
+            'happened_at' => 'date',
+            'published_at' => 'datetime',
+        ];
+    }
+}
+```
+
+`highlights()` cai nas três primeiras fotos quando ninguém marcou destaque, para o card nunca sair vazio.
+
+Factory:
+
+```php
+final class AlbumFactory extends Factory
+{
+    protected $model = Album::class;
+
+    public function definition(): array
+    {
+        $title = fake()->unique()->words(3, asText: true);
+
+        return [
+            'event_id' => null,
+            'slug' => Str::slug($title),
+            'title' => Str::title($title),
+            'location' => fake()->optional()->city(),
+            'happened_at' => fake()->dateTimeBetween('-2 years', 'now'),
+            'description' => fake()->optional()->sentence(),
+            'published_at' => null,
+        ];
+    }
+
+    public function published(): static
+    {
+        return $this->state(fn (): array => ['published_at' => now()->subMinute()]);
+    }
+
+    public function forEvent(Event $event): static
+    {
+        return $this->state(fn (): array => ['event_id' => $event->id]);
+    }
+
+    /** Exige Storage::fake('public') no teste. */
+    public function withPhotos(int $count = 3): static
+    {
+        return $this->afterCreating(static function (Album $album) use ($count): void {
+            foreach (range(1, $count) as $index) {
+                $album->addMedia(UploadedFile::fake()->image("foto-{$index}.jpg", 1_600, 1_200))
+                    ->toMediaCollection(Album::PHOTOS);
+            }
+        });
+    }
+}
+```
+
+**Expected behavior.**
+
+```gherkin
+Feature: Álbum
+    Scenario: Conversões são registradas na collection de fotos
+        Given Storage::fake('public') e fila síncrona
+        When um álbum recebe uma foto 1600x1200
+        Then a média tem as conversões "thumb" e "large" geradas em webp
+
+    Scenario: Destaques caem nas primeiras fotos
+        Given um álbum com 5 fotos e nenhuma marcada como destaque
+        Then highlights() devolve as 3 primeiras na ordem do order_column
+
+    Scenario: Destaques marcados vencem
+        Given um álbum com 5 fotos e a 4ª e a 5ª marcadas como destaque
+        Then highlights() devolve exatamente a 4ª e a 5ª
+
+    Scenario: Escopo published ignora data futura
+        Given um álbum com published_at amanhã
+        Then Album::published() não o inclui
+
+    Scenario: Foto rejeitada por mime
+        When um GIF é adicionado à collection "photos"
+        Then o media library lança FileUnacceptableForCollection
+```
+
+Testes em `app-modules/events/tests/Feature/Gallery/AlbumTest.php`, nomeados em inglês `test('when ..., then ...')` como o resto do módulo.
+
+### Passo 1.5: Glossário e regras de dependência
+
+- [ ] Acrescentar ao `app-modules/events/CONTEXT.md` (tabela Glossary) as linhas **Album**, **Photo**, **Highlight**.
+- [ ] Acrescentar em "Module Boundaries": `Portal → Events` lê `Album` publicado; `Panel Admin → Events` escreve álbum e curadoria.
+- [ ] Remover "Timeline / activity feed" não; acrescentar em Out of Scope: "Home carousel de destaques (issue #504, fase 2)".
+- [ ] Em `CONTEXT-MAP.md`, atualizar a descrição da linha Events ("… + photo albums per event") e a regra de dependência: "**Events** … `portal` renders the public gallery (`/galeria`) and `panel-admin` owns album CRUD; both depend on `events`, never the reverse."
+- [ ] Escrever `app-modules/events/docs/adr/0009-galeria-como-subdominio-de-events.md` (formato de `0004-…`): contexto (issue #504), alternativas (módulo `gallery` novo; `Event` HasMedia), decisão (sub-domínio; álbum próprio com `event_id` opcional; borda HTTP no portal como ADR marketing/0004), consequências (portal ganha dependência de `events`; álbum sem evento é permitido; Home fica para outra entrega).
+
+Glossário sugerido:
+
+| Term          | Definition                                                                                          | Not to be confused with                                  |
+| ------------- | --------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| **Album**     | A curated set of photos from one community moment. Has title, location, date and an optional `Event`. Visible on the portal only when published and non-empty. | "Gallery" — the public page that lists albums.          |
+| **Photo**     | One media item in an album's `photos` collection. Carries caption and highlight flag as custom properties, plus an order. | Profile avatar/cover, which are single-file collections. |
+| **Highlight** | A photo flagged by staff to represent the album on its card. Falls back to the first three photos when none is flagged. | Album cover — the cover is simply the first highlight.  |
+
+---
+
+## Fase 2 — Admin (`app-modules/panel-admin`)
+
+### Passo 2.1: `AlbumResource`
+
+- [ ] Criar `app-modules/panel-admin/src/Filament/Resources/Albums/AlbumResource.php`.
+- [ ] Criar `Pages/ListAlbums.php`, `Pages/CreateAlbum.php`, `Pages/EditAlbum.php`.
+- [ ] Criar `app-modules/panel-admin/lang/{en,pt_BR}/albums.php`.
+
+**Context.** Cópia estrutural de `EventResource`. Labels via métodos `getNavigationLabel()/getModelLabel()/getPluralModelLabel()` lendo `__('panel-admin::albums.*')`.
+
+```
+Resource: AlbumResource
+  Location: He4rt\PanelAdmin\Filament\Resources\Albums\AlbumResource
+  Docs: https://filamentphp.com/docs/5.x/resources/overview
+  Model: He4rt\Events\Gallery\Models\Album
+  Slug: albums
+  RecordTitleAttribute: title
+  Navigation:
+    Icon: Filament\Support\Icons\Heroicon::OutlinedPhoto
+    Group: NavGroup::Content (montado à mão no provider, ver Passo 2.5)
+  Pages:
+    index  → ListAlbums::route('/')
+    create → CreateAlbum::route('/create')
+    edit   → EditAlbum::route('/{record}/edit')
+  Relations:
+    PhotosRelationManager
+  Authorization: todo usuário que acessa o painel admin (config he4rt.admins via User::canAccessPanel). Sem policy, igual aos outros resources.
+```
+
+`lang/pt_BR/albums.php`:
+
+```php
+return [
+    'label' => 'Álbum',
+    'plural' => 'Álbuns de fotos',
+    'columns' => [
+        'title' => 'Título', 'slug' => 'Slug', 'event' => 'Evento', 'location' => 'Local',
+        'happened_at' => 'Aconteceu em', 'description' => 'Descrição', 'published_at' => 'Publicado em',
+        'photos' => 'Fotos', 'photos_count' => 'Fotos', 'created_at' => 'Criado em',
+    ],
+    'form' => [
+        'helpers' => [
+            'event' => 'Opcional. Escolher um evento preenche local e data, se estiverem vazios.',
+            'published_at' => 'Vazio mantém o álbum como rascunho, fora do portal.',
+            'photos' => 'Até :max_files fotos por vez, :max_mb MB cada. JPG, PNG ou WEBP.',
+        ],
+    ],
+    'filters' => ['published' => 'Publicados', 'drafts' => 'Rascunhos'],
+    'photos' => [
+        'title' => 'Fotos',
+        'columns' => ['preview' => 'Prévia', 'highlight' => 'Destaque', 'caption' => 'Legenda', 'size' => 'Tamanho', 'uploaded_at' => 'Enviada em'],
+        'empty' => 'Envie fotos pelo campo "Fotos" do formulário acima.',
+    ],
+];
+```
+
+`lang/en/albums.php` com as mesmas chaves em inglês (`plural` = `Photo albums`).
+
+### Passo 2.2: `Schemas/AlbumForm.php`
+
+- [ ] Criar `app-modules/panel-admin/src/Filament/Resources/Albums/Schemas/AlbumForm.php`.
+
+**Context.** Formulário de 2 colunas como `EventForm`. O campo de fotos é o primeiro `SpatieMediaLibraryFileUpload` do repo. Regras herdadas do commit `bbd0d2ec`: não usar `imageAspectRatio()`, teto anunciado = `UploadLimit::kilobytes()`. Como não há editor de recorte, `automaticallyResizeImagesToWidth/Height` ficam nulos e a conversão faz o enquadramento.
+
+```
+Form:
+  Columns: 2
+  Imports:
+    Filament\Schemas\Components\Utilities\Get
+    Filament\Schemas\Components\Utilities\Set
+    App\Support\UploadLimit
+    He4rt\Events\Gallery\Enums\PhotoConversion
+    He4rt\Events\Gallery\Models\Album
+    He4rt\Events\Event\Models\Event
+
+  Field: title
+    Component: Filament\Forms\Components\TextInput
+    Docs: https://filamentphp.com/docs/5.x/forms/text-input
+    Validation: required, max:200
+    Config: ->live(onBlur: true), ->afterStateUpdated(fn (Set $set, Get $get, ?string $state) => blank($get('slug')) ? $set('slug', Str::slug($state ?? '')) : null), ->columnSpanFull()
+
+  Field: slug
+    Component: Filament\Forms\Components\TextInput
+    Docs: https://filamentphp.com/docs/5.x/forms/text-input
+    Validation: required, max:120, alpha_dash, unique:events_albums,slug (ignora o registro atual)
+    Config: ->unique(table: Album::class, column: 'slug', ignoreRecord: true), ->alphaDash()
+
+  Field: event_id
+    Component: Filament\Forms\Components\Select
+    Docs: https://filamentphp.com/docs/5.x/forms/select
+    Validation: nullable, exists:events,id
+    Config: ->relationship('event', 'title'), ->searchable(), ->preload(), ->nullable(), ->live(),
+            ->afterStateUpdated(function (?string $state, Get $get, Set $set): void {
+                $event = $state !== null ? Event::query()->find($state) : null;
+                if (! $event instanceof Event) { return; }
+                if (blank($get('location'))) { $set('location', $event->location); }
+                if (blank($get('happened_at'))) { $set('happened_at', $event->starts_at->toDateString()); }
+            }),
+            ->helperText(__('panel-admin::albums.form.helpers.event'))
+
+  Field: happened_at
+    Component: Filament\Forms\Components\DatePicker
+    Docs: https://filamentphp.com/docs/5.x/forms/date-time-picker
+    Validation: required, date, before_or_equal:today
+    Config: ->maxDate(now()), ->native(false), ->displayFormat('d/m/Y')
+
+  Field: location
+    Component: Filament\Forms\Components\TextInput
+    Validation: nullable, max:255
+
+  Field: description
+    Component: Filament\Forms\Components\Textarea
+    Docs: https://filamentphp.com/docs/5.x/forms/textarea
+    Validation: nullable, max:2000
+    Config: ->rows(3), ->columnSpanFull()
+
+  Field: published_at
+    Component: Filament\Forms\Components\DateTimePicker
+    Validation: nullable, date
+    Config: ->nullable(), ->seconds(false), ->timezone(config('app.display_timezone')), ->helperText(__('panel-admin::albums.form.helpers.published_at'))
+
+  Field: photos
+    Component: Filament\Forms\Components\SpatieMediaLibraryFileUpload
+    Docs: https://filamentphp.com/docs/5.x/forms/file-upload  (métodos do plugin: collection, conversion, customProperties, responsiveImages)
+    Validation: nullable, image, mimetypes:image/jpeg,image/png,image/webp, max:{UploadLimit::kilobytes(PhotoConversion::maxKilobytes())}
+    Config: ->collection(Album::PHOTOS), ->conversion(PhotoConversion::Thumb->value), ->multiple(), ->reorderable(), ->appendFiles(),
+            ->image(), ->acceptedFileTypes(PhotoConversion::mimeTypes()), ->maxSize(UploadLimit::kilobytes(PhotoConversion::maxKilobytes())),
+            ->maxFiles(100), ->panelLayout('grid'), ->imageAspectRatio(ratio: null), ->automaticallyCropImagesToAspectRatio(condition: false),
+            ->automaticallyResizeImagesToWidth(width: null), ->automaticallyResizeImagesToHeight(height: null),
+            ->helperText(__('panel-admin::albums.form.helpers.photos', ['max_files' => 100, 'max_mb' => round(UploadLimit::kilobytes(PhotoConversion::maxKilobytes()) / 1_024, 1)])),
+            ->columnSpanFull()
+```
+
+O plugin grava a ordem via `Media::setNewOrder()` quando `reorderable()` está ativo (`SpatieMediaLibraryFileUpload::reorderUploadedFilesUsing`). `conversion('thumb')` faz o uploader mostrar a miniatura webp em vez do original de 5 MB; enquanto a fila não roda o Filament cai no original sozinho.
+
+**Expected behavior.**
+
+```gherkin
+Feature: Formulário de álbum
+    Scenario: Slug sugerido a partir do título
+        Given o campo slug vazio
+        When o admin digita "Pub #2 Curitiba" e sai do campo título
+        Then slug recebe "pub-2-curitiba"
+
+    Scenario: Slug preenchido não é sobrescrito
+        Given slug "meu-slug"
+        When o título muda
+        Then slug continua "meu-slug"
+
+    Scenario: Evento preenche local e data
+        Given local e data vazios
+        When o admin escolhe o evento "Pub #2" (local "Curitiba", starts_at 2025-08-15)
+        Then local vira "Curitiba" e happened_at vira 2025-08-15
+
+    Scenario: Upload em lote
+        When o admin envia 3 JPGs válidos e salva
+        Then o álbum tem 3 médias na collection "photos" na ordem enviada
+
+    Scenario: Arquivo fora do mime
+        When o admin envia um GIF
+        Then o formulário reprova o campo photos com erro de mimetypes
+
+    Scenario: Validação (dataset)
+        - title: required, max:200
+        - slug: required, max:120, alpha_dash, unique
+        - happened_at: required, before_or_equal:today
+        - event_id: exists
+```
+
+### Passo 2.3: `Tables/AlbumsTable.php`
+
+- [ ] Criar `app-modules/panel-admin/src/Filament/Resources/Albums/Tables/AlbumsTable.php` com `public static function table(Table $table): Table` (mesma assinatura de `EventsTable`).
+
+```
+Table:
+  DefaultSort: happened_at desc
+  Column: photos
+    Component: Filament\Tables\Columns\SpatieMediaLibraryImageColumn
+    Docs: https://filamentphp.com/docs/5.x/tables/columns/image
+    Config: ->collection(Album::PHOTOS), ->conversion(PhotoConversion::Thumb->value), ->stacked(), ->limit(3), ->limitedRemainingText(), ->label(__('panel-admin::albums.columns.photos'))
+  Column: title
+    Component: Filament\Tables\Columns\TextColumn
+    Config: ->searchable(), ->sortable(), ->description(fn (Album $record): ?string => $record->location)
+  Column: event.title
+    Component: Filament\Tables\Columns\TextColumn
+    Config: ->placeholder('—'), ->toggleable()
+  Column: happened_at
+    Component: Filament\Tables\Columns\TextColumn
+    Config: ->date('d/m/Y'), ->sortable()
+  Column: photos_count
+    Component: Filament\Tables\Columns\TextColumn
+    Config: ->counts('photos'), ->badge(), ->sortable()
+  Column: published_at
+    Component: Filament\Tables\Columns\TextColumn
+    Config: ->dateTime('d/m/Y H:i'), ->timezone(config('app.display_timezone')), ->placeholder(__('panel-admin::albums.filters.drafts')), ->sortable()
+  Column: created_at
+    Component: Filament\Tables\Columns\TextColumn
+    Config: ->dateTime(), ->sortable(), ->toggleable(isToggledHiddenByDefault: true)
+
+  Filter: published
+    Component: Filament\Tables\Filters\TernaryFilter
+    Docs: https://filamentphp.com/docs/5.x/tables/filters/ternary
+    Config: ->nullable(), ->attribute('published_at'), ->trueLabel(__('panel-admin::albums.filters.published')), ->falseLabel(__('panel-admin::albums.filters.drafts'))
+
+  Actions: EditAction, DeleteAction (linha); BulkActionGroup[DeleteBulkAction] (toolbar)
+```
+
+A memória do projeto avisa: o painel usa `PaginationMode::Cursor` global, e ordenar por agregado (`photos_count`) quebra a página 2. Se `photos_count->sortable()` estourar, remover o `sortable()` desse campo em vez de trocar o modo de paginação.
+
+### Passo 2.4: `RelationManagers/PhotosRelationManager.php`
+
+- [ ] Criar `app-modules/panel-admin/src/Filament/Resources/Albums/RelationManagers/PhotosRelationManager.php`.
+
+**Context.** O uploader não edita metadado por arquivo. A curadoria (destaque, legenda, ordem fina) fica numa tabela sobre a relação `media` do álbum, filtrada na collection `photos`. Toda escrita passa por `CuratePhoto`.
+
+```
+RelationManager: PhotosRelationManager
+  Location: He4rt\PanelAdmin\Filament\Resources\Albums\RelationManagers\PhotosRelationManager
+  Docs: https://filamentphp.com/docs/5.x/resources/managing-relationships
+  Relationship: media (MorphMany de Spatie) — propriedade `$relationship = 'media'`
+  Title: __('panel-admin::albums.photos.title')
+  Can create: no (upload é pelo formulário)
+  Can edit: inline (colunas editáveis)
+  Can delete: yes (DeleteAction; o Media apaga o arquivo e as conversões)
+  Can reorder: yes
+
+  Table:
+    ModifyQuery: fn (Builder $query) => $query->where('collection_name', Album::PHOTOS)
+    Reorderable: ->reorderable('order_column'), ->defaultSort('order_column')
+    Paginated: false (um álbum tem dezenas de fotos, não milhares)
+    EmptyState: heading __('panel-admin::albums.photos.empty')
+
+    Column: preview
+      Component: Filament\Tables\Columns\ImageColumn
+      Config: ->state(fn (Media $record): string => $record->hasGeneratedConversion(PhotoConversion::Thumb->value) ? $record->getUrl(PhotoConversion::Thumb->value) : $record->getUrl()), ->imageHeight(64), ->square()
+    Column: highlight
+      Component: Filament\Tables\Columns\ToggleColumn
+      Docs: https://filamentphp.com/docs/5.x/tables/columns/toggle
+      Config: ->state(fn (Media $record): bool => Photo::fromMedia($record)->highlight),
+              ->updateStateUsing(fn (Media $record, bool $state) => resolve(CuratePhoto::class)->handle($record, new CuratePhotoData(caption: Photo::fromMedia($record)->caption, highlight: $state)))
+    Column: caption
+      Component: Filament\Tables\Columns\TextInputColumn
+      Docs: https://filamentphp.com/docs/5.x/tables/columns/text-input
+      Config: ->state(fn (Media $record): ?string => Photo::fromMedia($record)->caption), ->rules(['nullable', 'max:140']),
+              ->updateStateUsing(fn (Media $record, ?string $state) => resolve(CuratePhoto::class)->handle($record, new CuratePhotoData(caption: $state, highlight: Photo::fromMedia($record)->highlight)))
+    Column: size
+      Component: Filament\Tables\Columns\TextColumn
+      Config: ->state(fn (Media $record): string => $record->humanReadableSize)
+    Column: created_at
+      Component: Filament\Tables\Columns\TextColumn
+      Config: ->dateTime('d/m H:i'), ->timezone(config('app.display_timezone'))
+
+  Actions: DeleteAction (linha), BulkActionGroup[DeleteBulkAction]
+```
+
+Registrar em `AlbumResource::getRelations()`.
+
+**Expected behavior.**
+
+```gherkin
+Feature: Curadoria de fotos no admin
+    Scenario: Só fotos da collection aparecem
+        Given um álbum com 2 fotos
+        When o admin abre a aba Fotos
+        Then a tabela lista 2 registros
+
+    Scenario: Marcar destaque
+        When o admin liga o toggle Destaque da 2ª foto
+        Then custom_properties.highlight da média é true
+
+    Scenario: Legenda inline
+        When o admin escreve "Lightning talks" na legenda
+        Then custom_properties.caption é "Lightning talks"
+
+    Scenario: Reordenar
+        When o admin arrasta a 3ª foto para a 1ª posição
+        Then order_column reflete a nova ordem e /galeria/{slug} mostra a foto primeiro
+```
+
+### Passo 2.5: Navegação e registro do resource
+
+- [ ] `PanelAdminServiceProvider::register()`: adicionar `AlbumResource::class` ao array `->resources([...])`.
+- [ ] `PanelAdminServiceProvider::defaultNavigation()`: adicionar `...AlbumResource::getNavigationItems()` ao final do grupo `NavGroup::Content`.
+- [ ] Atualizar `app-modules/panel-admin/tests/Feature/NavigationGroupsTest.php`, teste "o grupo Conteúdo…": lista passa a `['Artigos', 'Contribuições', 'Retrospectivas', 'Photo albums']` (locale dos testes é `en`).
+
+```php
+// antes
+->items([
+    ...ContentEntryResource::getNavigationItems(),
+    ...InteractionResource::getNavigationItems(),
+    ...RetrospectiveResource::getNavigationItems(),
+]),
+// depois
+->items([
+    ...ContentEntryResource::getNavigationItems(),
+    ...InteractionResource::getNavigationItems(),
+    ...RetrospectiveResource::getNavigationItems(),
+    ...AlbumResource::getNavigationItems(),
+]),
+```
+
+### Passo 2.6: Testes do admin
+
+- [ ] Criar `app-modules/panel-admin/tests/Feature/Albums/AlbumResourceTest.php` (nomes em pt_BR, `beforeEach` igual ao de `Contents/ContentEntryResourceTest.php` + `Storage::fake('public')`).
+
+```
+AlbumResourceTest:
+  Listagem:
+    - lista renderiza e mostra álbuns existentes (livewire(ListAlbums)->loadTable()->assertCanSeeTableRecords)
+    - filtro "Publicados" esconde rascunhos (filterTable('published', true))
+  Criação:
+    - cria álbum com 2 fotos via fillForm(['photos' => [UploadedFile::fake()->image(...), ...]]) e persiste na collection "photos"
+    - validação (dataset): title required; slug required, alpha_dash, unique; happened_at required
+  Edição:
+    - salva alteração de título (fillForm + call('save') + assertHasNoFormErrors)
+  RelationManager:
+    - renderiza com ownerRecord + pageClass EditAlbum
+    - toggle de destaque grava custom property (callTableColumnAction / updateTableColumnState('highlight', $media, true))
+    - legenda grava custom property
+  Navegação:
+    - grupo Conteúdo inclui o label do resource (NavigationGroupsTest)
+```
+
+---
+
+## Fase 3 — Portal (`app-modules/portal`)
+
+### Passo 3.1: Dependência de módulo
+
+- [ ] `app-modules/portal/composer.json`: adicionar `"he4rt/events": "^1.0.0"` em `require` (estilo caret obrigatório). Rodar `composer dump-autoload`.
+
+### Passo 3.2: Read model `AlbumFeed` e DTOs
+
+- [ ] Criar `app-modules/portal/src/Gallery/AlbumFeed.php`.
+- [ ] Criar `app-modules/portal/src/Gallery/DTOs/PhotoView.php`, `AlbumCard.php`, `AlbumDetail.php`.
+
+**Context.** Mesmo desenho de `ArticleFeed`: classe final resolvida do container, mapeia Eloquent para DTOs imutáveis, uma query por caso de uso. A URL de cada foto é decidida aqui, com o fallback de conversão que `HasProfileImages::imageUrl()` já faz.
+
+```php
+final readonly class PhotoView
+{
+    public function __construct(
+        public string $thumbUrl,
+        public string $largeUrl,
+        public ?string $caption,
+        public bool $highlight,
+    ) {}
+
+    public static function fromMedia(Media $media): self
+    {
+        $photo = Photo::fromMedia($media);
+
+        return new self(
+            thumbUrl: self::url($media, PhotoConversion::Thumb),
+            largeUrl: self::url($media, PhotoConversion::Large),
+            caption: $photo->caption,
+            highlight: $photo->highlight,
+        );
+    }
+
+    private static function url(Media $media, PhotoConversion $conversion): string
+    {
+        return $media->hasGeneratedConversion($conversion->value)
+            ? $media->getUrl($conversion->value)
+            : $media->getUrl();
+    }
+}
+```
+
+```php
+final readonly class AlbumCard
+{
+    /** @param list<PhotoView> $highlights */
+    public function __construct(
+        public string $slug,
+        public string $title,
+        public ?string $location,
+        public CarbonImmutable $happenedAt,
+        public int $photoCount,
+        public array $highlights,
+    ) {}
+
+    public function remaining(): int { return max(0, $this->photoCount - count($this->highlights)); }
+
+    public function happenedLabel(): string
+    {
+        return Str::ucfirst($this->happenedAt->translatedFormat('F \d\e Y'));
+    }
+}
+```
+
+`AlbumDetail` = `AlbumCard` + `description`, `eventTitle` (nullable) e `photos: list<PhotoView>` completo.
+
+```php
+final class AlbumFeed
+{
+    /** @return list<AlbumCard> */
+    public function albums(): array
+    {
+        return Album::query()
+            ->published()->withPhotos()->chronological()
+            ->with('media')->withCount('photos')
+            ->get()
+            ->map(fn (Album $album): AlbumCard => new AlbumCard(
+                slug: $album->slug,
+                title: $album->title,
+                location: $album->location,
+                happenedAt: $album->happened_at->toImmutable(),
+                photoCount: (int) $album->photos_count,
+                highlights: $album->highlights()->take(Album::CARD_HIGHLIGHTS)
+                    ->map(fn (Media $media): PhotoView => PhotoView::fromMedia($media))->values()->all(),
+            ))
+            ->values()->all();
+    }
+
+    public function find(string $slug): ?AlbumDetail
+    {
+        $album = Album::query()->published()->withPhotos()->where('slug', $slug)->with(['media', 'event'])->first();
+
+        return $album instanceof Album ? AlbumDetail::fromAlbum($album) : null;
+    }
+}
+```
+
+Carregar `media` inteiro (`with('media')`) é o que o `InteractsWithMedia` espera: `getMedia()` lê a relação `media` carregada, não `photos`. Sem isso, cada card dispararia uma query.
+
+### Passo 3.3: Páginas e rotas
+
+- [ ] Criar `app-modules/portal/src/Gallery/GalleryPage.php` e `AlbumPage.php` (Livewire full-page, `#[Layout('portal::components.layouts.app')]`).
+- [ ] Registrar rotas no `PortalServiceProvider::boot()`, dentro do grupo `web`, logo após `/artigos`.
+
+```php
+Route::get('/galeria', GalleryPage::class)
+    ->name('gallery')
+    ->withHead(
+        title: 'Galeria da comunidade',
+        description: 'Fotos dos encontros da He4rt Developers: meetups, workshops, pubs e confraternizações, álbum por álbum.',
+    );
+
+Route::get('/galeria/{slug}', AlbumPage::class)
+    ->where('slug', '[a-z0-9-]+')
+    ->name('gallery.album');
+```
+
+`AlbumPage::mount(AlbumFeed $feed, string $slug)`: `$this->album = $feed->find($slug) ?? abort(404)`. O `<head>` desta rota é dinâmico (título do álbum), então é definido no componente com o helper do `laravel/head` em vez de `withHead()` na rota — consultar `App\Support\Seo\SiteHead` para o método usado nas páginas dinâmicas, ou `head()->title(...)` conforme a API instalada.
+
+- [ ] Navbar: adicionar entrada `['label' => 'Galeria', 'href' => route('gallery', absolute: false), 'active' => request()->routeIs('gallery', 'gallery.album')]` após "Redes" em `resources/views/components/navbar.blade.php`.
+- [ ] Sitemap: adicionar `'gallery' => ['changefreq' => 'weekly', 'priority' => '0.7']` em `SitemapController::PAGES`. Álbuns individuais entram numa segunda leva (o controller hoje é uma constante estática).
+
+**Expected behavior.**
+
+```gherkin
+Feature: Rotas da galeria
+    Scenario: Rotas dentro do grupo web
+        Then "gallery" e "gallery.album" listam o middleware "web" (PortalRoutesTest dataset)
+
+    Scenario: Álbum publicado com fotos
+        Given um álbum publicado com 3 fotos e slug "pub-2"
+        When GET /galeria/pub-2
+        Then 200 com o título do álbum
+
+    Scenario: Rascunho é 404
+        Given um álbum rascunho com slug "secreto"
+        When GET /galeria/secreto
+        Then 404
+
+    Scenario: Álbum vazio é 404
+        Given um álbum publicado sem fotos
+        When GET /galeria/{slug}
+        Then 404
+
+    Scenario: Navbar
+        When GET /
+        Then o HTML contém href="/galeria"
+```
+
+### Passo 3.4: Views
+
+- [ ] `resources/views/gallery.blade.php` — lista.
+- [ ] `resources/views/gallery-album.blade.php` — grid + lightbox.
+- [ ] `resources/views/components/gallery/album-card.blade.php`, `components/gallery/lightbox.blade.php`.
+
+**Context.** Cabeçalho com `x-he4rt::headline` (badge "Galeria" com `heroicon-o-photo`, título "O que acontece quando a gente sai do Discord.", descrição do layout aprovado na issue). Cada card é uma `<article>` com link `after:absolute after:inset-0` como `articles/card.blade.php`. Imagens são `<img loading="lazy" decoding="async" class="aspect-[4/3] object-cover">`; não existe componente de imagem no design system e não se cria um agora.
+
+Estado vazio (nenhum álbum publicado), no mesmo tom do de artigos:
+
+```blade
+<div class="border-outline-low bg-elevation-01dp flex flex-col items-center gap-3 rounded-lg border border-dashed p-12 text-center">
+    <p class="text-text-high text-sm font-semibold">Ainda não há álbuns por aqui.</p>
+    <p class="text-text-medium max-w-sm text-xs">As fotos dos próximos encontros aparecem nesta página. Enquanto isso, o Discord está aberto.</p>
+</div>
+```
+
+Lightbox (Alpine em `@assets`, componente `galleryLightbox(photos)`):
+
+- estado: `open`, `index`; `photos` = `@js($photosPayload)` com `{l: largeUrl, c: caption}`;
+- `openAt(i)`, `next()`, `prev()`, `close()`; `x-on:keydown.window.escape`, `.arrow-left`, `.arrow-right`;
+- `x-trap.noscroll="open"` para foco e bloqueio de scroll; `aria-modal="true"`, botão fechar com `aria-label`;
+- swipe: `x-on:touchstart` / `x-on:touchend` medindo `clientX` (> 40px troca de foto);
+- deep link `?foto=N` via `history.replaceState`, lido em `init()` como o `readUrl()` de `articlesFeed`;
+- pré-carrega a próxima `large` com `new Image().src`.
+
+Sem CSS novo no Vite: utilitários Tailwind mais um `<style>` local se precisar (padrão de `social-links.blade.php`).
+
+**Expected behavior.**
+
+```gherkin
+Feature: Página /galeria
+    Scenario: Lista em ordem cronológica inversa
+        Given álbuns publicados de Mar/2025 e Ago/2025, ambos com fotos
+        When GET /galeria
+        Then "Ago 2025" aparece antes de "Mar 2025" no HTML
+
+    Scenario: Card mostra destaques e o restante
+        Given um álbum com 24 fotos e 3 destaques
+        Then o card mostra 3 thumbs e o texto "+21"
+
+    Scenario: Rascunho não aparece
+        Given um álbum rascunho
+        Then o título dele não está no HTML de /galeria
+
+    Scenario: Estado vazio
+        Given nenhum álbum publicado
+        Then /galeria mostra "Ainda não há álbuns por aqui."
+
+Feature: Lightbox
+    Scenario: Abrir e navegar
+        Given o álbum tem 3 fotos
+        When o visitante clica na 2ª foto
+        Then o lightbox abre em 2/3 e a URL ganha ?foto=2
+        When pressiona →
+        Then mostra 3/3
+        When pressiona Esc
+        Then o lightbox fecha e ?foto some da URL
+```
+
+Os cenários de lightbox são verificados no navegador; o teste automatizado cobre a presença do payload e do `x-data="galleryLightbox(` no HTML.
+
+### Passo 3.5: Testes do portal
+
+- [ ] Criar `app-modules/portal/tests/Feature/GalleryPageTest.php` (pt_BR, `withoutVite()`, `Storage::fake('public')`, helper local `publishedAlbum(array $attributes = [], int $photos = 3): Album`).
+- [ ] `PortalRoutesTest`: adicionar `'gallery'` e `'gallery.album'` ao dataset.
+- [ ] `HomepageTest`: novo `it('leva para a galeria pela navbar')` com `assertSee('href="/galeria"', escape: false)`.
+- [ ] `SeoHeadTest`, teste do sitemap: `->toContain('<loc>'.route('gallery').'</loc>')`.
+
+---
+
+## Fase 4 — Qualidade e entrega
+
+- [ ] `vendor/bin/pint --dirty --format agent`
+- [ ] `make phpstan` (novo model precisa do PHPDoc completo; `photos_count` como `@property-read`).
+- [ ] `make rector`
+- [ ] Testes via `lerd`, `--parallel`; suíte completa antes do push com `vendor/bin/pest --parallel --update-shards`.
+- [ ] Um commit por fase (`feat(events): …`, `feat(panel-admin): …`, `feat(portal): …`, `docs(events): …`).
+- [ ] PR da branch `feat/gallery` para `4.x` com o template do repo; `Closes #504`; evidências: print de `/galeria`, do lightbox e da aba Fotos do admin.
+
+---
+
+## Fora desta entrega
+
+- Carrossel de destaques na Home (decisão de 2026-09-07: Home fica limpa).
+- Rota pública de evento; o card só mostra o nome do evento vinculado.
+- Álbuns individuais no sitemap.
+- Imagens responsivas (`withResponsiveImages()`); `thumb` e `large` bastam para o volume atual.
+- Filtro por categoria de momento (palestra, bastidores…): a issue cita, mas `Album` já aceita um enum futuro sem mudar tabela de fotos.

--- a/app-modules/events/lang/en/enums.php
+++ b/app-modules/events/lang/en/enums.php
@@ -50,4 +50,11 @@ return [
         'admin' => 'Admin',
         'system' => 'System',
     ],
+
+    'photo_conversion' => [
+        'thumb' => 'Thumbnail',
+        'large' => 'Large',
+        'thumb_description' => 'Cropped 640x480 for cards and grids.',
+        'large_description' => 'Up to 1920px on the longest side, for the lightbox.',
+    ],
 ];

--- a/app-modules/events/lang/pt_BR/enums.php
+++ b/app-modules/events/lang/pt_BR/enums.php
@@ -50,4 +50,11 @@ return [
         'admin' => 'Administrador',
         'system' => 'Sistema',
     ],
+
+    'photo_conversion' => [
+        'thumb' => 'Miniatura',
+        'large' => 'Ampliada',
+        'thumb_description' => 'Recorte 640x480 para cards e grades.',
+        'large_description' => 'Até 1920px no lado maior, para o lightbox.',
+    ],
 ];

--- a/app-modules/events/phpstan.ignore.neon
+++ b/app-modules/events/phpstan.ignore.neon
@@ -1,2 +1,11 @@
 parameters:
-    ignoreErrors: []
+    ignoreErrors:
+        # O stub do Larastan restringe DB::raw() a literal-string. Aqui o valor
+        # é o nome qualificado da chave do dono, envolvido pelo grammar, sem
+        # entrada externa: o cast ::text é a única forma de comparar uuid com
+        # o model_id (varchar) da tabela media no Postgres.
+        -
+            message: '#^Parameter \#1 \$value of static method Illuminate\\Database\\Connection::raw\(\) expects float\|int\|literal-string, non-falsy-string given\.$#'
+            identifier: argument.type
+            count: 1
+            path: src/Gallery/Support/PhotosRelation.php

--- a/app-modules/events/src/EventsServiceProvider.php
+++ b/app-modules/events/src/EventsServiceProvider.php
@@ -9,8 +9,10 @@ use He4rt\Events\CheckIn\Listeners\GenerateQrTokenOnConfirmed;
 use He4rt\Events\CheckIn\Listeners\HandleBotCheckIn;
 use He4rt\Events\Console\Commands\ClosePendingEventsCommand;
 use He4rt\Events\Enrollment\Events\EnrollmentConfirmed;
+use He4rt\Events\Gallery\Models\Album;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 
@@ -23,6 +25,10 @@ class EventsServiceProvider extends ServiceProvider
     {
         $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
         $this->loadTranslationsFrom(__DIR__.'/../lang', 'events');
+
+        Relation::morphMap([
+            'events_album' => Album::class,
+        ]);
 
         Event::listen(EnrollmentConfirmed::class, GenerateQrTokenOnConfirmed::class);
         Event::listen(CheckInRequested::class, HandleBotCheckIn::class);

--- a/app-modules/events/src/Gallery/Actions/CuratePhoto.php
+++ b/app-modules/events/src/Gallery/Actions/CuratePhoto.php
@@ -12,10 +12,10 @@ final class CuratePhoto
 {
     public function handle(Media $media, CuratePhotoData $data): Media
     {
-        $caption = $data->caption !== null ? mb_trim($data->caption) : null;
+        $caption = mb_trim($data->caption ?? '');
 
         $media
-            ->setCustomProperty(Photo::CAPTION, $caption !== '' ? $caption : null)
+            ->setCustomProperty(Photo::CAPTION, $caption === '' ? null : $caption)
             ->setCustomProperty(Photo::HIGHLIGHT, $data->highlight);
 
         $media->save();

--- a/app-modules/events/src/Gallery/Actions/CuratePhoto.php
+++ b/app-modules/events/src/Gallery/Actions/CuratePhoto.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Events\Gallery\Actions;
+
+use He4rt\Events\Gallery\DTOs\CuratePhotoData;
+use He4rt\Events\Gallery\DTOs\Photo;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+final class CuratePhoto
+{
+    public function handle(Media $media, CuratePhotoData $data): Media
+    {
+        $caption = $data->caption !== null ? mb_trim($data->caption) : null;
+
+        $media
+            ->setCustomProperty(Photo::CAPTION, $caption !== '' ? $caption : null)
+            ->setCustomProperty(Photo::HIGHLIGHT, $data->highlight);
+
+        $media->save();
+
+        return $media;
+    }
+}

--- a/app-modules/events/src/Gallery/DTOs/CuratePhotoData.php
+++ b/app-modules/events/src/Gallery/DTOs/CuratePhotoData.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Events\Gallery\DTOs;
+
+final readonly class CuratePhotoData
+{
+    public function __construct(
+        public ?string $caption,
+        public bool $highlight,
+    ) {}
+}

--- a/app-modules/events/src/Gallery/DTOs/Photo.php
+++ b/app-modules/events/src/Gallery/DTOs/Photo.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Events\Gallery\DTOs;
+
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+/**
+ * Leitura tipada de uma foto de álbum. Legenda e destaque moram nas custom
+ * properties da mídia, e as chaves só existem aqui.
+ */
+final readonly class Photo
+{
+    public const string CAPTION = 'caption';
+
+    public const string HIGHLIGHT = 'highlight';
+
+    public function __construct(
+        public int $id,
+        public string $uuid,
+        public ?string $caption,
+        public bool $highlight,
+        public int $position,
+    ) {}
+
+    public static function fromMedia(Media $media): self
+    {
+        $caption = $media->getCustomProperty(self::CAPTION);
+
+        return new self(
+            id: (int) $media->getKey(),
+            uuid: (string) $media->uuid,
+            caption: is_string($caption) && $caption !== '' ? $caption : null,
+            highlight: (bool) $media->getCustomProperty(self::HIGHLIGHT, default: false),
+            position: (int) ($media->order_column ?? 0),
+        );
+    }
+}

--- a/app-modules/events/src/Gallery/Enums/PhotoConversion.php
+++ b/app-modules/events/src/Gallery/Enums/PhotoConversion.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Events\Gallery\Enums;
+
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasDescription;
+use Filament\Support\Contracts\HasLabel;
+use Spatie\Image\Enums\Fit;
+
+/**
+ * Fonte única das versões de uma foto de álbum: nome da conversão no media
+ * library, dimensão servida e como a imagem é enquadrada nela.
+ *
+ * Uma versão nova entra como mais um case e já nasce registrada na collection.
+ */
+enum PhotoConversion: string implements HasColor, HasDescription, HasLabel
+{
+    case Thumb = 'thumb';
+    case Large = 'large';
+
+    /**
+     * GIF fica de fora de propósito: foto de evento não é animação, e aceitá-lo
+     * exigiria o caminho "servido sem conversão" que o perfil precisou.
+     *
+     * @return list<string>
+     */
+    public static function mimeTypes(): array
+    {
+        return ['image/jpeg', 'image/png', 'image/webp'];
+    }
+
+    public static function maxKilobytes(): int
+    {
+        return 10_240;
+    }
+
+    public function width(): int
+    {
+        return match ($this) {
+            self::Thumb => 640,
+            self::Large => 1_920,
+        };
+    }
+
+    public function height(): int
+    {
+        return match ($this) {
+            self::Thumb => 480,
+            self::Large => 1_920,
+        };
+    }
+
+    /**
+     * A miniatura é recortada para todos os cards terem a mesma proporção; a
+     * ampliada só é limitada, preservando o enquadramento original.
+     */
+    public function fit(): Fit
+    {
+        return match ($this) {
+            self::Thumb => Fit::Crop,
+            self::Large => Fit::Max,
+        };
+    }
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Thumb => __('events::enums.photo_conversion.thumb'),
+            self::Large => __('events::enums.photo_conversion.large'),
+        };
+    }
+
+    public function getColor(): string
+    {
+        return match ($this) {
+            self::Thumb => 'gray',
+            self::Large => 'primary',
+        };
+    }
+
+    public function getDescription(): string
+    {
+        return match ($this) {
+            self::Thumb => __('events::enums.photo_conversion.thumb_description'),
+            self::Large => __('events::enums.photo_conversion.large_description'),
+        };
+    }
+}

--- a/app-modules/events/src/Gallery/Enums/PhotoConversion.php
+++ b/app-modules/events/src/Gallery/Enums/PhotoConversion.php
@@ -8,6 +8,7 @@ use Filament\Support\Contracts\HasColor;
 use Filament\Support\Contracts\HasDescription;
 use Filament\Support\Contracts\HasLabel;
 use Spatie\Image\Enums\Fit;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 /**
  * Fonte única das versões de uma foto de álbum: nome da conversão no media
@@ -62,6 +63,17 @@ enum PhotoConversion: string implements HasColor, HasDescription, HasLabel
             self::Thumb => Fit::Crop,
             self::Large => Fit::Max,
         };
+    }
+
+    /**
+     * As conversões rodam em fila. Até a desta versão existir, quem exibe
+     * recebe o arquivo original em vez de um link quebrado.
+     */
+    public function urlFor(Media $media): string
+    {
+        return $media->hasGeneratedConversion($this->value)
+            ? $media->getUrl($this->value)
+            : $media->getUrl();
     }
 
     public function getLabel(): string

--- a/app-modules/events/src/Gallery/Models/Album.php
+++ b/app-modules/events/src/Gallery/Models/Album.php
@@ -119,9 +119,7 @@ final class Album extends Model implements HasMedia
     {
         $photos = $this->getMedia(self::PHOTOS);
 
-        $flagged = $photos->filter(
-            fn (Media $media): bool => (bool) $media->getCustomProperty(Photo::HIGHLIGHT, default: false),
-        );
+        $flagged = $photos->filter(fn (Media $media): bool => Photo::fromMedia($media)->highlight);
 
         $chosen = $flagged->isNotEmpty() ? $flagged : $photos->take(self::CARD_HIGHLIGHTS);
 

--- a/app-modules/events/src/Gallery/Models/Album.php
+++ b/app-modules/events/src/Gallery/Models/Album.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Events\Gallery\Models;
+
+use Carbon\Carbon;
+use He4rt\Events\Database\Factories\AlbumFactory;
+use He4rt\Events\Event\Models\Event;
+use He4rt\Events\Gallery\DTOs\Photo;
+use He4rt\Events\Gallery\Enums\PhotoConversion;
+use He4rt\Events\Gallery\Support\PhotosRelation;
+use Illuminate\Database\Eloquent\Attributes\Table;
+use Illuminate\Database\Eloquent\Attributes\UseFactory;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Collection;
+use Spatie\MediaLibrary\HasMedia;
+use Spatie\MediaLibrary\InteractsWithMedia;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+/**
+ * Um momento da comunidade em fotos. Pode apontar para um evento cadastrado,
+ * mas não precisa: confra, bastidores e encontros antigos também são álbuns.
+ *
+ * @property string $id
+ * @property string|null $event_id
+ * @property string $slug
+ * @property string $title
+ * @property string|null $location
+ * @property Carbon $happened_at
+ * @property string|null $description
+ * @property Carbon|null $published_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read int|null $photos_count
+ */
+#[UseFactory(factoryClass: AlbumFactory::class)]
+#[Table(name: 'events_albums')]
+final class Album extends Model implements HasMedia
+{
+    /** @use HasFactory<AlbumFactory> */
+    use HasFactory;
+    use HasUuids;
+    use InteractsWithMedia;
+
+    public const string PHOTOS = 'photos';
+
+    public const int CARD_HIGHLIGHTS = 3;
+
+    protected $fillable = [
+        'event_id',
+        'slug',
+        'title',
+        'location',
+        'happened_at',
+        'description',
+        'published_at',
+    ];
+
+    /**
+     * As conversões ficam em fila de propósito: um álbum chega em lote, e
+     * converter dezenas de fotos dentro do request estouraria o tempo dele.
+     * Quem exibe cai no original enquanto a conversão não existe.
+     */
+    public function registerMediaCollections(): void
+    {
+        $this->addMediaCollection(self::PHOTOS)
+            ->useDisk('public')
+            ->acceptsMimeTypes(PhotoConversion::mimeTypes())
+            ->registerMediaConversions(function (?Media $media = null): void {
+                foreach (PhotoConversion::cases() as $conversion) {
+                    $this->addMediaConversion($conversion->value)
+                        ->fit($conversion->fit(), $conversion->width(), $conversion->height())
+                        ->format('webp');
+                }
+            });
+    }
+
+    /** @return BelongsTo<Event, $this> */
+    public function event(): BelongsTo
+    {
+        return $this->belongsTo(Event::class);
+    }
+
+    /**
+     * Só as fotos, já na ordem do admin. Existe além de getMedia() para
+     * withCount('photos') e para o whereHas da listagem pública.
+     *
+     * @return PhotosRelation<Media, $this>
+     */
+    public function photos(): PhotosRelation
+    {
+        $media = $this->media()->getRelated();
+
+        $relation = new PhotosRelation(
+            $media->newQuery(),
+            $this,
+            $media->qualifyColumn('model_type'),
+            $media->qualifyColumn('model_id'),
+            $this->getKeyName(),
+        );
+
+        return $relation
+            ->where('collection_name', self::PHOTOS)
+            ->orderBy('order_column');
+    }
+
+    /**
+     * Fotos marcadas pela equipe para representar o álbum. Sem marcação, as
+     * primeiras da ordem, para o card nunca sair vazio.
+     *
+     * @return Collection<int, Media>
+     */
+    public function highlights(): Collection
+    {
+        $photos = $this->getMedia(self::PHOTOS);
+
+        $flagged = $photos->filter(
+            fn (Media $media): bool => (bool) $media->getCustomProperty(Photo::HIGHLIGHT, default: false),
+        );
+
+        $chosen = $flagged->isNotEmpty() ? $flagged : $photos->take(self::CARD_HIGHLIGHTS);
+
+        return $chosen->values();
+    }
+
+    public function cover(): ?Media
+    {
+        return $this->highlights()->first();
+    }
+
+    public function isPublished(): bool
+    {
+        return $this->published_at !== null && $this->published_at->isPast();
+    }
+
+    /** @param  Builder<self>  $query */
+    protected function scopePublished(Builder $query): void
+    {
+        $query->whereNotNull('published_at')->where('published_at', '<=', now());
+    }
+
+    /** @param  Builder<self>  $query */
+    protected function scopeWithPhotos(Builder $query): void
+    {
+        $query->whereHas('photos');
+    }
+
+    /** @param  Builder<self>  $query */
+    protected function scopeChronological(Builder $query): void
+    {
+        $query->latest('happened_at')->latest();
+    }
+
+    /** @return array<string, mixed> */
+    protected function casts(): array
+    {
+        return [
+            'happened_at' => 'date',
+            'published_at' => 'datetime',
+        ];
+    }
+}

--- a/app-modules/events/src/Gallery/Support/PhotosRelation.php
+++ b/app-modules/events/src/Gallery/Support/PhotosRelation.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Events\Gallery\Support;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Support\Facades\DB;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+/**
+ * MorphMany para a tabela `media` a partir de um dono com chave UUID.
+ *
+ * A tabela do media library guarda `model_id` como texto para servir a
+ * qualquer tipo de chave. Carregar a relação funciona, porque o valor vai
+ * como parâmetro. Já `whereHas` e `withCount` comparam coluna com coluna, e
+ * o Postgres não tem operador `uuid = varchar`. Aqui a chave do dono ganha o
+ * cast para texto nessa comparação.
+ *
+ * @template TRelatedModel of Media
+ * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ *
+ * @extends MorphMany<TRelatedModel, TDeclaringModel>
+ */
+final class PhotosRelation extends MorphMany
+{
+    /**
+     * @param  Builder<TRelatedModel>  $query
+     * @param  Builder<TDeclaringModel>  $parentQuery
+     * @param  array<int|string, mixed>  $columns
+     * @return Builder<TRelatedModel>
+     */
+    public function getRelationExistenceQuery(Builder $query, Builder $parentQuery, $columns = ['*']): Builder
+    {
+        $grammar = $query->getQuery()->getGrammar();
+
+        $parentKeyAsText = DB::raw($grammar->wrap($this->getQualifiedParentKeyName()).'::text');
+
+        return $query
+            ->select($columns)
+            ->whereColumn($parentKeyAsText, '=', $this->getExistenceCompareKey())
+            ->where($query->qualifyColumn($this->getMorphType()), $this->getMorphClass());
+    }
+}

--- a/app-modules/events/tests/Feature/Gallery/AlbumTest.php
+++ b/app-modules/events/tests/Feature/Gallery/AlbumTest.php
@@ -90,6 +90,12 @@ test('when an album has no photos, then the withPhotos scope excludes it', funct
     expect(Album::query()->published()->withPhotos()->pluck('id')->all())->toBe([$withPhotos->id]);
 });
 
+test('when the factory is asked for zero photos, then no media is created', function (): void {
+    $album = Album::factory()->withPhotos(0)->create();
+
+    expect($album->getMedia(Album::PHOTOS))->toBeEmpty();
+});
+
 test('when the linked event is deleted, then the album survives without an event', function (): void {
     $event = Event::factory()->create();
     $album = Album::factory()->forEvent($event)->create();

--- a/app-modules/events/tests/Feature/Gallery/AlbumTest.php
+++ b/app-modules/events/tests/Feature/Gallery/AlbumTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Events\Event\Models\Event;
+use He4rt\Events\Gallery\Actions\CuratePhoto;
+use He4rt\Events\Gallery\DTOs\CuratePhotoData;
+use He4rt\Events\Gallery\DTOs\Photo;
+use He4rt\Events\Gallery\Enums\PhotoConversion;
+use He4rt\Events\Gallery\Models\Album;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Spatie\MediaLibrary\MediaCollections\Exceptions\FileUnacceptableForCollection;
+
+beforeEach(function (): void {
+    Storage::fake('public');
+    runMediaConversionsInline();
+});
+
+test('when a photo is added, then thumb and large webp conversions are generated', function (): void {
+    $album = Album::factory()->create();
+
+    $album
+        ->addMedia(UploadedFile::fake()->image('foto.jpg', 1_600, 1_200))
+        ->toMediaCollection(Album::PHOTOS);
+
+    $media = $album->getFirstMedia(Album::PHOTOS);
+
+    expect($media)->not->toBeNull()
+        ->and($media->hasGeneratedConversion(PhotoConversion::Thumb->value))->toBeTrue()
+        ->and($media->hasGeneratedConversion(PhotoConversion::Large->value))->toBeTrue()
+        ->and($media->getUrl(PhotoConversion::Thumb->value))->toEndWith('.webp');
+});
+
+test('when a gif is added, then the photos collection rejects it', function (): void {
+    $album = Album::factory()->create();
+
+    $album
+        ->addMedia(UploadedFile::fake()->image('animada.gif'))
+        ->toMediaCollection(Album::PHOTOS);
+})->throws(FileUnacceptableForCollection::class);
+
+test('when nobody flagged a highlight, then the first three photos represent the album', function (): void {
+    $album = Album::factory()->withPhotos(5)->create();
+
+    $highlights = $album->highlights();
+
+    expect($highlights)->toHaveCount(Album::CARD_HIGHLIGHTS)
+        ->and($highlights->pluck('name')->all())->toBe(['foto-1', 'foto-2', 'foto-3']);
+});
+
+test('when photos are flagged as highlight, then only those represent the album', function (): void {
+    $album = Album::factory()->withPhotos(5)->create();
+    $photos = $album->getMedia(Album::PHOTOS);
+
+    $curate = resolve(CuratePhoto::class);
+    $curate->handle($photos[3], new CuratePhotoData(caption: 'Lightning talks', highlight: true));
+    $curate->handle($photos[4], new CuratePhotoData(caption: null, highlight: true));
+
+    $highlights = $album->fresh()->highlights();
+
+    expect($highlights->pluck('name')->all())->toBe(['foto-4', 'foto-5'])
+        ->and($album->fresh()->cover()?->name)->toBe('foto-4');
+});
+
+test('when curating with a blank caption, then the caption is stored as null', function (): void {
+    $album = Album::factory()->withPhotos(1)->create();
+    $media = $album->getFirstMedia(Album::PHOTOS);
+
+    resolve(CuratePhoto::class)->handle($media, new CuratePhotoData(caption: '   ', highlight: false));
+
+    $photo = Photo::fromMedia($media->fresh());
+
+    expect($photo->caption)->toBeNull()
+        ->and($photo->highlight)->toBeFalse();
+});
+
+test('when published_at is in the future, then the published scope excludes the album', function (): void {
+    $past = Album::factory()->published()->create();
+    Album::factory()->create(['published_at' => now()->addDay()]);
+    Album::factory()->create();
+
+    expect(Album::query()->published()->pluck('id')->all())->toBe([$past->id]);
+});
+
+test('when an album has no photos, then the withPhotos scope excludes it', function (): void {
+    $withPhotos = Album::factory()->published()->withPhotos(1)->create();
+    Album::factory()->published()->create();
+
+    expect(Album::query()->published()->withPhotos()->pluck('id')->all())->toBe([$withPhotos->id]);
+});
+
+test('when the linked event is deleted, then the album survives without an event', function (): void {
+    $event = Event::factory()->create();
+    $album = Album::factory()->forEvent($event)->create();
+
+    $event->delete();
+
+    expect($album->fresh()->event_id)->toBeNull();
+});

--- a/app-modules/panel-admin/lang/en/albums.php
+++ b/app-modules/panel-admin/lang/en/albums.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'label' => 'Album',
+    'plural' => 'Photo albums',
+
+    'columns' => [
+        'title' => 'Title',
+        'slug' => 'Slug',
+        'event' => 'Event',
+        'location' => 'Location',
+        'happened_at' => 'Happened on',
+        'description' => 'Description',
+        'published_at' => 'Published at',
+        'photos' => 'Photos',
+        'photos_count' => 'Photos',
+        'created_at' => 'Created at',
+    ],
+
+    'form' => [
+        'helpers' => [
+            'event' => 'Optional. Picking an event fills location and date when they are empty.',
+            'published_at' => 'Leave empty to keep the album as a draft, hidden from the portal.',
+            'photos' => 'Up to :max_files photos per upload, :max_mb MB each. JPG, PNG or WEBP.',
+        ],
+    ],
+
+    'filters' => [
+        'published' => 'Published',
+        'drafts' => 'Drafts',
+    ],
+
+    'photos' => [
+        'title' => 'Photos',
+        'empty' => 'Upload photos through the "Photos" field in the form above.',
+        'columns' => [
+            'preview' => 'Preview',
+            'highlight' => 'Highlight',
+            'caption' => 'Caption',
+            'size' => 'Size',
+            'uploaded_at' => 'Uploaded at',
+        ],
+    ],
+];

--- a/app-modules/panel-admin/lang/pt_BR/albums.php
+++ b/app-modules/panel-admin/lang/pt_BR/albums.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'label' => 'Álbum',
+    'plural' => 'Álbuns de fotos',
+
+    'columns' => [
+        'title' => 'Título',
+        'slug' => 'Slug',
+        'event' => 'Evento',
+        'location' => 'Local',
+        'happened_at' => 'Aconteceu em',
+        'description' => 'Descrição',
+        'published_at' => 'Publicado em',
+        'photos' => 'Fotos',
+        'photos_count' => 'Fotos',
+        'created_at' => 'Criado em',
+    ],
+
+    'form' => [
+        'helpers' => [
+            'event' => 'Opcional. Escolher um evento preenche local e data, se estiverem vazios.',
+            'published_at' => 'Vazio mantém o álbum como rascunho, fora do portal.',
+            'photos' => 'Até :max_files fotos por vez, :max_mb MB cada. JPG, PNG ou WEBP.',
+        ],
+    ],
+
+    'filters' => [
+        'published' => 'Publicados',
+        'drafts' => 'Rascunhos',
+    ],
+
+    'photos' => [
+        'title' => 'Fotos',
+        'empty' => 'Envie fotos pelo campo "Fotos" do formulário acima.',
+        'columns' => [
+            'preview' => 'Prévia',
+            'highlight' => 'Destaque',
+            'caption' => 'Legenda',
+            'size' => 'Tamanho',
+            'uploaded_at' => 'Enviada em',
+        ],
+    ],
+];

--- a/app-modules/panel-admin/src/Filament/Resources/Albums/AlbumResource.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Albums/AlbumResource.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\PanelAdmin\Filament\Resources\Albums;
+
+use BackedEnum;
+use Filament\Resources\Pages\PageRegistration;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+use He4rt\Events\Gallery\Models\Album;
+use He4rt\PanelAdmin\Filament\Resources\Albums\Pages\CreateAlbum;
+use He4rt\PanelAdmin\Filament\Resources\Albums\Pages\EditAlbum;
+use He4rt\PanelAdmin\Filament\Resources\Albums\Pages\ListAlbums;
+use He4rt\PanelAdmin\Filament\Resources\Albums\RelationManagers\PhotosRelationManager;
+use He4rt\PanelAdmin\Filament\Resources\Albums\Schemas\AlbumForm;
+use He4rt\PanelAdmin\Filament\Resources\Albums\Tables\AlbumsTable;
+
+final class AlbumResource extends Resource
+{
+    protected static ?string $model = Album::class;
+
+    protected static ?string $slug = 'albums';
+
+    protected static ?string $recordTitleAttribute = 'title';
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedPhoto;
+
+    public static function getNavigationLabel(): string
+    {
+        return __('panel-admin::albums.plural');
+    }
+
+    public static function getModelLabel(): string
+    {
+        return __('panel-admin::albums.label');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return __('panel-admin::albums.plural');
+    }
+
+    public static function form(Schema $schema): Schema
+    {
+        return AlbumForm::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return AlbumsTable::table($table);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            PhotosRelationManager::class,
+        ];
+    }
+
+    /**
+     * @return array<string, PageRegistration>
+     */
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListAlbums::route('/'),
+            'create' => CreateAlbum::route('/create'),
+            'edit' => EditAlbum::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app-modules/panel-admin/src/Filament/Resources/Albums/Pages/CreateAlbum.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Albums/Pages/CreateAlbum.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\PanelAdmin\Filament\Resources\Albums\Pages;
+
+use Filament\Resources\Pages\CreateRecord;
+use He4rt\PanelAdmin\Filament\Resources\Albums\AlbumResource;
+
+final class CreateAlbum extends CreateRecord
+{
+    protected static string $resource = AlbumResource::class;
+}

--- a/app-modules/panel-admin/src/Filament/Resources/Albums/Pages/EditAlbum.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Albums/Pages/EditAlbum.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\PanelAdmin\Filament\Resources\Albums\Pages;
+
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+use He4rt\PanelAdmin\Filament\Resources\Albums\AlbumResource;
+
+final class EditAlbum extends EditRecord
+{
+    protected static string $resource = AlbumResource::class;
+
+    /**
+     * @return DeleteAction[]
+     */
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/app-modules/panel-admin/src/Filament/Resources/Albums/Pages/ListAlbums.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Albums/Pages/ListAlbums.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\PanelAdmin\Filament\Resources\Albums\Pages;
+
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+use He4rt\PanelAdmin\Filament\Resources\Albums\AlbumResource;
+
+final class ListAlbums extends ListRecords
+{
+    protected static string $resource = AlbumResource::class;
+
+    /**
+     * @return CreateAction[]
+     */
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app-modules/panel-admin/src/Filament/Resources/Albums/RelationManagers/PhotosRelationManager.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Albums/RelationManagers/PhotosRelationManager.php
@@ -46,7 +46,7 @@ final class PhotosRelationManager extends RelationManager
             ->columns([
                 ImageColumn::make('preview')
                     ->label(__('panel-admin::albums.photos.columns.preview'))
-                    ->state(fn (Media $record): string => $this->previewUrl($record))
+                    ->state(fn (Media $record): string => PhotoConversion::Thumb->urlFor($record))
                     ->imageHeight(64)
                     ->square(),
 
@@ -88,12 +88,5 @@ final class PhotosRelationManager extends RelationManager
                     DeleteBulkAction::make(),
                 ]),
             ]);
-    }
-
-    private function previewUrl(Media $media): string
-    {
-        $thumb = PhotoConversion::Thumb->value;
-
-        return $media->hasGeneratedConversion($thumb) ? $media->getUrl($thumb) : $media->getUrl();
     }
 }

--- a/app-modules/panel-admin/src/Filament/Resources/Albums/RelationManagers/PhotosRelationManager.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Albums/RelationManagers/PhotosRelationManager.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\PanelAdmin\Filament\Resources\Albums\RelationManagers;
+
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables\Columns\ImageColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Columns\TextInputColumn;
+use Filament\Tables\Columns\ToggleColumn;
+use Filament\Tables\Table;
+use He4rt\Events\Gallery\Actions\CuratePhoto;
+use He4rt\Events\Gallery\DTOs\CuratePhotoData;
+use He4rt\Events\Gallery\DTOs\Photo;
+use He4rt\Events\Gallery\Enums\PhotoConversion;
+use He4rt\Events\Gallery\Models\Album;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+/**
+ * Curadoria das fotos de um álbum: destaque, legenda e ordem. O upload em si
+ * acontece no formulário do álbum.
+ */
+final class PhotosRelationManager extends RelationManager
+{
+    protected static string $relationship = 'media';
+
+    public static function getTitle(Model $ownerRecord, string $pageClass): string
+    {
+        return __('panel-admin::albums.photos.title');
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->modifyQueryUsing(fn (Builder $query): Builder => $query->where('collection_name', Album::PHOTOS))
+            ->defaultSort('order_column')
+            ->reorderable('order_column')
+            ->paginated(condition: false)
+            ->emptyStateHeading(__('panel-admin::albums.photos.empty'))
+            ->columns([
+                ImageColumn::make('preview')
+                    ->label(__('panel-admin::albums.photos.columns.preview'))
+                    ->state(fn (Media $record): string => $this->previewUrl($record))
+                    ->imageHeight(64)
+                    ->square(),
+
+                ToggleColumn::make('highlight')
+                    ->label(__('panel-admin::albums.photos.columns.highlight'))
+                    ->state(fn (Media $record): bool => Photo::fromMedia($record)->highlight)
+                    ->updateStateUsing(function (Media $record, bool $state): void {
+                        resolve(CuratePhoto::class)->handle($record, new CuratePhotoData(
+                            caption: Photo::fromMedia($record)->caption,
+                            highlight: $state,
+                        ));
+                    }),
+
+                TextInputColumn::make('caption')
+                    ->label(__('panel-admin::albums.photos.columns.caption'))
+                    ->state(fn (Media $record): ?string => Photo::fromMedia($record)->caption)
+                    ->rules(['nullable', 'string', 'max:140'])
+                    ->updateStateUsing(function (Media $record, ?string $state): void {
+                        resolve(CuratePhoto::class)->handle($record, new CuratePhotoData(
+                            caption: $state,
+                            highlight: Photo::fromMedia($record)->highlight,
+                        ));
+                    }),
+
+                TextColumn::make('size')
+                    ->label(__('panel-admin::albums.photos.columns.size'))
+                    ->state(fn (Media $record): string => $record->human_readable_size),
+
+                TextColumn::make('created_at')
+                    ->label(__('panel-admin::albums.photos.columns.uploaded_at'))
+                    ->dateTime('d/m H:i')
+                    ->timezone(config()->string('app.display_timezone')),
+            ])
+            ->recordActions([
+                DeleteAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    private function previewUrl(Media $media): string
+    {
+        $thumb = PhotoConversion::Thumb->value;
+
+        return $media->hasGeneratedConversion($thumb) ? $media->getUrl($thumb) : $media->getUrl();
+    }
+}

--- a/app-modules/panel-admin/src/Filament/Resources/Albums/Schemas/AlbumForm.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Albums/Schemas/AlbumForm.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\PanelAdmin\Filament\Resources\Albums\Schemas;
+
+use App\Support\UploadLimit;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Components\Utilities\Set;
+use Filament\Schemas\Schema;
+use He4rt\Events\Event\Models\Event;
+use He4rt\Events\Gallery\Enums\PhotoConversion;
+use He4rt\Events\Gallery\Models\Album;
+use Illuminate\Support\Str;
+
+final class AlbumForm
+{
+    public const int MAX_PHOTOS_PER_UPLOAD = 100;
+
+    public static function configure(Schema $schema): Schema
+    {
+        $maxKilobytes = UploadLimit::kilobytes(PhotoConversion::maxKilobytes());
+
+        return $schema
+            ->columns(2)
+            ->components([
+                TextInput::make('title')
+                    ->label(__('panel-admin::albums.columns.title'))
+                    ->required()
+                    ->maxLength(200)
+                    ->live(onBlur: true)
+                    ->afterStateUpdated(function (Set $set, Get $get, ?string $state): void {
+                        if (blank($get('slug'))) {
+                            $set('slug', Str::slug($state ?? ''));
+                        }
+                    })
+                    ->columnSpanFull(),
+
+                TextInput::make('slug')
+                    ->label(__('panel-admin::albums.columns.slug'))
+                    ->required()
+                    ->maxLength(120)
+                    ->alphaDash()
+                    ->unique(
+                        table: Album::class,
+                        column: 'slug',
+                        ignoreRecord: true,
+                    ),
+
+                Select::make('event_id')
+                    ->label(__('panel-admin::albums.columns.event'))
+                    ->relationship('event', 'title')
+                    ->searchable()
+                    ->preload()
+                    ->nullable()
+                    ->live()
+                    ->afterStateUpdated(function (?string $state, Get $get, Set $set): void {
+                        $event = $state !== null ? Event::query()->find($state) : null;
+
+                        if (!$event instanceof Event) {
+                            return;
+                        }
+
+                        if (blank($get('location'))) {
+                            $set('location', $event->location);
+                        }
+
+                        if (blank($get('happened_at'))) {
+                            $set('happened_at', $event->starts_at->toDateString());
+                        }
+                    })
+                    ->helperText(__('panel-admin::albums.form.helpers.event')),
+
+                DatePicker::make('happened_at')
+                    ->label(__('panel-admin::albums.columns.happened_at'))
+                    ->required()
+                    ->native(condition: false)
+                    ->displayFormat('d/m/Y')
+                    ->maxDate(now()),
+
+                TextInput::make('location')
+                    ->label(__('panel-admin::albums.columns.location'))
+                    ->nullable()
+                    ->maxLength(255),
+
+                Textarea::make('description')
+                    ->label(__('panel-admin::albums.columns.description'))
+                    ->nullable()
+                    ->maxLength(2_000)
+                    ->rows(3)
+                    ->columnSpanFull(),
+
+                DateTimePicker::make('published_at')
+                    ->label(__('panel-admin::albums.columns.published_at'))
+                    ->nullable()
+                    ->seconds(condition: false)
+                    ->timezone(config()->string('app.display_timezone'))
+                    ->helperText(__('panel-admin::albums.form.helpers.published_at'))
+                    ->columnSpanFull(),
+
+                // Sem imageAspectRatio() nem redimensionamento no browser: quem
+                // enquadra é a conversão no servidor (ver ProfilePage, #458).
+                SpatieMediaLibraryFileUpload::make('photos')
+                    ->label(__('panel-admin::albums.columns.photos'))
+                    ->collection(Album::PHOTOS)
+                    ->conversion(PhotoConversion::Thumb->value)
+                    ->multiple()
+                    ->reorderable()
+                    ->appendFiles()
+                    ->image()
+                    ->imageAspectRatio(ratio: null)
+                    ->automaticallyCropImagesToAspectRatio(condition: false)
+                    ->automaticallyResizeImagesToWidth(width: null)
+                    ->automaticallyResizeImagesToHeight(height: null)
+                    ->acceptedFileTypes(PhotoConversion::mimeTypes())
+                    ->maxSize($maxKilobytes)
+                    ->maxFiles(self::MAX_PHOTOS_PER_UPLOAD)
+                    ->panelLayout('grid')
+                    ->helperText(__('panel-admin::albums.form.helpers.photos', [
+                        'max_files' => self::MAX_PHOTOS_PER_UPLOAD,
+                        'max_mb' => round($maxKilobytes / 1_024, 1),
+                    ]))
+                    ->columnSpanFull(),
+            ]);
+    }
+}

--- a/app-modules/panel-admin/src/Filament/Resources/Albums/Tables/AlbumsTable.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Albums/Tables/AlbumsTable.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\PanelAdmin\Filament\Resources\Albums\Tables;
+
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Tables\Columns\SpatieMediaLibraryImageColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\TernaryFilter;
+use Filament\Tables\Table;
+use He4rt\Events\Gallery\Enums\PhotoConversion;
+use He4rt\Events\Gallery\Models\Album;
+
+final class AlbumsTable
+{
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->defaultSort('happened_at', 'desc')
+            ->columns([
+                SpatieMediaLibraryImageColumn::make('photos')
+                    ->label(__('panel-admin::albums.columns.photos'))
+                    ->collection(Album::PHOTOS)
+                    ->conversion(PhotoConversion::Thumb->value)
+                    ->stacked()
+                    ->limit(3)
+                    ->limitedRemainingText(),
+
+                TextColumn::make('title')
+                    ->label(__('panel-admin::albums.columns.title'))
+                    ->description(fn (Album $record): ?string => $record->location)
+                    ->searchable()
+                    ->sortable(),
+
+                TextColumn::make('event.title')
+                    ->label(__('panel-admin::albums.columns.event'))
+                    ->placeholder('—')
+                    ->toggleable(),
+
+                TextColumn::make('happened_at')
+                    ->label(__('panel-admin::albums.columns.happened_at'))
+                    ->date('d/m/Y')
+                    ->sortable(),
+
+                TextColumn::make('photos_count')
+                    ->label(__('panel-admin::albums.columns.photos_count'))
+                    ->counts('photos')
+                    ->badge(),
+
+                TextColumn::make('published_at')
+                    ->label(__('panel-admin::albums.columns.published_at'))
+                    ->dateTime('d/m/Y H:i')
+                    ->timezone(config()->string('app.display_timezone'))
+                    ->placeholder(__('panel-admin::albums.filters.drafts'))
+                    ->sortable(),
+
+                TextColumn::make('created_at')
+                    ->label(__('panel-admin::albums.columns.created_at'))
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                TernaryFilter::make('published')
+                    ->label(__('panel-admin::albums.columns.published_at'))
+                    ->nullable()
+                    ->attribute('published_at')
+                    ->trueLabel(__('panel-admin::albums.filters.published'))
+                    ->falseLabel(__('panel-admin::albums.filters.drafts')),
+            ])
+            ->recordActions([
+                EditAction::make(),
+                DeleteAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+}

--- a/app-modules/panel-admin/src/Filament/Resources/Albums/Tables/AlbumsTable.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Albums/Tables/AlbumsTable.php
@@ -14,6 +14,7 @@ use Filament\Tables\Filters\TernaryFilter;
 use Filament\Tables\Table;
 use He4rt\Events\Gallery\Enums\PhotoConversion;
 use He4rt\Events\Gallery\Models\Album;
+use Illuminate\Database\Eloquent\Builder;
 
 final class AlbumsTable
 {
@@ -67,8 +68,10 @@ final class AlbumsTable
             ->filters([
                 TernaryFilter::make('published')
                     ->label(__('panel-admin::albums.columns.published_at'))
-                    ->nullable()
-                    ->attribute('published_at')
+                    ->queries(
+                        true: self::onlyPublished(...),
+                        false: self::onlyDrafts(...),
+                    )
                     ->trueLabel(__('panel-admin::albums.filters.published'))
                     ->falseLabel(__('panel-admin::albums.filters.drafts')),
             ])
@@ -81,5 +84,26 @@ final class AlbumsTable
                     DeleteBulkAction::make(),
                 ]),
             ]);
+    }
+
+    /**
+     * Mesma regra de `Album::scopePublished()`: um agendado para o futuro ainda
+     * não está publicado.
+     *
+     * @param  Builder<Album>  $query
+     * @return Builder<Album>
+     */
+    private static function onlyPublished(Builder $query): Builder
+    {
+        return $query->published();
+    }
+
+    /**
+     * @param  Builder<Album>  $query
+     * @return Builder<Album>
+     */
+    private static function onlyDrafts(Builder $query): Builder
+    {
+        return $query->whereNull('published_at');
     }
 }

--- a/app-modules/panel-admin/src/PanelAdminServiceProvider.php
+++ b/app-modules/panel-admin/src/PanelAdminServiceProvider.php
@@ -13,6 +13,7 @@ use Filament\Support\Facades\FilamentAsset;
 use He4rt\PanelAdmin\Contributions\Widgets\ActivityTimelineWidget;
 use He4rt\PanelAdmin\Discord\DiscordCluster;
 use He4rt\PanelAdmin\Enums\NavigationGroup as NavGroup;
+use He4rt\PanelAdmin\Filament\Resources\Albums\AlbumResource;
 use He4rt\PanelAdmin\Filament\Resources\ContentEntries\ContentEntryResource;
 use He4rt\PanelAdmin\Filament\Resources\Events\EventResource;
 use He4rt\PanelAdmin\Filament\Resources\ExternalIdentities\ExternalIdentityResource;
@@ -64,6 +65,7 @@ class PanelAdminServiceProvider extends ServiceProvider
                     ContentEntryResource::class,
                     InteractionResource::class,
                     RetrospectiveResource::class,
+                    AlbumResource::class,
                 ])
                 ->discoverResources(
                     in: __DIR__.'/Moderation/Resources',
@@ -176,6 +178,7 @@ class PanelAdminServiceProvider extends ServiceProvider
                         ...ContentEntryResource::getNavigationItems(),
                         ...InteractionResource::getNavigationItems(),
                         ...RetrospectiveResource::getNavigationItems(),
+                        ...AlbumResource::getNavigationItems(),
                     ]),
             ]);
     }

--- a/app-modules/panel-admin/tests/Feature/Albums/AlbumResourceTest.php
+++ b/app-modules/panel-admin/tests/Feature/Albums/AlbumResourceTest.php
@@ -65,6 +65,17 @@ test('o filtro de publicados esconde os rascunhos', function (): void {
         ->assertCanNotSeeTableRecords([$draft]);
 });
 
+test('o filtro de publicados esconde os agendados para o futuro', function (): void {
+    $published = Album::factory()->published()->create();
+    $scheduled = Album::factory()->scheduled()->create();
+
+    livewire(ListAlbums::class)
+        ->loadTable()
+        ->filterTable('published', true)
+        ->assertCanSeeTableRecords([$published])
+        ->assertCanNotSeeTableRecords([$scheduled]);
+});
+
 test('cria um álbum com fotos em lote na collection de fotos', function (): void {
     livewire(CreateAlbum::class)
         ->fillForm(albumFormData([

--- a/app-modules/panel-admin/tests/Feature/Albums/AlbumResourceTest.php
+++ b/app-modules/panel-admin/tests/Feature/Albums/AlbumResourceTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Facades\Filament;
+use He4rt\Events\Event\Models\Event;
+use He4rt\Events\Gallery\DTOs\Photo;
+use He4rt\Events\Gallery\Models\Album;
+use He4rt\Identity\User\Models\User;
+use He4rt\PanelAdmin\Filament\Resources\Albums\Pages\CreateAlbum;
+use He4rt\PanelAdmin\Filament\Resources\Albums\Pages\EditAlbum;
+use He4rt\PanelAdmin\Filament\Resources\Albums\Pages\ListAlbums;
+use He4rt\PanelAdmin\Filament\Resources\Albums\RelationManagers\PhotosRelationManager;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(function (): void {
+    config([
+        'he4rt.admins' => 'danielhe4rt',
+        'app.display_timezone' => 'America/Sao_Paulo',
+    ]);
+
+    Storage::fake('public');
+    runMediaConversionsInline();
+
+    $this->admin = User::factory()->create(['username' => 'danielhe4rt']);
+
+    $this->actingAs($this->admin);
+
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+});
+
+/** @return array<string, mixed> */
+function albumFormData(array $overrides = []): array
+{
+    return [
+        'title' => 'Pub #2',
+        'slug' => 'pub-2',
+        'location' => 'Curitiba',
+        'happened_at' => '2025-08-15',
+        'description' => 'Mesa redonda sobre carreira e networking.',
+        ...$overrides,
+    ];
+}
+
+test('a listagem carrega para admin com os álbuns existentes', function (): void {
+    $albums = Album::factory()->count(3)->create();
+
+    livewire(ListAlbums::class)
+        ->loadTable()
+        ->assertOk()
+        ->assertCanSeeTableRecords($albums);
+});
+
+test('o filtro de publicados esconde os rascunhos', function (): void {
+    $published = Album::factory()->published()->create();
+    $draft = Album::factory()->create();
+
+    livewire(ListAlbums::class)
+        ->loadTable()
+        ->filterTable('published', true)
+        ->assertCanSeeTableRecords([$published])
+        ->assertCanNotSeeTableRecords([$draft]);
+});
+
+test('cria um álbum com fotos em lote na collection de fotos', function (): void {
+    livewire(CreateAlbum::class)
+        ->fillForm(albumFormData([
+            'photos' => [
+                UploadedFile::fake()->image('abertura.jpg', 1_600, 1_200),
+                UploadedFile::fake()->image('networking.jpg', 1_600, 1_200),
+            ],
+        ]))
+        ->call('create')
+        ->assertHasNoFormErrors()
+        ->assertRedirect();
+
+    $album = Album::query()->where('slug', 'pub-2')->sole();
+
+    expect($album->getMedia(Album::PHOTOS))->toHaveCount(2)
+        ->and($album->published_at)->toBeNull();
+});
+
+test('valida o formulário de criação', function (array $data, array $errors): void {
+    livewire(CreateAlbum::class)
+        ->fillForm(albumFormData($data))
+        ->call('create')
+        ->assertHasFormErrors($errors)
+        ->assertNoRedirect();
+})->with([
+    'título obrigatório' => [['title' => null], ['title' => 'required']],
+    'título com no máximo 200 caracteres' => [['title' => str_repeat('a', 201)], ['title' => 'max']],
+    'slug obrigatório' => [['slug' => null], ['slug' => 'required']],
+    'slug só com letras, números e traços' => [['slug' => 'pub 2!'], ['slug' => 'alpha_dash']],
+    'data obrigatória' => [['happened_at' => null], ['happened_at' => 'required']],
+]);
+
+test('rejeita slug repetido', function (): void {
+    Album::factory()->create(['slug' => 'pub-2']);
+
+    livewire(CreateAlbum::class)
+        ->fillForm(albumFormData())
+        ->call('create')
+        ->assertHasFormErrors(['slug' => 'unique']);
+});
+
+test('escolher um evento preenche local e data quando estão vazios', function (): void {
+    $event = Event::factory()->create([
+        'location' => 'São Paulo',
+        'starts_at' => '2025-03-20 19:00:00',
+        'ends_at' => '2025-03-20 22:00:00',
+    ]);
+
+    livewire(CreateAlbum::class)
+        ->fillForm(['title' => 'Pub #1', 'location' => null, 'happened_at' => null])
+        ->fillForm(['event_id' => $event->id])
+        ->assertSchemaStateSet([
+            'location' => 'São Paulo',
+            'happened_at' => '2025-03-20',
+        ]);
+});
+
+test('edita o título de um álbum', function (): void {
+    $album = Album::factory()->create();
+
+    livewire(EditAlbum::class, ['record' => $album->getRouteKey()])
+        ->fillForm(['title' => 'Confra de fim de ano'])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    expect($album->fresh()->title)->toBe('Confra de fim de ano');
+});
+
+test('a aba de fotos lista só as fotos do álbum', function (): void {
+    $album = Album::factory()->withPhotos(2)->create();
+
+    livewire(PhotosRelationManager::class, [
+        'ownerRecord' => $album,
+        'pageClass' => EditAlbum::class,
+    ])
+        ->loadTable()
+        ->assertOk()
+        ->assertCanSeeTableRecords($album->getMedia(Album::PHOTOS));
+});
+
+test('marcar destaque e legenda grava nas propriedades da foto', function (): void {
+    $album = Album::factory()->withPhotos(2)->create();
+    $photo = $album->getMedia(Album::PHOTOS)->last();
+
+    livewire(PhotosRelationManager::class, [
+        'ownerRecord' => $album,
+        'pageClass' => EditAlbum::class,
+    ])
+        ->call('updateTableColumnState', 'highlight', $photo->getKey(), true)
+        ->call('updateTableColumnState', 'caption', $photo->getKey(), 'Lightning talks');
+
+    $curated = Photo::fromMedia($photo->fresh());
+
+    expect($curated->highlight)->toBeTrue()
+        ->and($curated->caption)->toBe('Lightning talks')
+        ->and($album->fresh()->cover()?->getKey())->toBe($photo->getKey());
+});

--- a/app-modules/panel-admin/tests/Feature/NavigationGroupsTest.php
+++ b/app-modules/panel-admin/tests/Feature/NavigationGroupsTest.php
@@ -65,7 +65,7 @@ test('o grupo Pessoas reúne as quatro telas da aba', function (): void {
 test('a navegação padrão expõe o grupo Conteúdo com o que a comunidade publica', function (): void {
     $content = adminNavigationGroup(NavGroup::Content->getLabel());
 
-    expect(navigationItemLabels($content))->toBe(['Artigos', 'Contribuições', 'Retrospectivas']);
+    expect(navigationItemLabels($content))->toBe(['Artigos', 'Contribuições', 'Retrospectivas', 'Photo albums']);
 });
 
 test('os clusters seguem como itens de topo, fora de grupo', function (): void {

--- a/app-modules/portal/composer.json
+++ b/app-modules/portal/composer.json
@@ -5,7 +5,8 @@
     "version": "1.0",
     "license": "proprietary",
     "require": {
-        "he4rt/contents": "^1.0.0"
+        "he4rt/contents": "^1.0.0",
+        "he4rt/events": "^1.0.0"
     },
     "autoload": {
         "psr-4": {

--- a/app-modules/portal/resources/views/components/gallery/album-card.blade.php
+++ b/app-modules/portal/resources/views/components/gallery/album-card.blade.php
@@ -1,0 +1,57 @@
+@props(['album'])
+
+{{-- O link do título cobre o card inteiro (after:inset-0); o resto é decoração. --}}
+<article
+    class="border-outline-low bg-elevation-01dp hover:border-primary/60 relative grid gap-5 rounded-lg border p-5 transition-[border-color] lg:grid-cols-[220px_minmax(0,1fr)] lg:gap-8"
+>
+    <div class="flex flex-col gap-2">
+        <h2 class="text-text-high text-xl leading-tight font-bold">
+            <a
+                href="{{ route('gallery.album', ['slug' => $album->slug], absolute: false) }}"
+                class="focus-visible:outline-primary after:absolute after:inset-0 after:rounded-lg focus-visible:outline-2 focus-visible:outline-offset-2"
+            >
+                {{ $album->title }}
+            </a>
+        </h2>
+
+        <p class="text-text-medium text-sm leading-relaxed">
+            @if ($album->location)
+                {{ $album->location }}
+                <br />
+            @endif
+            <time datetime="{{ $album->happenedAt->toDateString() }}">{{ $album->happenedLabel() }}</time>
+        </p>
+
+        <span class="border-primary/32 bg-primary/5 text-primary mt-auto self-start rounded-md border px-2 py-0.5 font-mono text-xs">
+            {{ $album->photoCountLabel() }}
+        </span>
+    </div>
+
+    <div class="grid grid-cols-3 gap-3 sm:grid-cols-[repeat(3,minmax(0,1fr))_auto]">
+        @foreach ($album->highlights as $photo)
+            <figure class="relative overflow-hidden rounded-md">
+                <img
+                    src="{{ $photo->thumbUrl }}"
+                    alt="{{ $photo->caption ?? '' }}"
+                    loading="lazy"
+                    decoding="async"
+                    class="aspect-[4/3] w-full object-cover"
+                />
+                @if ($photo->caption)
+                    <figcaption class="absolute inset-x-0 bottom-0 truncate bg-gradient-to-t from-black/70 to-transparent px-2 pt-6 pb-1.5 text-xs text-white">
+                        {{ $photo->caption }}
+                    </figcaption>
+                @endif
+            </figure>
+        @endforeach
+
+        @if ($album->remaining() > 0)
+            <div
+                aria-hidden="true"
+                class="border-outline-low text-text-high flex aspect-[4/3] items-center justify-center rounded-md border border-dashed font-mono text-sm sm:aspect-auto sm:w-20"
+            >
+                +{{ $album->remaining() }}
+            </div>
+        @endif
+    </div>
+</article>

--- a/app-modules/portal/resources/views/components/gallery/lightbox.blade.php
+++ b/app-modules/portal/resources/views/components/gallery/lightbox.blade.php
@@ -1,0 +1,64 @@
+{{-- Overlay do lightbox. Vive dentro do x-data="galleryLightbox(...)" da página. --}}
+<div
+    x-show="open"
+    x-cloak
+    x-trap.noscroll="open"
+    x-on:keydown.window.escape="close()"
+    x-on:keydown.window.arrow-right="next()"
+    x-on:keydown.window.arrow-left="prev()"
+    x-on:touchstart.passive="touchStart($event)"
+    x-on:touchend="touchEnd($event)"
+    x-transition.opacity.duration.150ms
+    role="dialog"
+    aria-modal="true"
+    aria-label="Foto ampliada"
+    class="fixed inset-0 z-50 flex flex-col bg-black/95 text-white"
+    style="display: none"
+>
+    <div class="flex items-center justify-between px-4 py-3">
+        <span class="font-mono text-sm tabular-nums" x-text="(index + 1) + ' / ' + photos.length"></span>
+        <button
+            type="button"
+            x-on:click="close()"
+            class="rounded-md p-2 transition-colors hover:bg-white/10 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+            aria-label="Fechar"
+        >
+            <x-filament::icon icon="heroicon-o-x-mark" class="h-6 w-6" />
+        </button>
+    </div>
+
+    <div class="relative flex min-h-0 flex-1 items-center justify-center px-4" x-on:click.self="close()">
+        <button
+            type="button"
+            x-show="hasMany"
+            x-on:click="prev()"
+            class="absolute top-1/2 left-2 hidden -translate-y-1/2 rounded-full bg-black/50 p-3 transition-colors hover:bg-white/10 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white sm:block"
+            aria-label="Foto anterior"
+        >
+            <x-filament::icon icon="heroicon-o-chevron-left" class="h-6 w-6" />
+        </button>
+
+        <img
+            :src="current.l"
+            :alt="current.c ?? ''"
+            class="max-h-full max-w-full rounded-md object-contain select-none"
+            draggable="false"
+        />
+
+        <button
+            type="button"
+            x-show="hasMany"
+            x-on:click="next()"
+            class="absolute top-1/2 right-2 hidden -translate-y-1/2 rounded-full bg-black/50 p-3 transition-colors hover:bg-white/10 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white sm:block"
+            aria-label="Próxima foto"
+        >
+            <x-filament::icon icon="heroicon-o-chevron-right" class="h-6 w-6" />
+        </button>
+    </div>
+
+    <p
+        x-show="current.c"
+        x-text="current.c"
+        class="px-4 py-3 text-center text-sm text-white/80"
+    ></p>
+</div>

--- a/app-modules/portal/resources/views/components/navbar.blade.php
+++ b/app-modules/portal/resources/views/components/navbar.blade.php
@@ -6,6 +6,11 @@
             'active' => request()->routeIs('articles'),
         ],
         [
+            'label' => 'Galeria',
+            'href' => route('gallery', absolute: false),
+            'active' => request()->routeIs('gallery', 'gallery.album'),
+        ],
+        [
             'label' => 'Redes',
             'href' => route('social-links', absolute: false),
             'active' => request()->routeIs('social-links'),

--- a/app-modules/portal/resources/views/gallery-album.blade.php
+++ b/app-modules/portal/resources/views/gallery-album.blade.php
@@ -1,0 +1,154 @@
+<div x-data="galleryLightbox(@js($album->lightboxPayload()))" class="pb-20">
+    <section class="relative overflow-hidden pt-10 pb-8 lg:pt-14">
+        <div
+            aria-hidden="true"
+            class="pointer-events-none absolute inset-x-0 -top-24 -z-10 mx-auto h-64 max-w-4xl rounded-full opacity-60 blur-3xl"
+            style="background: radial-gradient(60% 120% at 50% 0%, color-mix(in oklab, var(--primary) 40%, transparent), transparent 70%)"
+        ></div>
+
+        <div class="hp-page">
+            <div class="flex max-w-3xl flex-col gap-5">
+                <a
+                    href="{{ route('gallery', absolute: false) }}"
+                    class="text-text-medium hover:text-text-high flex items-center gap-2 self-start font-mono text-xs tracking-[0.2em] uppercase transition-colors"
+                >
+                    <x-filament::icon icon="heroicon-s-arrow-left" class="h-3.5 w-3.5" />
+                    Galeria
+                </a>
+
+                <h1 class="text-text-high text-4xl leading-[1.08] font-bold tracking-tight lg:text-5xl">
+                    {{ $album->title }}
+                </h1>
+
+                <p class="text-text-medium flex flex-wrap items-center gap-x-3 gap-y-1 text-sm">
+                    <time datetime="{{ $album->happenedAt->toDateString() }}">{{ $album->happenedLabel() }}</time>
+                    @if ($album->location)
+                        <span aria-hidden="true" class="text-text-low">·</span>
+                        <span>{{ $album->location }}</span>
+                    @endif
+                    @if ($album->eventTitle)
+                        <span aria-hidden="true" class="text-text-low">·</span>
+                        <span>{{ $album->eventTitle }}</span>
+                    @endif
+                    <span aria-hidden="true" class="text-text-low">·</span>
+                    <span class="font-mono">{{ $album->photoCountLabel() }}</span>
+                </p>
+
+                @if ($album->description)
+                    <p class="text-text-medium max-w-xl text-base leading-relaxed">{{ $album->description }}</p>
+                @endif
+            </div>
+        </div>
+    </section>
+
+    <div class="hp-page">
+        <div class="grid gap-3 [grid-template-columns:repeat(auto-fill,minmax(180px,1fr))] sm:[grid-template-columns:repeat(auto-fill,minmax(220px,1fr))]">
+            @foreach ($album->photos as $index => $photo)
+                <button
+                    type="button"
+                    x-on:click="openAt({{ $index }})"
+                    class="group focus-visible:outline-primary relative overflow-hidden rounded-md focus-visible:outline-2 focus-visible:outline-offset-2"
+                    aria-label="Abrir foto {{ $index + 1 }} de {{ $album->photoCount() }}"
+                >
+                    <img
+                        src="{{ $photo->thumbUrl }}"
+                        alt="{{ $photo->caption ?? '' }}"
+                        loading="{{ $index < 8 ? 'eager' : 'lazy' }}"
+                        decoding="async"
+                        class="aspect-[4/3] w-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+                    />
+                    @if ($photo->caption)
+                        <span class="absolute inset-x-0 bottom-0 truncate bg-gradient-to-t from-black/70 to-transparent px-2 pt-6 pb-1.5 text-left text-xs text-white">
+                            {{ $photo->caption }}
+                        </span>
+                    @endif
+                </button>
+            @endforeach
+        </div>
+    </div>
+
+    <x-portal::gallery.lightbox />
+
+    @assets
+        <script>
+            document.addEventListener('alpine:init', () => {
+                // O lightbox lê a foto pela URL (?foto=N, base 1) para um link
+                // compartilhado abrir direto na imagem certa. replaceState evita
+                // encher o histórico: fechar o lightbox não pode virar "voltar".
+                Alpine.data('galleryLightbox', (photos) => ({
+                    photos,
+                    open: false,
+                    index: 0,
+                    touchStartX: null,
+
+                    init() {
+                        const requested = Number.parseInt(new URLSearchParams(window.location.search).get('foto'), 10)
+
+                        if (Number.isInteger(requested) && requested >= 1 && requested <= this.photos.length) {
+                            this.openAt(requested - 1)
+                        }
+                    },
+
+                    get current() {
+                        return this.photos[this.index] ?? { l: '', c: null }
+                    },
+
+                    get hasMany() {
+                        return this.photos.length > 1
+                    },
+
+                    openAt(index) {
+                        this.index = index
+                        this.open = true
+                        this.syncUrl()
+                        this.preload(index + 1)
+                    },
+
+                    close() {
+                        this.open = false
+                        this.syncUrl()
+                    },
+
+                    next() {
+                        if (!this.open || !this.hasMany) return
+                        this.index = (this.index + 1) % this.photos.length
+                        this.syncUrl()
+                        this.preload(this.index + 1)
+                    },
+
+                    prev() {
+                        if (!this.open || !this.hasMany) return
+                        this.index = (this.index - 1 + this.photos.length) % this.photos.length
+                        this.syncUrl()
+                        this.preload(this.index - 1)
+                    },
+
+                    syncUrl() {
+                        const url = new URL(window.location.href)
+                        this.open ? url.searchParams.set('foto', String(this.index + 1)) : url.searchParams.delete('foto')
+                        window.history.replaceState(window.history.state, '', url)
+                    },
+
+                    preload(index) {
+                        const photo = this.photos[(index + this.photos.length) % this.photos.length]
+                        if (!photo) return
+                        const image = new Image()
+                        image.src = photo.l
+                    },
+
+                    touchStart(event) {
+                        this.touchStartX = event.changedTouches[0].clientX
+                    },
+
+                    touchEnd(event) {
+                        if (this.touchStartX === null) return
+                        const delta = event.changedTouches[0].clientX - this.touchStartX
+                        this.touchStartX = null
+                        if (delta > 40) this.prev()
+                        else if (delta < -40) this.next()
+                    },
+                }))
+            })
+        </script>
+    @endassets
+</div>

--- a/app-modules/portal/resources/views/gallery.blade.php
+++ b/app-modules/portal/resources/views/gallery.blade.php
@@ -1,0 +1,49 @@
+<div class="pb-20">
+    <section class="relative overflow-hidden pt-10 pb-8 lg:pt-14">
+        {{-- glow da marca: assinatura do portal, sob o conteúdo --}}
+        <div
+            aria-hidden="true"
+            class="pointer-events-none absolute inset-x-0 -top-24 -z-10 mx-auto h-64 max-w-4xl rounded-full opacity-60 blur-3xl"
+            style="background: radial-gradient(60% 120% at 50% 0%, color-mix(in oklab, var(--primary) 40%, transparent), transparent 70%)"
+        ></div>
+
+        <div class="hp-page">
+            <div class="flex max-w-3xl flex-col gap-5">
+                <p class="text-text-medium flex items-center gap-3 font-mono text-xs tracking-[0.2em] uppercase">
+                    <span aria-hidden="true" class="bg-outline-low inline-block h-px w-8"></span>
+                    Galeria · fotos dos encontros
+                </p>
+
+                <h1 class="text-text-high text-4xl leading-[1.08] font-bold tracking-tight lg:text-5xl">
+                    O que acontece quando a gente sai do <span class="text-primary">Discord</span>.
+                </h1>
+
+                <p class="text-text-medium max-w-xl text-base leading-relaxed">
+                    Meetups, workshops, pubs e confraternizações da He4rt Developers, álbum por álbum. Abra um
+                    e veja quem estava lá.
+                </p>
+            </div>
+        </div>
+    </section>
+
+    <div class="hp-page flex flex-col gap-6">
+        @if ($albums === [])
+            {{-- A galeria é preenchida pelo painel. Até o primeiro álbum sair, a página
+                 diz isso em vez de ficar em branco. --}}
+            <div class="border-outline-low bg-elevation-01dp flex flex-col items-center gap-3 rounded-lg border border-dashed p-12 text-center">
+                <p class="text-text-high text-sm font-semibold">Ainda não há álbuns por aqui.</p>
+                <p class="text-text-medium max-w-sm text-xs">
+                    Os próximos encontros vão aparecer nesta página. Enquanto isso, acompanhe a agenda pelas
+                    nossas redes.
+                </p>
+                <x-he4rt::button :href="route('social-links', absolute: false)" size="sm" variant="outline">
+                    Ver nossas redes
+                </x-he4rt::button>
+            </div>
+        @else
+            @foreach ($albums as $album)
+                <x-portal::gallery.album-card :album="$album" />
+            @endforeach
+        @endif
+    </div>
+</div>

--- a/app-modules/portal/src/Gallery/AlbumFeed.php
+++ b/app-modules/portal/src/Gallery/AlbumFeed.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Portal\Gallery;
+
+use He4rt\Events\Gallery\Models\Album;
+use He4rt\Portal\Gallery\DTOs\AlbumCard;
+use He4rt\Portal\Gallery\DTOs\AlbumDetail;
+
+/**
+ * Read model da galeria pública.
+ *
+ * Só álbuns publicados e com pelo menos uma foto chegam aqui. A relação
+ * `media` inteira é carregada de propósito: é ela que o media library lê em
+ * getMedia(), então sem isso cada card dispararia uma query.
+ */
+final class AlbumFeed
+{
+    /** @return list<AlbumCard> */
+    public function albums(): array
+    {
+        $albums = Album::query()
+            ->published()
+            ->withPhotos()
+            ->chronological()
+            ->with('media')
+            ->withCount('photos')
+            ->get();
+
+        return array_values(
+            $albums->map(fn (Album $album): AlbumCard => AlbumCard::fromAlbum($album))->all(),
+        );
+    }
+
+    public function find(string $slug): ?AlbumDetail
+    {
+        $album = Album::query()
+            ->published()
+            ->withPhotos()
+            ->where('slug', $slug)
+            ->with(['media', 'event'])
+            ->first();
+
+        return $album instanceof Album ? AlbumDetail::fromAlbum($album) : null;
+    }
+}

--- a/app-modules/portal/src/Gallery/AlbumPage.php
+++ b/app-modules/portal/src/Gallery/AlbumPage.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Portal\Gallery;
+
+use He4rt\Portal\Gallery\DTOs\AlbumDetail;
+use He4rt\Portal\Gallery\DTOs\PhotoView;
+use Illuminate\Contracts\View\View;
+use Laravel\Head\Facades\Head;
+use Livewire\Attributes\Layout;
+use Livewire\Attributes\Locked;
+use Livewire\Component;
+
+/**
+ * Um álbum inteiro, com o lightbox. Rascunho e álbum sem foto não existem
+ * para quem está de fora: os dois respondem 404.
+ *
+ * O Livewire só serializa propriedades públicas escalares, então a página
+ * guarda o slug e resolve o DTO a cada render.
+ */
+#[Layout(name: 'portal::components.layouts.app')]
+final class AlbumPage extends Component
+{
+    #[Locked]
+    public string $slug;
+
+    private ?AlbumDetail $album = null;
+
+    public function mount(string $slug, AlbumFeed $feed): void
+    {
+        $this->slug = $slug;
+
+        $album = $this->album($feed);
+
+        // O <head> desta rota depende do álbum, então é montado aqui e não
+        // no withHead() da rota.
+        Head::title($album->title)
+            ->description($this->description($album));
+
+        if ($album->cover instanceof PhotoView) {
+            Head::ogImage($album->cover->largeUrl, alt: $album->title);
+        }
+    }
+
+    public function render(AlbumFeed $feed): View
+    {
+        return view('portal::gallery-album', [
+            'album' => $this->album($feed),
+        ]);
+    }
+
+    private function album(AlbumFeed $feed): AlbumDetail
+    {
+        $this->album ??= $feed->find($this->slug);
+
+        abort_unless($this->album instanceof AlbumDetail, 404);
+
+        return $this->album;
+    }
+
+    private function description(AlbumDetail $album): string
+    {
+        if ($album->description !== null && $album->description !== '') {
+            return $album->description;
+        }
+
+        return sprintf(
+            'Fotos do %s, %s. %s da comunidade He4rt Developers.',
+            $album->title,
+            $album->happenedLabel(),
+            $album->photoCountLabel(),
+        );
+    }
+}

--- a/app-modules/portal/src/Gallery/DTOs/AlbumCard.php
+++ b/app-modules/portal/src/Gallery/DTOs/AlbumCard.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Portal\Gallery\DTOs;
+
+use Carbon\CarbonImmutable;
+use He4rt\Events\Gallery\Models\Album;
+use Illuminate\Support\Str;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+final readonly class AlbumCard
+{
+    /**
+     * @param  list<PhotoView>  $highlights
+     */
+    public function __construct(
+        public string $slug,
+        public string $title,
+        public ?string $location,
+        public CarbonImmutable $happenedAt,
+        public int $photoCount,
+        public array $highlights,
+    ) {}
+
+    public static function fromAlbum(Album $album): self
+    {
+        return new self(
+            slug: $album->slug,
+            title: $album->title,
+            location: $album->location,
+            happenedAt: $album->happened_at->toImmutable(),
+            photoCount: $album->photos_count ?? $album->getMedia(Album::PHOTOS)->count(),
+            highlights: array_values(
+                $album->highlights()
+                    ->take(Album::CARD_HIGHLIGHTS)
+                    ->map(fn (Media $media): PhotoView => PhotoView::fromMedia($media))
+                    ->all(),
+            ),
+        );
+    }
+
+    public function remaining(): int
+    {
+        return max(0, $this->photoCount - count($this->highlights));
+    }
+
+    public function happenedLabel(): string
+    {
+        return Str::ucfirst($this->happenedAt->translatedFormat('F \d\e Y'));
+    }
+
+    public function photoCountLabel(): string
+    {
+        return sprintf('%d %s', $this->photoCount, Str::plural('foto', $this->photoCount));
+    }
+}

--- a/app-modules/portal/src/Gallery/DTOs/AlbumDetail.php
+++ b/app-modules/portal/src/Gallery/DTOs/AlbumDetail.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Portal\Gallery\DTOs;
+
+use Carbon\CarbonImmutable;
+use He4rt\Events\Gallery\Models\Album;
+use Illuminate\Support\Str;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+final readonly class AlbumDetail
+{
+    /**
+     * @param  list<PhotoView>  $photos
+     */
+    public function __construct(
+        public string $slug,
+        public string $title,
+        public ?string $location,
+        public CarbonImmutable $happenedAt,
+        public ?string $description,
+        public ?string $eventTitle,
+        public array $photos,
+        public ?PhotoView $cover,
+    ) {}
+
+    public static function fromAlbum(Album $album): self
+    {
+        $cover = $album->cover();
+
+        return new self(
+            slug: $album->slug,
+            title: $album->title,
+            location: $album->location,
+            happenedAt: $album->happened_at->toImmutable(),
+            description: $album->description,
+            eventTitle: $album->event?->title,
+            photos: array_values(
+                $album->getMedia(Album::PHOTOS)
+                    ->map(fn (Media $media): PhotoView => PhotoView::fromMedia($media))
+                    ->all(),
+            ),
+            cover: $cover instanceof Media ? PhotoView::fromMedia($cover) : null,
+        );
+    }
+
+    public function photoCount(): int
+    {
+        return count($this->photos);
+    }
+
+    public function happenedLabel(): string
+    {
+        return Str::ucfirst($this->happenedAt->translatedFormat('F \d\e Y'));
+    }
+
+    public function photoCountLabel(): string
+    {
+        return sprintf('%d %s', $this->photoCount(), Str::plural('foto', $this->photoCount()));
+    }
+
+    /**
+     * Payload mínimo do lightbox: a versão ampliada e a legenda de cada foto.
+     *
+     * @return list<array{l: string, c: string|null}>
+     */
+    public function lightboxPayload(): array
+    {
+        return array_map(
+            static fn (PhotoView $photo): array => ['l' => $photo->largeUrl, 'c' => $photo->caption],
+            $this->photos,
+        );
+    }
+}

--- a/app-modules/portal/src/Gallery/DTOs/PhotoView.php
+++ b/app-modules/portal/src/Gallery/DTOs/PhotoView.php
@@ -22,21 +22,10 @@ final readonly class PhotoView
         $photo = Photo::fromMedia($media);
 
         return new self(
-            thumbUrl: self::url($media, PhotoConversion::Thumb),
-            largeUrl: self::url($media, PhotoConversion::Large),
+            thumbUrl: PhotoConversion::Thumb->urlFor($media),
+            largeUrl: PhotoConversion::Large->urlFor($media),
             caption: $photo->caption,
             highlight: $photo->highlight,
         );
-    }
-
-    /**
-     * A conversão roda em fila. Até ela existir, o portal serve o original
-     * em vez de um link quebrado.
-     */
-    private static function url(Media $media, PhotoConversion $conversion): string
-    {
-        return $media->hasGeneratedConversion($conversion->value)
-            ? $media->getUrl($conversion->value)
-            : $media->getUrl();
     }
 }

--- a/app-modules/portal/src/Gallery/DTOs/PhotoView.php
+++ b/app-modules/portal/src/Gallery/DTOs/PhotoView.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Portal\Gallery\DTOs;
+
+use He4rt\Events\Gallery\DTOs\Photo;
+use He4rt\Events\Gallery\Enums\PhotoConversion;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+final readonly class PhotoView
+{
+    public function __construct(
+        public string $thumbUrl,
+        public string $largeUrl,
+        public ?string $caption,
+        public bool $highlight,
+    ) {}
+
+    public static function fromMedia(Media $media): self
+    {
+        $photo = Photo::fromMedia($media);
+
+        return new self(
+            thumbUrl: self::url($media, PhotoConversion::Thumb),
+            largeUrl: self::url($media, PhotoConversion::Large),
+            caption: $photo->caption,
+            highlight: $photo->highlight,
+        );
+    }
+
+    /**
+     * A conversão roda em fila. Até ela existir, o portal serve o original
+     * em vez de um link quebrado.
+     */
+    private static function url(Media $media, PhotoConversion $conversion): string
+    {
+        return $media->hasGeneratedConversion($conversion->value)
+            ? $media->getUrl($conversion->value)
+            : $media->getUrl();
+    }
+}

--- a/app-modules/portal/src/Gallery/GalleryPage.php
+++ b/app-modules/portal/src/Gallery/GalleryPage.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Portal\Gallery;
+
+use Illuminate\Contracts\View\View;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+/**
+ * Página pública da galeria: um card por álbum, do mais recente ao mais antigo.
+ */
+#[Layout(name: 'portal::components.layouts.app')]
+final class GalleryPage extends Component
+{
+    public function render(AlbumFeed $feed): View
+    {
+        return view('portal::gallery', [
+            'albums' => $feed->albums(),
+        ]);
+    }
+}

--- a/app-modules/portal/src/PortalServiceProvider.php
+++ b/app-modules/portal/src/PortalServiceProvider.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace He4rt\Portal;
 
 use He4rt\Portal\Articles\ArticlesPage;
+use He4rt\Portal\Gallery\AlbumPage;
+use He4rt\Portal\Gallery\GalleryPage;
 use He4rt\Portal\Home\HeroSection;
 use He4rt\Portal\Home\Homepage;
 use He4rt\Portal\Retrospective\CommunityRetrospectivePage;
@@ -64,6 +66,21 @@ class PortalServiceProvider extends ServiceProvider
                     title: 'Artigos da comunidade',
                     description: 'Os artigos publicados pela organização He4rt Developers no dev.to, por tema e por quem escreveu.',
                 );
+
+            Route::get('/galeria', GalleryPage::class)
+                ->name('gallery')
+                ->withHead(
+                    title: 'Galeria da comunidade',
+                    description: 'Fotos dos encontros da He4rt Developers: meetups, workshops, pubs e confraternizações, álbum por álbum.',
+                );
+
+            /*
+             * O <head> do álbum depende do registro (título, descrição, og:image),
+             * então o componente monta o head no mount() em vez de usar withHead().
+             */
+            Route::get('/galeria/{slug}', AlbumPage::class)
+                ->where('slug', '[a-z0-9-]+')
+                ->name('gallery.album');
 
             Route::get('/comunidade/retrospectiva', CommunityRetrospectivePage::class)
                 ->name('community.retrospective')

--- a/app-modules/portal/src/Sitemap/SitemapController.php
+++ b/app-modules/portal/src/Sitemap/SitemapController.php
@@ -25,6 +25,7 @@ final class SitemapController extends Controller
         'home' => ['changefreq' => 'daily', 'priority' => '1.0'],
         'social-links' => ['changefreq' => 'monthly', 'priority' => '0.6'],
         'community.retrospective' => ['changefreq' => 'weekly', 'priority' => '0.7'],
+        'gallery' => ['changefreq' => 'weekly', 'priority' => '0.7'],
     ];
 
     public function __invoke(): Response

--- a/app-modules/portal/tests/Feature/Gallery/GalleryPageTest.php
+++ b/app-modules/portal/tests/Feature/Gallery/GalleryPageTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Events\Event\Models\Event;
+use He4rt\Events\Gallery\Actions\CuratePhoto;
+use He4rt\Events\Gallery\DTOs\CuratePhotoData;
+use He4rt\Events\Gallery\Models\Album;
+use Illuminate\Support\Facades\Storage;
+
+use function Pest\Laravel\get;
+
+beforeEach(function (): void {
+    $this->withoutVite();
+
+    Storage::fake('public');
+    runMediaConversionsInline();
+});
+
+it('lista os álbuns publicados do mais recente ao mais antigo', function (): void {
+    Album::factory()->published()->withPhotos(2)->create([
+        'title' => 'Pub de fim de ano',
+        'happened_at' => '2025-12-13',
+    ]);
+    Album::factory()->published()->withPhotos(2)->create([
+        'title' => 'Meetup de março',
+        'happened_at' => '2025-03-20',
+    ]);
+
+    $html = get('/galeria')->assertOk()->getContent();
+
+    expect($html)
+        ->toContain('Pub de fim de ano')
+        ->toContain('Meetup de março');
+
+    expect(mb_strpos($html, 'Pub de fim de ano'))
+        ->toBeLessThan(mb_strpos($html, 'Meetup de março'));
+});
+
+it('mostra os destaques e quantas fotos ficaram de fora', function (): void {
+    $album = Album::factory()->published()->withPhotos(5)->create();
+
+    resolve(CuratePhoto::class)->handle(
+        $album->getMedia(Album::PHOTOS)->last(),
+        new CuratePhotoData(caption: 'Brinde final', highlight: true),
+    );
+
+    get('/galeria')
+        ->assertOk()
+        ->assertSee('Brinde final')
+        ->assertSee('5 fotos')
+        ->assertSee('+4');
+});
+
+it('esconde rascunhos e álbuns sem fotos', function (): void {
+    Album::factory()->withPhotos(2)->create(['title' => 'Rascunho secreto']);
+    Album::factory()->published()->create(['title' => 'Álbum vazio']);
+    Album::factory()->published()->withPhotos(1)->create(['title' => 'Álbum visível']);
+
+    get('/galeria')
+        ->assertOk()
+        ->assertSee('Álbum visível')
+        ->assertDontSee('Rascunho secreto')
+        ->assertDontSee('Álbum vazio');
+});
+
+it('explica quando ainda não há álbuns', function (): void {
+    get('/galeria')
+        ->assertOk()
+        ->assertSee('Ainda não há álbuns por aqui.');
+});
+
+it('abre um álbum com todas as fotos e o payload do lightbox', function (): void {
+    $event = Event::factory()->create(['title' => 'He4rt Meetup SP']);
+
+    $album = Album::factory()
+        ->published()
+        ->forEvent($event)
+        ->withPhotos(4)
+        ->create([
+            'slug' => 'meetup-sp-2025',
+            'title' => 'Meetup SP 2025',
+            'location' => 'São Paulo',
+            'description' => 'Primeira edição presencial do ano.',
+        ]);
+
+    resolve(CuratePhoto::class)->handle(
+        $album->getMedia(Album::PHOTOS)->first(),
+        new CuratePhotoData(caption: 'Abertura', highlight: false),
+    );
+
+    $html = get('/galeria/meetup-sp-2025')->assertOk()->getContent();
+
+    expect($html)
+        ->toContain('<title>Meetup SP 2025')
+        ->toContain('Primeira edição presencial do ano.')
+        ->toContain('He4rt Meetup SP')
+        ->toContain('São Paulo')
+        ->toContain('4 fotos')
+        ->toContain('Abrir foto 4 de 4')
+        ->toContain('galleryLightbox(')
+        ->toContain('Abertura')
+        ->toContain('<meta property="og:image"');
+});
+
+it('responde 404 para rascunho, álbum vazio e slug desconhecido', function (): void {
+    Album::factory()->withPhotos(1)->create(['slug' => 'rascunho']);
+    Album::factory()->published()->create(['slug' => 'vazio']);
+
+    get('/galeria/rascunho')->assertNotFound();
+    get('/galeria/vazio')->assertNotFound();
+    get('/galeria/nao-existe')->assertNotFound();
+});
+
+it('marca a galeria como ativa na navbar do álbum', function (): void {
+    Album::factory()->published()->withPhotos(1)->create(['slug' => 'ativo']);
+
+    get('/galeria/ativo')
+        ->assertOk()
+        ->assertSee('href="/galeria"', escape: false);
+});

--- a/app-modules/portal/tests/Feature/HomepageTest.php
+++ b/app-modules/portal/tests/Feature/HomepageTest.php
@@ -62,3 +62,9 @@ it('leva para o acervo pela navbar', function (): void {
         ->assertOk()
         ->assertSee('href="/artigos"', escape: false);
 });
+
+it('leva para a galeria pela navbar', function (): void {
+    get('/')
+        ->assertOk()
+        ->assertSee('href="/galeria"', escape: false);
+});

--- a/app-modules/portal/tests/Feature/PortalRoutesTest.php
+++ b/app-modules/portal/tests/Feature/PortalRoutesTest.php
@@ -23,6 +23,8 @@ it('serve as rotas do portal dentro do grupo web', function (string $name): void
 })->with([
     'community.retrospective',
     'community.retrospective.preview',
+    'gallery',
+    'gallery.album',
     'social-links',
 ]);
 

--- a/app-modules/portal/tests/Feature/SeoHeadTest.php
+++ b/app-modules/portal/tests/Feature/SeoHeadTest.php
@@ -125,6 +125,7 @@ it('serve um sitemap XML com as páginas públicas do portal', function (): void
         ->toContain('<?xml version="1.0" encoding="UTF-8"?>')
         ->toContain('<loc>'.route('home').'</loc>')
         ->toContain('<loc>'.route('social-links').'</loc>')
+        ->toContain('<loc>'.route('gallery').'</loc>')
         ->toContain('<loc>'.route('community.retrospective').'</loc>');
 });
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -49,7 +49,13 @@ expect()->extend('toBeOne', fn () => $this->toBe(1));
 |
 */
 
-function something(): void
+/**
+ * O media library despacha as conversões para a conexão de fila do ambiente e
+ * só depois do commit. Num teste, a fila é a real e a transação nunca comita,
+ * então as conversões precisam rodar na hora para existirem.
+ */
+function runMediaConversionsInline(): void
 {
-    // ..
+    config()->set('media-library.queue_connection_name', 'sync');
+    config()->set('media-library.queue_conversions_after_database_commit', value: false);
 }


### PR DESCRIPTION
## Contexto

A gente faz meetup, workshop, pub, confraternização... e as fotos ficam espalhadas em Drive, WhatsApp e Discord. Quem chega na comunidade não vê nada disso no site. A issue #504 pede uma galeria pra mostrar o que acontece quando a gente sai do Discord.

Esse PR entrega a primeira fase: um lugar único pra galera subir as fotos de cada encontro e uma página pública em `/galeria`. A Home fica como está (o carrossel é fase 2, tá anotado no `CONTEXT.md` do módulo).

Como funciona:

- O organizador cria um **álbum** no painel admin, sobe todas as fotos de uma vez (até 100 por upload) e, se quiser, marca até 3 como **destaque** e coloca legenda. Vincular a um `Event` é opcional: pub e confra não têm inscrição, mas têm foto.
- O álbum nasce rascunho. Só aparece no portal quando tem `published_at` no passado **e** pelo menos uma foto.
- No portal, `/galeria` lista os álbuns do mais recente pro mais antigo, com os destaques e o "+N" de fotos que ficaram de fora. `/galeria/{slug}` abre o álbum inteiro com lightbox (teclado, swipe, `?foto=N` pra compartilhar direto na imagem).

O domínio vive em `events/Gallery` como sub-domínio (ADR-0009 explica o porquê). Events não registra rota nem UI: `portal` é dono da borda pública, `panel-admin` do CRUD, no mesmo desenho do encurtador.

### Alterações

**events (domínio)**
- Migration `events_albums` (`event_id` opcional com `nullOnDelete`, `happened_at`, `published_at`, índice de ordenação pública).
- `Album` implementa `HasMedia` com a coleção `photos` (disco `public`, jpeg/png/webp até 10 MB, conversões `thumb` 640×480 e `large` 1920 em fila, saída webp).
- `PhotoConversion` (enum com os contratos Filament), `Photo` (DTO lido das custom properties `caption`/`highlight`), `CuratePhoto` + `CuratePhotoData`.
- `PhotosRelation`: `MorphMany` que faz o cast `uuid::text` no `whereHas`/`withCount`, porque `media.model_id` é varchar no Postgres.
- Morph map `events_album`, `AlbumFactory` com estados `published()`, `forEvent()`, `withPhotos()`.

**panel-admin**
- `AlbumResource` (Conteúdo → Álbuns de fotos): form com slug automático, pré-preenchimento de local/data a partir do evento, `SpatieMediaLibraryFileUpload` múltiplo e reordenável.
- `PhotosRelationManager`: grade das fotos com toggle de destaque, legenda inline (máx. 140), tamanho e reordenação por drag.
- Lang `albums.php` em pt_BR e en.

**portal**
- `AlbumFeed` (read model) + DTOs `AlbumCard`, `AlbumDetail`, `PhotoView` (cai pro original enquanto a conversão não existe).
- `GalleryPage` (`/galeria`) e `AlbumPage` (`/galeria/{slug}`, 404 pra rascunho/vazio, `<head>` e `og:image` montados a partir do álbum).
- Lightbox em Alpine (`@assets`), link "Galeria" na navbar, `gallery` no sitemap, `he4rt/events` no `composer.json` do módulo.

**docs**
- Glossário (Album, Photo, Highlight) e fronteiras no `CONTEXT.md` de events; linha e regra de dependência no `CONTEXT-MAP.md`; ADR-0009; plano em `events/docs/plans/2026-09-07-galeria-de-fotos.md`.

**tests**
- Helper `runMediaConversionsInline()` em `tests/Pest.php`: o Spatie lê `QUEUE_CONNECTION` direto e adia conversões pro commit da transação, que nunca acontece em teste. Sem isso, nenhuma conversão roda na suite.

---

## Plano de Testes

- [x] `vendor/bin/pint --dirty`
- [x] `vendor/bin/phpstan analyse` em `events`, `panel-admin` e `portal`
- [x] `vendor/bin/rector process` nos arquivos novos
- [x] `vendor/bin/pest --parallel` (suite completa)
- [x] `events/tests/Feature/Gallery/AlbumTest.php`: conversões, mime rejeitado, destaques e fallback, legenda em branco, escopos `published`/`withPhotos`, `nullOnDelete` do evento
- [x] `panel-admin/tests/Feature/Albums/AlbumResourceTest.php`: listagem, filtro, criação com upload, validação, slug único, pré-preenchimento pelo evento, edição, RM com destaque e legenda
- [x] `portal/tests/Feature/Gallery/GalleryPageTest.php`: ordem, destaques e "+N", rascunho/vazio escondidos, estado vazio, página do álbum com `<title>`, `og:image` e payload do lightbox, 404s, navbar
- [x] `PortalRoutesTest`, `HomepageTest` e `SeoHeadTest` cobrindo as rotas novas, o link da navbar e o sitemap

Pra testar na mão: criar um álbum em `/admin/albums`, subir fotos, marcar destaques na aba de fotos, preencher "Publicado em" e abrir `/galeria`. As conversões rodam em fila, então precisa de worker rodando (ou `QUEUE_CONNECTION=sync`) pra ver os thumbs em webp. Até lá o portal serve o original.

---

## Evidências

Sem print por enquanto. As telas do admin e do portal seguem os componentes já existentes (`SpatieMediaLibraryFileUpload`, `hp-page`, navbar).

---

## Issues Relacionadas

Closes #504
