### PR TITLE
feat(activity): enum TimelineReaction

### DIFF
--- a/app-modules/activity/database/migrations/2026_09_04_000001_create_activity_user_reactions_table.php
+++ b/app-modules/activity/database/migrations/2026_09_04_000001_create_activity_user_reactions_table.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use He4rt\Activity\Reaction\Enums\TimelineReaction;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -14,8 +15,7 @@ return new class extends Migration
             $table->uuid('id')->primary();
             $table->foreignUuid('user_id')->constrained('users');
             $table->foreignUuid('timeline_id')->constrained('activity_timeline')->cascadeOnDelete();
-            // TODO(#540): trocar pelo comment gerado por TimelineReaction::stringifyCases() quando o enum existir.
-            $table->string('reaction')->comment('like|love|laugh|celebrate|fire|sad');
+            $table->string('reaction')->comment(TimelineReaction::stringifyCases());
             $table->timestampsTz();
 
             $table->unique(['user_id', 'timeline_id'], 'activity_user_reactions_user_timeline_unique');

--- a/app-modules/activity/src/Reaction/Enums/TimelineReaction.php
+++ b/app-modules/activity/src/Reaction/Enums/TimelineReaction.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Activity\Reaction\Enums;
+
+use App\Enums\Concerns\StringifyEnum;
+use Filament\Support\Contracts\HasLabel;
+
+/**
+ * Conjunto fechado de reações da timeline web. O banco guarda só o value;
+ * rótulo e glifo vivem aqui e nunca são persistidos.
+ */
+enum TimelineReaction: string implements HasLabel
+{
+    use StringifyEnum;
+
+    case Like = 'like';
+    case Love = 'love';
+    case Laugh = 'laugh';
+    case Celebrate = 'celebrate';
+    case Fire = 'fire';
+    case Sad = 'sad';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Like => 'Curtir',
+            self::Love => 'Amei',
+            self::Laugh => 'Haha',
+            self::Celebrate => 'Parabéns',
+            self::Fire => 'Fogo',
+            self::Sad => 'Triste',
+        };
+    }
+
+    public function emoji(): string
+    {
+        return match ($this) {
+            self::Like => '👍',
+            self::Love => '❤️',
+            self::Laugh => '😂',
+            self::Celebrate => '🎉',
+            self::Fire => '🔥',
+            self::Sad => '😢',
+        };
+    }
+}

--- a/app-modules/activity/src/Reaction/Enums/TimelineReaction.php
+++ b/app-modules/activity/src/Reaction/Enums/TimelineReaction.php
@@ -67,7 +67,7 @@ enum TimelineReaction: string implements HasColor, HasDescription, HasLabel
         };
     }
 
-    public function emoji(): string
+    public function getEmoji(): string
     {
         return match ($this) {
             self::Like => '👍',

--- a/app-modules/activity/src/Reaction/Enums/TimelineReaction.php
+++ b/app-modules/activity/src/Reaction/Enums/TimelineReaction.php
@@ -5,13 +5,16 @@ declare(strict_types=1);
 namespace He4rt\Activity\Reaction\Enums;
 
 use App\Enums\Concerns\StringifyEnum;
+use Filament\Support\Colors\Color;
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasDescription;
 use Filament\Support\Contracts\HasLabel;
 
 /**
  * Conjunto fechado de reações da timeline web. O banco guarda só o value;
- * rótulo e glifo vivem aqui e nunca são persistidos.
+ * rótulo, cor e glifo vivem aqui e nunca são persistidos.
  */
-enum TimelineReaction: string implements HasLabel
+enum TimelineReaction: string implements HasColor, HasDescription, HasLabel
 {
     use StringifyEnum;
 
@@ -31,6 +34,36 @@ enum TimelineReaction: string implements HasLabel
             self::Celebrate => 'Parabéns',
             self::Fire => 'Fogo',
             self::Sad => 'Triste',
+        };
+    }
+
+    /**
+     * Conjunto não-ordenado: não há ramp claro->danger. Cada cor puxa a do
+     * próprio glifo, para o rótulo textual não brigar com o emoji ao lado.
+     *
+     * @return array<int, string>
+     */
+    public function getColor(): array
+    {
+        return match ($this) {
+            self::Like => Color::Sky,
+            self::Love => Color::Rose,
+            self::Laugh => Color::Amber,
+            self::Celebrate => Color::Violet,
+            self::Fire => Color::Orange,
+            self::Sad => Color::Slate,
+        };
+    }
+
+    public function getDescription(): string
+    {
+        return match ($this) {
+            self::Like => 'Concorda ou apoia sem muito peso',
+            self::Love => 'Guardou carinho pelo conteúdo',
+            self::Laugh => 'Achou graça',
+            self::Celebrate => 'Comemora uma conquista de alguém da comunidade',
+            self::Fire => 'Reconhece que o conteúdo ficou excelente',
+            self::Sad => 'Solidariza com uma notícia difícil',
         };
     }
 

--- a/app-modules/activity/tests/Unit/Reaction/TimelineReactionTest.php
+++ b/app-modules/activity/tests/Unit/Reaction/TimelineReactionTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasDescription;
 use Filament\Support\Contracts\HasLabel;
 use He4rt\Activity\Reaction\Enums\TimelineReaction;
 
@@ -15,9 +17,13 @@ it('tem exatamente os seis casos do conjunto fixo', function (): void {
         ->and(TimelineReaction::Sad->value)->toBe('sad');
 });
 
-it('implementa o contrato HasLabel', function (TimelineReaction $reaction): void {
-    expect($reaction)->toBeInstanceOf(HasLabel::class)
+it('implementa os contratos Filament para todos os casos', function (TimelineReaction $reaction): void {
+    expect($reaction)->toBeInstanceOf(HasColor::class)
+        ->toBeInstanceOf(HasDescription::class)
+        ->toBeInstanceOf(HasLabel::class)
         ->and($reaction->getLabel())->toBeString()->not->toBeEmpty()
+        ->and($reaction->getColor())->toBeArray()->not->toBeEmpty()
+        ->and($reaction->getDescription())->toBeString()->not->toBeEmpty()
         ->and($reaction->emoji())->toBeString()->not->toBeEmpty();
 })->with(TimelineReaction::cases());
 
@@ -37,6 +43,20 @@ it('devolve o glifo de cada reação', function (): void {
         ->and(TimelineReaction::Celebrate->emoji())->toBe('🎉')
         ->and(TimelineReaction::Fire->emoji())->toBe('🔥')
         ->and(TimelineReaction::Sad->emoji())->toBe('😢');
+});
+
+it('não repete cor, rótulo, descrição nem glifo entre os casos', function (): void {
+    $cases = TimelineReaction::cases();
+
+    $colors = array_map(fn (TimelineReaction $r): string => serialize($r->getColor()), $cases);
+    $labels = array_map(fn (TimelineReaction $r): string => $r->getLabel(), $cases);
+    $descriptions = array_map(fn (TimelineReaction $r): string => $r->getDescription(), $cases);
+    $emojis = array_map(fn (TimelineReaction $r): string => $r->emoji(), $cases);
+
+    expect(array_unique($colors))->toHaveCount(6)
+        ->and(array_unique($labels))->toHaveCount(6)
+        ->and(array_unique($descriptions))->toHaveCount(6)
+        ->and(array_unique($emojis))->toHaveCount(6);
 });
 
 it('devolve null para valor fora do conjunto', function (): void {

--- a/app-modules/activity/tests/Unit/Reaction/TimelineReactionTest.php
+++ b/app-modules/activity/tests/Unit/Reaction/TimelineReactionTest.php
@@ -24,7 +24,7 @@ it('implementa os contratos Filament para todos os casos', function (TimelineRea
         ->and($reaction->getLabel())->toBeString()->not->toBeEmpty()
         ->and($reaction->getColor())->toBeArray()->not->toBeEmpty()
         ->and($reaction->getDescription())->toBeString()->not->toBeEmpty()
-        ->and($reaction->emoji())->toBeString()->not->toBeEmpty();
+        ->and($reaction->getEmoji())->toBeString()->not->toBeEmpty();
 })->with(TimelineReaction::cases());
 
 it('devolve o rótulo pt-BR de cada reação', function (): void {
@@ -37,12 +37,12 @@ it('devolve o rótulo pt-BR de cada reação', function (): void {
 });
 
 it('devolve o glifo de cada reação', function (): void {
-    expect(TimelineReaction::Like->emoji())->toBe('👍')
-        ->and(TimelineReaction::Love->emoji())->toBe('❤️')
-        ->and(TimelineReaction::Laugh->emoji())->toBe('😂')
-        ->and(TimelineReaction::Celebrate->emoji())->toBe('🎉')
-        ->and(TimelineReaction::Fire->emoji())->toBe('🔥')
-        ->and(TimelineReaction::Sad->emoji())->toBe('😢');
+    expect(TimelineReaction::Like->getEmoji())->toBe('👍')
+        ->and(TimelineReaction::Love->getEmoji())->toBe('❤️')
+        ->and(TimelineReaction::Laugh->getEmoji())->toBe('😂')
+        ->and(TimelineReaction::Celebrate->getEmoji())->toBe('🎉')
+        ->and(TimelineReaction::Fire->getEmoji())->toBe('🔥')
+        ->and(TimelineReaction::Sad->getEmoji())->toBe('😢');
 });
 
 it('não repete cor, rótulo, descrição nem glifo entre os casos', function (): void {
@@ -51,7 +51,7 @@ it('não repete cor, rótulo, descrição nem glifo entre os casos', function ()
     $colors = array_map(fn (TimelineReaction $r): string => serialize($r->getColor()), $cases);
     $labels = array_map(fn (TimelineReaction $r): string => $r->getLabel(), $cases);
     $descriptions = array_map(fn (TimelineReaction $r): string => $r->getDescription(), $cases);
-    $emojis = array_map(fn (TimelineReaction $r): string => $r->emoji(), $cases);
+    $emojis = array_map(fn (TimelineReaction $r): string => $r->getEmoji(), $cases);
 
     expect(array_unique($colors))->toHaveCount(6)
         ->and(array_unique($labels))->toHaveCount(6)

--- a/app-modules/activity/tests/Unit/Reaction/TimelineReactionTest.php
+++ b/app-modules/activity/tests/Unit/Reaction/TimelineReactionTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Support\Contracts\HasLabel;
+use He4rt\Activity\Reaction\Enums\TimelineReaction;
+
+it('tem exatamente os seis casos do conjunto fixo', function (): void {
+    expect(TimelineReaction::cases())->toHaveCount(6)
+        ->and(TimelineReaction::Like->value)->toBe('like')
+        ->and(TimelineReaction::Love->value)->toBe('love')
+        ->and(TimelineReaction::Laugh->value)->toBe('laugh')
+        ->and(TimelineReaction::Celebrate->value)->toBe('celebrate')
+        ->and(TimelineReaction::Fire->value)->toBe('fire')
+        ->and(TimelineReaction::Sad->value)->toBe('sad');
+});
+
+it('implementa o contrato HasLabel', function (TimelineReaction $reaction): void {
+    expect($reaction)->toBeInstanceOf(HasLabel::class)
+        ->and($reaction->getLabel())->toBeString()->not->toBeEmpty()
+        ->and($reaction->emoji())->toBeString()->not->toBeEmpty();
+})->with(TimelineReaction::cases());
+
+it('devolve o rótulo pt-BR de cada reação', function (): void {
+    expect(TimelineReaction::Like->getLabel())->toBe('Curtir')
+        ->and(TimelineReaction::Love->getLabel())->toBe('Amei')
+        ->and(TimelineReaction::Laugh->getLabel())->toBe('Haha')
+        ->and(TimelineReaction::Celebrate->getLabel())->toBe('Parabéns')
+        ->and(TimelineReaction::Fire->getLabel())->toBe('Fogo')
+        ->and(TimelineReaction::Sad->getLabel())->toBe('Triste');
+});
+
+it('devolve o glifo de cada reação', function (): void {
+    expect(TimelineReaction::Like->emoji())->toBe('👍')
+        ->and(TimelineReaction::Love->emoji())->toBe('❤️')
+        ->and(TimelineReaction::Laugh->emoji())->toBe('😂')
+        ->and(TimelineReaction::Celebrate->emoji())->toBe('🎉')
+        ->and(TimelineReaction::Fire->emoji())->toBe('🔥')
+        ->and(TimelineReaction::Sad->emoji())->toBe('😢');
+});
+
+it('devolve null para valor fora do conjunto', function (): void {
+    expect(TimelineReaction::tryFrom('xpto'))->toBeNull()
+        ->and(TimelineReaction::tryFrom(''))->toBeNull()
+        ->and(TimelineReaction::tryFrom('👍'))->toBeNull();
+});
+
+it('lista os seis values em stringifyCases', function (): void {
+    expect(TimelineReaction::stringifyCases())
+        ->toBe('Available enum cases: like, love, laugh, celebrate, fire, sad');
+});


### PR DESCRIPTION
## Contexto

Fatia S2 do subsistema de reações da timeline web (#539). A S1 (#541) criou a tabela `activity_user_reactions`; esta entrega o conjunto fixo das 6 reações **só em código** — o banco guarda apenas o `value`.

| Case | `value` | Glifo | Rótulo | Cor |
|------|---------|-------|--------|-----|
| `Like` | `like` | 👍 | Curtir | `Sky` |
| `Love` | `love` | ❤️ | Amei | `Rose` |
| `Laugh` | `laugh` | 😂 | Haha | `Amber` |
| `Celebrate` | `celebrate` | 🎉 | Parabéns | `Violet` |
| `Fire` | `fire` | 🔥 | Fogo | `Orange` |
| `Sad` | `sad` | 😢 | Triste | `Slate` |

Nada consome o enum ainda: ele destrava a S3 (#542), S4 (#543) e S5 (#544).

### Alterações

- **activity:** enum `TimelineReaction: string` em `src/Reaction/Enums/`, com `use StringifyEnum` e os contratos `HasColor, HasDescription, HasLabel` (guideline `07-enum-filament-contracts`). Todo getter é `match` exaustivo sem `default`. `emoji()` fica fora dos contratos — `HasIcon` devolve `Heroicon`, e o símbolo da reação é o glifo.
- **activity:** fecha o `TODO(#540)` da migration — o `->comment()` da coluna `reaction` passa a vir de `TimelineReaction::stringifyCases()`, como os outros ~18 comments de enum do repo.
- **activity:** teste unit em `tests/Unit/Reaction/TimelineReactionTest.php` — contratos, valores, rótulos e glifos exatos, `tryFrom()` nulo fora do conjunto, e distinção entre os 6 casos.

Conjunto **não-ordenado**, então `getColor()` não segue o ramp claro→`danger` da guideline: cada cor puxa a do próprio glifo, e `danger`/`warning` ficaram de fora por significarem erro e alerta.

---

## Plano de Testes

- [x] `make check` — rector, pint e phpstan (level 7) verdes, `errors: 0`
- [x] `make test-unit` — **555 passando, 2286 asserções**; o arquivo novo cobre 12 testes e 93 asserções
- [x] `make setup-test-db` aplicou a migration alterada, e o comment no Postgres confere: `Available enum cases: like, love, laugh, celebrate, fire, sad`
- [x] Mutação: duplicar o glifo do `Sad` quebra 2 testes; duplicar a cor quebra 1. Revertidas.

---

## Evidências

Sem impacto visual — o enum ainda não é renderizado. A UI de reação entra na #545 e #546.

---

## Issues Relacionadas

Closes #540
Related to #539