### PR TITLE
feat(identity,panel-app): permite alteração de @ (username) (#502)

### DIFF
--- a/app-modules/identity/database/migrations/2026_09_02_195006_add_username_fields_to_users_table.php
+++ b/app-modules/identity/database/migrations/2026_09_02_195006_add_username_fields_to_users_table.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', static function (Blueprint $table): void {
+            $table->timestampTz('username_manually_set_at')->nullable()->after('username');
+            $table->timestampTz('username_updated_at')->nullable()->after('username_manually_set_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', static function (Blueprint $table): void {
+            $table->dropColumn(['username_manually_set_at', 'username_updated_at']);
+        });
+    }
+};

--- a/app-modules/identity/src/Auth/Actions/EnrichUserOnFirstLogin.php
+++ b/app-modules/identity/src/Auth/Actions/EnrichUserOnFirstLogin.php
@@ -27,7 +27,8 @@ final class EnrichUserOnFirstLogin
             $updates['name'] = $oauthUser->name;
         }
 
-        $canUpdateUsername = $oauthUser->username !== $user->username
+        $canUpdateUsername = $user->username_manually_set_at === null
+            && $oauthUser->username !== $user->username
             && !User::query()
                 ->where('username', $oauthUser->username)
                 ->where('id', '!=', $user->id)

--- a/app-modules/identity/src/Auth/Actions/MergeAccountsAction.php
+++ b/app-modules/identity/src/Auth/Actions/MergeAccountsAction.php
@@ -51,7 +51,8 @@ final class MergeAccountsAction
             $updates['name'] = $source->name;
         }
 
-        $canUpdateUsername = $source->username !== $target->username
+        $canUpdateUsername = $target->username_manually_set_at === null
+            && $source->username !== $target->username
             && !User::query()
                 ->where('username', $source->username)
                 ->where('id', '!=', $target->id)
@@ -59,12 +60,16 @@ final class MergeAccountsAction
 
         if ($canUpdateUsername) {
             $updates['username'] = $source->username;
+            if ($source->username_manually_set_at !== null) {
+                $updates['username_manually_set_at'] = $source->username_manually_set_at;
+                $updates['username_updated_at'] = $source->username_updated_at;
+            }
         }
 
         try {
             DB::transaction(fn () => $target->update($updates));
         } catch (UniqueConstraintViolationException) {
-            unset($updates['username']);
+            unset($updates['username'], $updates['username_manually_set_at'], $updates['username_updated_at']);
             $target->update($updates);
         }
     }

--- a/app-modules/identity/src/User/Actions/UpdateUsername.php
+++ b/app-modules/identity/src/User/Actions/UpdateUsername.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Identity\User\Actions;
+
+use He4rt\Identity\User\Exceptions\UsernameException;
+use He4rt\Identity\User\Models\User;
+use He4rt\Identity\User\ValueObjects\UsernameValidator;
+use Illuminate\Database\UniqueConstraintViolationException;
+use Illuminate\Support\Facades\DB;
+
+final class UpdateUsername
+{
+    /**
+     * @throws UsernameException
+     */
+    public function handle(User $user, string $newUsername): User
+    {
+        $normalized = UsernameValidator::normalizeAndValidate($newUsername, $user);
+
+        if ($normalized === mb_strtolower($user->username)) {
+            throw UsernameException::sameAsCurrent();
+        }
+
+        if ($user->username_updated_at !== null && !$user->isAdmin()) {
+            $cooldownDays = (int) config('he4rt.username_cooldown_days', 7);
+            $availableAt = $user->username_updated_at->copy()->addDays($cooldownDays);
+
+            if (now()->lessThan($availableAt)) {
+                throw UsernameException::cooldownActive($availableAt);
+            }
+        }
+
+        $isTaken = User::query()
+            ->whereRaw('LOWER(username) = ?', [$normalized])
+            ->where('id', '!=', $user->id)
+            ->exists();
+
+        if ($isTaken) {
+            throw UsernameException::alreadyTaken($normalized);
+        }
+
+        try {
+            DB::transaction(function () use ($user, $normalized): void {
+                $user->update([
+                    'username' => $normalized,
+                    'username_updated_at' => now(),
+                    'username_manually_set_at' => $user->username_manually_set_at ?? now(),
+                ]);
+            });
+        } catch (UniqueConstraintViolationException) {
+            throw UsernameException::alreadyTaken($normalized);
+        }
+
+        return $user->refresh();
+    }
+
+    /**
+     * Alias for handle
+     *
+     * @throws UsernameException
+     */
+    public function execute(User $user, string $newUsername): User
+    {
+        return $this->handle($user, $newUsername);
+    }
+}

--- a/app-modules/identity/src/User/Exceptions/UsernameException.php
+++ b/app-modules/identity/src/User/Exceptions/UsernameException.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Identity\User\Exceptions;
+
+use Carbon\CarbonInterface;
+use Exception;
+
+final class UsernameException extends Exception
+{
+    public static function alreadyTaken(string $username): self
+    {
+        return new self(sprintf('O @%s já está em uso por outro membro.', $username), 422);
+    }
+
+    public static function invalidFormat(string $reason): self
+    {
+        return new self(sprintf('Formato de @ inválido: %s.', $reason), 422);
+    }
+
+    public static function cooldownActive(CarbonInterface $availableAt): self
+    {
+        $timezone = (string) config('app.display_timezone', 'America/Sao_Paulo');
+        $formattedDate = $availableAt->timezone($timezone)->format('d/m/Y H:i');
+
+        return new self(sprintf('Você só poderá alterar seu @ novamente a partir de %s.', $formattedDate), 422);
+    }
+
+    public static function sameAsCurrent(): self
+    {
+        return new self('O novo @ deve ser diferente do atual.', 422);
+    }
+
+    public static function reservedUsername(string $username): self
+    {
+        return new self(sprintf('O @%s está reservado para o sistema e não pode ser utilizado.', $username), 422);
+    }
+}

--- a/app-modules/identity/src/User/Exceptions/UsernameException.php
+++ b/app-modules/identity/src/User/Exceptions/UsernameException.php
@@ -6,17 +6,41 @@ namespace He4rt\Identity\User\Exceptions;
 
 use Carbon\CarbonInterface;
 use Exception;
+use Throwable;
 
 final class UsernameException extends Exception
 {
-    public static function alreadyTaken(string $username): self
-    {
-        return new self(sprintf('O @%s já está em uso por outro membro.', $username), 422);
+    /**
+     * @param  array<string, mixed>  $translationParams
+     */
+    public function __construct(
+        string $message = '',
+        int $code = 422,
+        ?Throwable $previous = null,
+        public readonly ?string $translationKey = null,
+        public readonly array $translationParams = [],
+    ) {
+        parent::__construct($message, $code, $previous);
     }
 
-    public static function invalidFormat(string $reason): self
+    public static function alreadyTaken(string $username): self
     {
-        return new self(sprintf('Formato de @ inválido: %s.', $reason), 422);
+        return new self(
+            sprintf('O @%s já está em uso por outro membro.', $username),
+            422,
+            translationKey: 'panel-app::profile.validation.username_already_taken',
+            translationParams: ['username' => $username],
+        );
+    }
+
+    public static function invalidFormat(string $reason, ?string $reasonKey = null): self
+    {
+        return new self(
+            sprintf('Formato de @ inválido: %s.', $reason),
+            422,
+            translationKey: 'panel-app::profile.validation.username_invalid_format',
+            translationParams: ['reason' => $reason, 'reason_key' => $reasonKey],
+        );
     }
 
     public static function cooldownActive(CarbonInterface $availableAt): self
@@ -24,16 +48,52 @@ final class UsernameException extends Exception
         $timezone = (string) config('app.display_timezone', 'America/Sao_Paulo');
         $formattedDate = $availableAt->timezone($timezone)->format('d/m/Y H:i');
 
-        return new self(sprintf('Você só poderá alterar seu @ novamente a partir de %s.', $formattedDate), 422);
+        return new self(
+            sprintf('Você só poderá alterar seu @ novamente a partir de %s.', $formattedDate),
+            422,
+            translationKey: 'panel-app::profile.validation.username_cooldown_active',
+            translationParams: ['date' => $formattedDate],
+        );
     }
 
     public static function sameAsCurrent(): self
     {
-        return new self('O novo @ deve ser diferente do atual.', 422);
+        return new self(
+            'O novo @ deve ser diferente do atual.',
+            422,
+            translationKey: 'panel-app::profile.validation.username_same_as_current',
+        );
     }
 
     public static function reservedUsername(string $username): self
     {
-        return new self(sprintf('O @%s está reservado para o sistema e não pode ser utilizado.', $username), 422);
+        return new self(
+            sprintf('O @%s está reservado para o sistema e não pode ser utilizado.', $username),
+            422,
+            translationKey: 'panel-app::profile.validation.username_reserved',
+            translationParams: ['username' => $username],
+        );
+    }
+
+    public function getLocalizedMessage(): string
+    {
+        if ($this->translationKey !== null) {
+            $params = $this->translationParams;
+            if (isset($params['reason_key']) && is_string($params['reason_key'])) {
+                $translatedReason = __($params['reason_key']);
+                if ($translatedReason !== $params['reason_key']) {
+                    $params['reason'] = $translatedReason;
+                }
+
+                unset($params['reason_key']);
+            }
+
+            $translated = __($this->translationKey, $params);
+            if ($translated !== $this->translationKey) {
+                return $translated;
+            }
+        }
+
+        return $this->getMessage();
     }
 }

--- a/app-modules/identity/src/User/Models/User.php
+++ b/app-modules/identity/src/User/Models/User.php
@@ -44,6 +44,8 @@ use Spatie\Permission\Traits\HasRoles;
  * @property CarbonInterface|null $suspended_until
  * @property CarbonInterface|null $banned_at
  * @property CarbonInterface|null $first_login_at
+ * @property CarbonInterface|null $username_manually_set_at
+ * @property CarbonInterface|null $username_updated_at
  * @property string|null $remember_token
  * @property CarbonInterface|null $created_at
  * @property CarbonInterface|null $updated_at
@@ -69,6 +71,15 @@ final class User extends Authenticatable implements FilamentUser, HasMedia, HasN
     public function isSuperAdmin(): bool
     {
         return $this->hasRole(UserRole::SuperAdmin);
+    }
+
+    public function isAdmin(): bool
+    {
+        $admins = array_filter(explode(',', (string) config('he4rt.admins', '')));
+
+        return $this->isSuperAdmin()
+            || in_array($this->username, $admins, strict: true)
+            || in_array($this->id, $admins, strict: true);
     }
 
     /**
@@ -154,6 +165,8 @@ final class User extends Authenticatable implements FilamentUser, HasMedia, HasN
             'suspended_until' => 'datetime',
             'banned_at' => 'datetime',
             'first_login_at' => 'datetime',
+            'username_manually_set_at' => 'datetime',
+            'username_updated_at' => 'datetime',
         ];
     }
 

--- a/app-modules/identity/src/User/ValueObjects/UsernameValidator.php
+++ b/app-modules/identity/src/User/ValueObjects/UsernameValidator.php
@@ -43,19 +43,31 @@ final class UsernameValidator
         $length = mb_strlen($normalized);
 
         if ($length < 2 || $length > 32) {
-            throw UsernameException::invalidFormat('o tamanho deve ter entre 2 e 32 caracteres');
+            throw UsernameException::invalidFormat(
+                'o tamanho deve ter entre 2 e 32 caracteres',
+                'panel-app::profile.validation.username_reason_length',
+            );
         }
 
         if (!preg_match('/^[a-z0-9._-]+$/', $normalized)) {
-            throw UsernameException::invalidFormat('apenas letras, números, sublinhado (_), hífen (-) e ponto (.) são permitidos');
+            throw UsernameException::invalidFormat(
+                'apenas letras, números, sublinhado (_), hífen (-) e ponto (.) são permitidos',
+                'panel-app::profile.validation.username_reason_characters',
+            );
         }
 
         if (!preg_match('/^[a-z0-9]/', $normalized) || !preg_match('/[a-z0-9]$/', $normalized)) {
-            throw UsernameException::invalidFormat('não pode começar ou terminar com caracteres especiais');
+            throw UsernameException::invalidFormat(
+                'não pode começar ou terminar com caracteres especiais',
+                'panel-app::profile.validation.username_reason_edges',
+            );
         }
 
         if (preg_match('/[._-]{2,}/', $normalized)) {
-            throw UsernameException::invalidFormat('não pode conter caracteres especiais consecutivos');
+            throw UsernameException::invalidFormat(
+                'não pode conter caracteres especiais consecutivos',
+                'panel-app::profile.validation.username_reason_consecutive',
+            );
         }
 
         if (in_array($normalized, self::RESERVED_USERNAMES, strict: true)) {

--- a/app-modules/identity/src/User/ValueObjects/UsernameValidator.php
+++ b/app-modules/identity/src/User/ValueObjects/UsernameValidator.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Identity\User\ValueObjects;
+
+use He4rt\Identity\User\Exceptions\UsernameException;
+use He4rt\Identity\User\Models\User;
+
+final class UsernameValidator
+{
+    /**
+     * @var list<string>
+     */
+    public const array RESERVED_USERNAMES = [
+        'admin',
+        'administrator',
+        'system',
+        'root',
+        'he4rt',
+        'heart',
+        'he4rtdevs',
+        'mod',
+        'moderator',
+        'staff',
+        'support',
+        'help',
+        'api',
+        'bot',
+        'null',
+        'undefined',
+        'anonymous',
+        'everyone',
+        'here',
+    ];
+
+    /**
+     * @throws UsernameException
+     */
+    public static function normalizeAndValidate(string $username, ?User $user = null): string
+    {
+        $normalized = mb_strtolower(mb_trim($username));
+        $length = mb_strlen($normalized);
+
+        if ($length < 2 || $length > 32) {
+            throw UsernameException::invalidFormat('o tamanho deve ter entre 2 e 32 caracteres');
+        }
+
+        if (!preg_match('/^[a-z0-9._-]+$/', $normalized)) {
+            throw UsernameException::invalidFormat('apenas letras, números, sublinhado (_), hífen (-) e ponto (.) são permitidos');
+        }
+
+        if (!preg_match('/^[a-z0-9]/', $normalized) || !preg_match('/[a-z0-9]$/', $normalized)) {
+            throw UsernameException::invalidFormat('não pode começar ou terminar com caracteres especiais');
+        }
+
+        if (preg_match('/[._-]{2,}/', $normalized)) {
+            throw UsernameException::invalidFormat('não pode conter caracteres especiais consecutivos');
+        }
+
+        if (in_array($normalized, self::RESERVED_USERNAMES, strict: true)) {
+            throw UsernameException::reservedUsername($normalized);
+        }
+
+        $adminsConfig = (string) config('he4rt.admins', '');
+        $adminEntries = array_filter(array_map(trim(...), explode(',', $adminsConfig)));
+        $adminNames = array_map(strtolower(...), $adminEntries);
+
+        if (in_array($normalized, $adminNames, strict: true)) {
+            $isOwnAdminUsername = $user instanceof User && (
+                mb_strtolower($user->username) === $normalized
+                || in_array(mb_strtolower($user->id), $adminNames, strict: true)
+            );
+
+            if (!$isOwnAdminUsername) {
+                throw UsernameException::reservedUsername($normalized);
+            }
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @throws UsernameException
+     */
+    public static function validate(string $username, ?User $user = null): string
+    {
+        return self::normalizeAndValidate($username, $user);
+    }
+}

--- a/app-modules/identity/tests/Feature/Auth/EnrichUserOnFirstLoginTest.php
+++ b/app-modules/identity/tests/Feature/Auth/EnrichUserOnFirstLoginTest.php
@@ -113,3 +113,19 @@ test('does not overwrite email with null', function (): void {
     expect($result->email)->toBe('existing@example.com')
         ->and($result->first_login_at)->not->toBeNull();
 });
+
+test('does not overwrite username when username_manually_set_at is present', function (): void {
+    $user = User::factory()->create([
+        'username' => 'custom-username',
+        'first_login_at' => null,
+        'username_manually_set_at' => now()->subDay(),
+    ]);
+
+    $action = new EnrichUserOnFirstLogin();
+    $result = $action->execute(
+        $user,
+        makeOAuthUserForEnrich(username: 'oauth-username'),
+    );
+
+    expect($result->username)->toBe('custom-username');
+});

--- a/app-modules/identity/tests/Feature/Auth/MergeAccountsActionTest.php
+++ b/app-modules/identity/tests/Feature/Auth/MergeAccountsActionTest.php
@@ -159,3 +159,42 @@ test('skips username update on old user when it would collide', function (): voi
     $oldUser->refresh();
     expect($oldUser->username)->toBe('old-user');
 });
+
+test('does not overwrite old user username when old user has username_manually_set_at', function (): void {
+    $oldUser = User::factory()->create([
+        'username' => 'manual-old-username',
+        'first_login_at' => null,
+        'username_manually_set_at' => now()->subMonth(),
+    ]);
+    $currentUser = User::factory()->create([
+        'username' => 'current-username',
+        'name' => 'Current Name',
+    ]);
+
+    $action = new MergeAccountsAction();
+    $action->execute($currentUser, $oldUser);
+
+    expect($oldUser->refresh()->username)->toBe('manual-old-username');
+});
+
+test('copies username_manually_set_at when currentUser has manual username', function (): void {
+    $manualTimestamp = now()->subDays(10);
+    $oldUser = User::factory()->create([
+        'username' => 'legacy-user',
+        'first_login_at' => null,
+        'username_manually_set_at' => null,
+    ]);
+    $currentUser = User::factory()->create([
+        'username' => 'manual-current-username',
+        'name' => 'Manual Current',
+        'username_manually_set_at' => $manualTimestamp,
+        'username_updated_at' => $manualTimestamp,
+    ]);
+
+    $action = new MergeAccountsAction();
+    $action->execute($currentUser, $oldUser);
+
+    $oldUser->refresh();
+    expect($oldUser->username)->toBe('manual-current-username')
+        ->and($oldUser->username_manually_set_at->toIso8601String())->toBe($manualTimestamp->toIso8601String());
+});

--- a/app-modules/identity/tests/Feature/User/UpdateUsernameTest.php
+++ b/app-modules/identity/tests/Feature/User/UpdateUsernameTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Identity\User\Actions\UpdateUsername;
+use He4rt\Identity\User\Exceptions\UsernameException;
+use He4rt\Identity\User\Models\User;
+use Illuminate\Support\Facades\Date;
+
+beforeEach(function (): void {
+    config()->set('he4rt.username_cooldown_days', 7);
+    config()->set('app.display_timezone', 'America/Sao_Paulo');
+});
+
+test('updates username with lowercase normalization and sets timestamps', function (): void {
+    $user = User::factory()->create([
+        'username' => 'originaluser',
+        'username_manually_set_at' => null,
+        'username_updated_at' => null,
+    ]);
+
+    $action = resolve(UpdateUsername::class);
+    $updated = $action->handle($user, 'NewHandle_99');
+
+    expect($updated->username)->toBe('newhandle_99')
+        ->and($updated->username_manually_set_at)->not->toBeNull()
+        ->and($updated->username_updated_at)->not->toBeNull();
+});
+
+test('preserves username_manually_set_at on subsequent updates after cooldown', function (): void {
+    $initialManualDate = now()->subDays(10);
+    $user = User::factory()->create([
+        'username' => 'firsthandle',
+        'username_manually_set_at' => $initialManualDate,
+        'username_updated_at' => $initialManualDate,
+    ]);
+
+    $action = resolve(UpdateUsername::class);
+    $updated = $action->handle($user, 'secondhandle');
+
+    expect($updated->username)->toBe('secondhandle')
+        ->and($updated->username_manually_set_at->toIso8601String())->toBe($initialManualDate->toIso8601String())
+        ->and($updated->username_updated_at->greaterThan($initialManualDate))->toBeTrue();
+});
+
+test('throws exception when cooldown is still active', function (): void {
+    Date::setTestNow('2026-09-08 12:00:00');
+
+    $user = User::factory()->create([
+        'username' => 'currentuser',
+        'username_manually_set_at' => now()->subDays(3),
+        'username_updated_at' => now()->subDays(3),
+    ]);
+
+    $action = resolve(UpdateUsername::class);
+
+    expect(fn () => $action->handle($user, 'newhandle'))
+        ->toThrow(UsernameException::class, '12/09/2026 09:00'); // 2026-09-08 12:00 UTC - 3 days + 7 days = 2026-09-12 12:00 UTC = 09:00 America/Sao_Paulo
+
+    Date::setTestNow();
+});
+
+test('allows update after 7 days cooldown has elapsed', function (): void {
+    $user = User::factory()->create([
+        'username' => 'currentuser',
+        'username_manually_set_at' => now()->subDays(8),
+        'username_updated_at' => now()->subDays(8),
+    ]);
+
+    $action = resolve(UpdateUsername::class);
+    $updated = $action->handle($user, 'newhandle');
+
+    expect($updated->username)->toBe('newhandle');
+});
+
+test('throws exception when new username is same as current username', function (): void {
+    $user = User::factory()->create([
+        'username' => 'myhandle',
+        'username_manually_set_at' => null,
+        'username_updated_at' => null,
+    ]);
+
+    $action = resolve(UpdateUsername::class);
+
+    expect(fn () => $action->handle($user, 'MYHANDLE'))
+        ->toThrow(UsernameException::class, 'O novo @ deve ser diferente do atual.');
+
+    expect($user->fresh()->username_updated_at)->toBeNull();
+});
+
+test('throws exception when username is already taken case-insensitively', function (): void {
+    User::factory()->create(['username' => 'takenhandle']);
+    $user = User::factory()->create(['username' => 'myhandle']);
+
+    $action = resolve(UpdateUsername::class);
+
+    expect(fn () => $action->handle($user, 'TAKENHANDLE'))
+        ->toThrow(UsernameException::class, 'O @takenhandle já está em uso por outro membro.');
+});
+
+test('rejects invalid username formats', function (string $invalidUsername): void {
+    $user = User::factory()->create(['username' => 'validuser']);
+    $action = resolve(UpdateUsername::class);
+
+    expect(fn () => $action->handle($user, $invalidUsername))
+        ->toThrow(UsernameException::class);
+})->with([
+    'single char' => 'a',
+    'too long' => str_repeat('a', 33),
+    'starts with dot' => '.username',
+    'ends with dot' => 'username.',
+    'starts with dash' => '-username',
+    'ends with dash' => 'username-',
+    'starts with underscore' => '_username',
+    'ends with underscore' => 'username_',
+    'consecutive dots' => 'user..name',
+    'consecutive dashes' => 'user--name',
+    'consecutive underscores' => 'user__name',
+    'consecutive mixed' => 'user.-name',
+    'invalid chars space' => 'user name',
+    'invalid chars at symbol' => 'user@name',
+    'invalid chars exclamation' => 'user!name',
+]);
+
+test('rejects reserved system usernames', function (string $reservedName): void {
+    $user = User::factory()->create(['username' => 'normaluser']);
+    $action = resolve(UpdateUsername::class);
+
+    expect(fn () => $action->handle($user, $reservedName))
+        ->toThrow(UsernameException::class, "O @{$reservedName} está reservado para o sistema e não pode ser utilizado.");
+})->with([
+    'admin',
+    'root',
+    'he4rt',
+    'system',
+    'support',
+    'api',
+]);
+
+test('prevents ordinary users from claiming admin username from config', function (): void {
+    config()->set('he4rt.admins', 'adminmaster,he4rtfounder');
+
+    $user = User::factory()->create(['username' => 'regularuser']);
+    $action = resolve(UpdateUsername::class);
+
+    expect(fn () => $action->handle($user, 'adminmaster'))
+        ->toThrow(UsernameException::class, 'O @adminmaster está reservado para o sistema e não pode ser utilizado.');
+});
+
+test('allows admin user to change their username', function (): void {
+    config()->set('he4rt.admins', 'danielhe4rt');
+
+    $admin = User::factory()->superAdmin()->create(['username' => 'danielhe4rt']);
+    expect($admin->isAdmin())->toBeTrue();
+
+    $action = resolve(UpdateUsername::class);
+    $updated = $action->handle($admin, 'daniel.reis');
+
+    expect($updated->username)->toBe('daniel.reis');
+});
+
+test('admin is exempt from 7 days cooldown and can change username repeatedly', function (): void {
+    config()->set('he4rt.admins', 'danielhe4rt');
+
+    $admin = User::factory()->superAdmin()->create([
+        'username' => 'danielhe4rt',
+        'username_updated_at' => now()->subMinutes(5),
+    ]);
+
+    expect($admin->isAdmin())->toBeTrue();
+
+    $action = resolve(UpdateUsername::class);
+    $updated = $action->handle($admin, 'daniel.reis');
+
+    expect($updated->username)->toBe('daniel.reis');
+});

--- a/app-modules/identity/tests/Feature/User/UpdateUsernameTest.php
+++ b/app-modules/identity/tests/Feature/User/UpdateUsernameTest.php
@@ -12,6 +12,10 @@ beforeEach(function (): void {
     config()->set('app.display_timezone', 'America/Sao_Paulo');
 });
 
+afterEach(function (): void {
+    Date::setTestNow();
+});
+
 test('updates username with lowercase normalization and sets timestamps', function (): void {
     $user = User::factory()->create([
         'username' => 'originaluser',
@@ -46,18 +50,20 @@ test('preserves username_manually_set_at on subsequent updates after cooldown', 
 test('throws exception when cooldown is still active', function (): void {
     Date::setTestNow('2026-09-08 12:00:00');
 
-    $user = User::factory()->create([
-        'username' => 'currentuser',
-        'username_manually_set_at' => now()->subDays(3),
-        'username_updated_at' => now()->subDays(3),
-    ]);
+    try {
+        $user = User::factory()->create([
+            'username' => 'currentuser',
+            'username_manually_set_at' => now()->subDays(3),
+            'username_updated_at' => now()->subDays(3),
+        ]);
 
-    $action = resolve(UpdateUsername::class);
+        $action = resolve(UpdateUsername::class);
 
-    expect(fn () => $action->handle($user, 'newhandle'))
-        ->toThrow(UsernameException::class, '12/09/2026 09:00'); // 2026-09-08 12:00 UTC - 3 days + 7 days = 2026-09-12 12:00 UTC = 09:00 America/Sao_Paulo
-
-    Date::setTestNow();
+        expect(fn () => $action->handle($user, 'newhandle'))
+            ->toThrow(UsernameException::class, '12/09/2026 09:00'); // 2026-09-08 12:00 UTC - 3 days + 7 days = 2026-09-12 12:00 UTC = 09:00 America/Sao_Paulo
+    } finally {
+        Date::setTestNow();
+    }
 });
 
 test('allows update after 7 days cooldown has elapsed', function (): void {

--- a/app-modules/integration-discord/src/ETL/Actions/ImportDiscordProfileAction.php
+++ b/app-modules/integration-discord/src/ETL/Actions/ImportDiscordProfileAction.php
@@ -79,7 +79,8 @@ final class ImportDiscordProfileAction
     {
         $changes = [];
 
-        $usernameChanged = $user->username !== $dto->username
+        $usernameChanged = $user->username_manually_set_at === null
+            && $user->username !== $dto->username
             && !User::query()
                 ->where('username', $dto->username)
                 ->where('id', '!=', $user->id)

--- a/app-modules/integration-discord/src/ETL/Actions/MergeDuplicateDiscordUserAction.php
+++ b/app-modules/integration-discord/src/ETL/Actions/MergeDuplicateDiscordUserAction.php
@@ -33,7 +33,7 @@ final class MergeDuplicateDiscordUserAction
 
             $newUser->delete();
 
-            if ($oldUser->username !== $targetUsername) {
+            if ($oldUser->username_manually_set_at === null && $oldUser->username !== $targetUsername) {
                 $taken = User::query()
                     ->where('username', $targetUsername)
                     ->where('id', '!=', $oldUser->id)

--- a/app-modules/integration-discord/src/ETL/Console/MergeDuplicateDiscordProfilesCommand.php
+++ b/app-modules/integration-discord/src/ETL/Console/MergeDuplicateDiscordProfilesCommand.php
@@ -44,9 +44,7 @@ class MergeDuplicateDiscordProfilesCommand extends Command
 
     private function runFromPairsFile(MergeDuplicateDiscordUserAction $merge, string $path): int
     {
-        $absolute = is_file($path)
-            ? $path
-            : (str_starts_with($path, '/') || preg_match('/^[A-Za-z]:[\\\\\/]/', $path) ? $path : base_path($path));
+        $absolute = str_starts_with($path, '/') ? $path : base_path($path);
 
         if (!is_file($absolute)) {
             error('Arquivo de pares nao encontrado: '.$absolute);

--- a/app-modules/integration-discord/src/ETL/Console/MergeDuplicateDiscordProfilesCommand.php
+++ b/app-modules/integration-discord/src/ETL/Console/MergeDuplicateDiscordProfilesCommand.php
@@ -44,7 +44,9 @@ class MergeDuplicateDiscordProfilesCommand extends Command
 
     private function runFromPairsFile(MergeDuplicateDiscordUserAction $merge, string $path): int
     {
-        $absolute = str_starts_with($path, '/') ? $path : base_path($path);
+        $absolute = is_file($path)
+            ? $path
+            : (str_starts_with($path, '/') || preg_match('/^[A-Za-z]:[\\\\\/]/', $path) ? $path : base_path($path));
 
         if (!is_file($absolute)) {
             error('Arquivo de pares nao encontrado: '.$absolute);

--- a/app-modules/integration-discord/tests/Feature/ETL/ImportDiscordProfileTest.php
+++ b/app-modules/integration-discord/tests/Feature/ETL/ImportDiscordProfileTest.php
@@ -422,3 +422,28 @@ test('it links discord identity to portal user matching username when no identit
 
     expect((string) $identity->model_id)->toBe((string) $portalUser->id);
 });
+
+test('it does not overwrite username when user has username_manually_set_at', function (): void {
+    $action = resolve(ImportDiscordProfileAction::class);
+
+    $user = User::factory()->create([
+        'username' => 'manual_custom_handle',
+        'username_manually_set_at' => now()->subDays(5),
+    ]);
+
+    ExternalIdentity::factory()->create([
+        'provider' => IdentityProvider::Discord,
+        'external_account_id' => '999999',
+        'model_type' => (new User)->getMorphClass(),
+        'model_id' => $user->id,
+    ]);
+
+    $action->handle(
+        DiscordProfileDTO::fromDump(discordProfile([
+            'user' => ['id' => '999999', 'username' => 'new_discord_handle'],
+            'connected_accounts' => [],
+        ])),
+    );
+
+    expect($user->fresh()->username)->toBe('manual_custom_handle');
+});

--- a/app-modules/integration-discord/tests/Feature/ETL/MergeDuplicateDiscordProfilesTest.php
+++ b/app-modules/integration-discord/tests/Feature/ETL/MergeDuplicateDiscordProfilesTest.php
@@ -216,3 +216,16 @@ test('respects --limit option', function (): void {
 
     expect($remaining)->toBe(1);
 });
+
+test('does not overwrite oldUser username when username_manually_set_at is set', function (): void {
+    $orphan = User::factory()->create([
+        'username' => 'custom-set-name',
+        'username_manually_set_at' => now()->subMonth(),
+        'created_at' => '2025-08-10 00:00:00',
+    ]);
+    [$newUser] = makeImportedDup('49615312957476864', '_tats', ['legacy_username' => 'custom-set-name']);
+
+    Artisan::call('discord:merge-duplicate-profiles', ['--from-date' => '2026-05-01']);
+
+    expect(User::query()->find($orphan->id)->username)->toBe('custom-set-name');
+});

--- a/app-modules/panel-app/lang/en/profile.php
+++ b/app-modules/panel-app/lang/en/profile.php
@@ -84,6 +84,15 @@ return [
         'image_dimensions' => 'After cropping, the image must be at least :min_width × :min_height px. The recommended size is :width × :height px.',
         'image_mimetypes' => 'Unsupported format. Upload a :formats image.',
         'image_unconverted_max_size' => 'A GIF can be at most :gif_mb MB. It is served exactly as it arrives, with no compression, so the file weighs on every profile visit.',
+        'username_already_taken' => 'The handle @:username is already in use by another member.',
+        'username_invalid_format' => 'Invalid handle format: :reason.',
+        'username_cooldown_active' => 'You will only be able to change your @ again starting on :date.',
+        'username_same_as_current' => 'The new @ must be different from the current one.',
+        'username_reserved' => 'The handle @:username is reserved for the system and cannot be used.',
+        'username_reason_length' => 'length must be between 2 and 32 characters',
+        'username_reason_characters' => 'only letters, numbers, underscores (_), hyphens (-), and dots (.) are allowed',
+        'username_reason_edges' => 'cannot start or end with special characters',
+        'username_reason_consecutive' => 'cannot contain consecutive special characters',
     ],
 
     'actions' => [

--- a/app-modules/panel-app/lang/en/profile.php
+++ b/app-modules/panel-app/lang/en/profile.php
@@ -47,6 +47,7 @@ return [
         'willing_to_relocate' => 'Willing to relocate',
         'has_disability' => 'Person with a disability',
         'employment_types' => 'Employment type',
+        'username' => 'Username (@)',
     ],
 
     'placeholders' => [
@@ -67,6 +68,16 @@ return [
         'has_disability' => 'Sensitive information — used only for affirmative-action roles.',
         'expected_salary' => 'Monthly amount in BRL. Private, used only in proposals.',
         'skills' => 'Pick your skills and set your level and years of experience for each.',
+        'username_modal_description' => 'Choose a new unique handle for your community profile.',
+        'username_cooldown_notice' => 'You will only be able to change your @ again after 7 days.',
+        'username_rules_title' => 'Rules for your @',
+        'username_rule_length' => 'Between 2 and 32 characters long (automatically converted to lowercase).',
+        'username_rule_characters' => 'Allowed: letters (a-z), numbers (0-9), dots (.), hyphens (-), and underscores (_).',
+        'username_rule_format' => 'Must start and end with a letter or number (no symbols at edges).',
+        'username_rule_consecutive' => 'No consecutive special characters allowed (e.g. .. or --).',
+        'username_rule_cooldown' => 'Regular members can change once every 7 days (admins are exempt).',
+        'admin_warning_title' => 'Administrator Notice',
+        'admin_warning_body' => 'If your production admin permissions rely on HE4RT_ADMINS_USERNAMES on the server, remember to update the environment variable after changing your handle.',
     ],
 
     'validation' => [
@@ -82,11 +93,13 @@ return [
         'add_skill' => 'Add skill',
         'change_avatar' => 'Change photo',
         'change_cover' => 'Change cover',
+        'change_username' => 'Change @',
         'adjust_avatar' => 'Adjust photo framing',
         'adjust_cover' => 'Adjust framing',
         'save_framing' => 'Save framing',
         'save_avatar' => 'Save photo',
         'save_cover' => 'Save cover',
+        'save_username' => 'Save @',
     ],
 
     'notifications' => [
@@ -94,6 +107,8 @@ return [
         'avatar_updated' => 'Photo updated successfully!',
         'cover_updated' => 'Cover updated successfully!',
         'framing_updated' => 'Framing saved!',
+        'username_updated' => 'Username updated successfully!',
+        'username_error' => 'Could not update @',
         'no_profile' => 'Profile not found for this tenant.',
     ],
 

--- a/app-modules/panel-app/lang/pt_BR/profile.php
+++ b/app-modules/panel-app/lang/pt_BR/profile.php
@@ -47,6 +47,7 @@ return [
         'willing_to_relocate' => 'Disposto a mudar de cidade',
         'has_disability' => 'Pessoa com deficiência (PcD)',
         'employment_types' => 'Tipo de contratação',
+        'username' => 'Nome de usuário (@)',
     ],
 
     'placeholders' => [
@@ -67,6 +68,16 @@ return [
         'expected_salary' => 'Valor mensal em R$. Informação privada, usada apenas em propostas.',
         'skills' => 'Selecione suas skills e informe o nível e os anos de experiência em cada uma.',
         'city' => 'Se sua cidade não estiver na listagem, pesquise.',
+        'username_modal_description' => 'Escolha um novo identificador único para seu perfil na comunidade.',
+        'username_cooldown_notice' => 'Você só poderá alterar seu @ novamente após 7 dias.',
+        'username_rules_title' => 'Regras para o @',
+        'username_rule_length' => 'Entre 2 e 32 caracteres (convertido automaticamente para minúsculo).',
+        'username_rule_characters' => 'Permitido letras (a-z), números (0-9), ponto (.), hífen (-) e sublinhado (_).',
+        'username_rule_format' => 'Deve começar e terminar com letra ou número (sem símbolos nas extremidades).',
+        'username_rule_consecutive' => 'Proibido símbolos especiais consecutivos (ex: .. ou --).',
+        'username_rule_cooldown' => 'Usuários comuns podem alterar apenas a cada 7 dias (administradores têm alteração livre).',
+        'admin_warning_title' => 'Aviso para Administradores',
+        'admin_warning_body' => 'Se suas permissões administrativas em produção dependerem de HE4RT_ADMINS_USERNAMES no servidor, lembre-se de atualizar a variável de ambiente após a alteração.',
     ],
 
     'validation' => [
@@ -82,11 +93,13 @@ return [
         'add_skill' => 'Adicionar skill',
         'change_avatar' => 'Alterar foto',
         'change_cover' => 'Alterar capa',
+        'change_username' => 'Alterar @',
         'adjust_avatar' => 'Ajustar enquadramento da foto',
         'adjust_cover' => 'Ajustar enquadramento',
         'save_framing' => 'Salvar enquadramento',
         'save_avatar' => 'Salvar foto',
         'save_cover' => 'Salvar capa',
+        'save_username' => 'Salvar @',
     ],
 
     'notifications' => [
@@ -94,6 +107,8 @@ return [
         'avatar_updated' => 'Foto atualizada com sucesso!',
         'cover_updated' => 'Capa atualizada com sucesso!',
         'framing_updated' => 'Enquadramento salvo!',
+        'username_updated' => 'Nome de usuário atualizado com sucesso!',
+        'username_error' => 'Não foi possível alterar o @',
         'no_profile' => 'Perfil não encontrado para este tenant.',
     ],
 

--- a/app-modules/panel-app/lang/pt_BR/profile.php
+++ b/app-modules/panel-app/lang/pt_BR/profile.php
@@ -84,6 +84,15 @@ return [
         'image_dimensions' => 'A imagem, depois do recorte, precisa ter no mínimo :min_width × :min_height px. O recomendado é :width × :height px.',
         'image_mimetypes' => 'Formato não suportado. Envie uma imagem :formats.',
         'image_unconverted_max_size' => 'GIF pode ter no máximo :gif_mb MB. Como ele é exibido do jeito que chega, sem compressão, o arquivo pesa em cada visita ao perfil.',
+        'username_already_taken' => 'O @:username já está em uso por outro membro.',
+        'username_invalid_format' => 'Formato de @ inválido: :reason.',
+        'username_cooldown_active' => 'Você só poderá alterar seu @ novamente a partir de :date.',
+        'username_same_as_current' => 'O novo @ deve ser diferente do atual.',
+        'username_reserved' => 'O @:username está reservado para o sistema e não pode ser utilizado.',
+        'username_reason_length' => 'o tamanho deve ter entre 2 e 32 caracteres',
+        'username_reason_characters' => 'apenas letras, números, sublinhado (_), hífen (-) e ponto (.) são permitidos',
+        'username_reason_edges' => 'não pode começar ou terminar com caracteres especiais',
+        'username_reason_consecutive' => 'não pode conter caracteres especiais consecutivos',
     ],
 
     'actions' => [

--- a/app-modules/panel-app/resources/views/components/profile-media-header.blade.php
+++ b/app-modules/panel-app/resources/views/components/profile-media-header.blade.php
@@ -120,8 +120,30 @@
             </div>
         </div>
 
-        {{-- Nickname + Birthdate --}}
-        <div class="grid grid-cols-1 items-start gap-4 sm:grid-cols-2">
+        {{-- Username + Nickname + Birthdate --}}
+        <div class="grid grid-cols-1 items-start gap-4 sm:grid-cols-3">
+            <div>
+                <div class="mb-1 flex items-center justify-between">
+                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                        {{ __('panel-app::profile.fields.username') }}
+                    </label>
+                    <button
+                        type="button"
+                        wire:click="mountAction('editUsername')"
+                        class="cursor-pointer text-xs font-medium text-purple-600 hover:text-purple-700 dark:text-purple-400 dark:hover:text-purple-300 transition-colors"
+                    >
+                        {{ __('panel-app::profile.actions.change_username') }}
+                    </button>
+                </div>
+                <div
+                    wire:click="mountAction('editUsername')"
+                    class="fi-input flex cursor-pointer items-center justify-between rounded-lg border border-gray-300 bg-gray-50 px-3 py-2 text-sm text-gray-700 shadow-sm transition-colors hover:border-purple-500 dark:border-white/10 dark:bg-white/5 dark:text-gray-300 dark:hover:border-purple-500"
+                    title="{{ __('panel-app::profile.actions.change_username') }}"
+                >
+                    <span class="font-medium text-gray-900 dark:text-white">{{ '@' }}{{ auth()->user()->username }}</span>
+                    <x-heroicon-m-pencil-square class="h-4 w-4 text-gray-400 dark:text-gray-500" />
+                </div>
+            </div>
             <div>
                 <label for="nickname" class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
                     {{ __('panel-app::profile.fields.nickname') }}

--- a/app-modules/panel-app/resources/views/components/profile-preview-card.blade.php
+++ b/app-modules/panel-app/resources/views/components/profile-preview-card.blade.php
@@ -139,7 +139,17 @@
                     </span>
                 @endif
             </div>
-            <p class="text-sm text-gray-500 dark:text-gray-400">{{ '@' }}{{ $username }}</p>
+            <div class="flex items-center gap-1.5">
+                <p class="text-sm text-gray-500 dark:text-gray-400">{{ '@' }}{{ $username }}</p>
+                <button
+                    type="button"
+                    wire:click="mountAction('editUsername')"
+                    class="inline-flex cursor-pointer items-center text-gray-400 hover:text-purple-600 dark:text-gray-500 dark:hover:text-purple-400 transition-colors"
+                    title="{{ __('panel-app::profile.actions.change_username') }}"
+                >
+                    <x-heroicon-m-pencil-square class="h-3.5 w-3.5" />
+                </button>
+            </div>
             @if ($location)
                 <p class="mt-0.5 flex items-center gap-1 text-xs text-gray-400 dark:text-gray-500">
                     <x-heroicon-m-map-pin class="h-3 w-3" />

--- a/app-modules/panel-app/resources/views/components/username-admin-warning.blade.php
+++ b/app-modules/panel-app/resources/views/components/username-admin-warning.blade.php
@@ -1,0 +1,13 @@
+<div class="flex items-start gap-3 rounded-xl border border-amber-500/20 bg-amber-500/5 p-4 text-xs dark:border-amber-500/20 dark:bg-amber-500/[0.04]" style="padding: 1rem;">
+    <div class="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-lg bg-amber-500/15 text-amber-600 dark:bg-amber-400/15 dark:text-amber-400">
+        <x-filament::icon icon="heroicon-m-shield-exclamation" class="size-4" :size="\Filament\Support\Enums\IconSize::Small" />
+    </div>
+    <div class="flex-1 space-y-1 leading-relaxed">
+        <p class="font-semibold text-zinc-900 dark:text-zinc-100">
+            {{ __('panel-app::profile.hints.admin_warning_title') }}
+        </p>
+        <p class="text-zinc-600 dark:text-zinc-300">
+            {{ __('panel-app::profile.hints.admin_warning_body') }}
+        </p>
+    </div>
+</div>

--- a/app-modules/panel-app/resources/views/components/username-rules.blade.php
+++ b/app-modules/panel-app/resources/views/components/username-rules.blade.php
@@ -1,0 +1,28 @@
+<div class="rounded-xl border border-zinc-200/80 bg-zinc-50/70 p-4 text-xs dark:border-white/10 dark:bg-white/[0.03]" style="padding: 1rem;">
+    <div class="mb-2.5 flex items-center gap-2 font-semibold text-zinc-900 dark:text-zinc-100">
+        <x-filament::icon icon="heroicon-m-information-circle" class="size-4 text-purple-600 dark:text-purple-400" :size="\Filament\Support\Enums\IconSize::Small" />
+        <span>{{ __('panel-app::profile.hints.username_rules_title') }}</span>
+    </div>
+    <ul class="space-y-2 text-zinc-600 dark:text-zinc-400">
+        <li class="flex items-start gap-2">
+            <x-filament::icon icon="heroicon-m-check" class="mt-0.5 size-4 shrink-0 text-purple-600 dark:text-purple-400" :size="\Filament\Support\Enums\IconSize::Small" />
+            <span>{{ __('panel-app::profile.hints.username_rule_length') }}</span>
+        </li>
+        <li class="flex items-start gap-2">
+            <x-filament::icon icon="heroicon-m-check" class="mt-0.5 size-4 shrink-0 text-purple-600 dark:text-purple-400" :size="\Filament\Support\Enums\IconSize::Small" />
+            <span>{{ __('panel-app::profile.hints.username_rule_characters') }}</span>
+        </li>
+        <li class="flex items-start gap-2">
+            <x-filament::icon icon="heroicon-m-check" class="mt-0.5 size-4 shrink-0 text-purple-600 dark:text-purple-400" :size="\Filament\Support\Enums\IconSize::Small" />
+            <span>{{ __('panel-app::profile.hints.username_rule_format') }}</span>
+        </li>
+        <li class="flex items-start gap-2">
+            <x-filament::icon icon="heroicon-m-check" class="mt-0.5 size-4 shrink-0 text-purple-600 dark:text-purple-400" :size="\Filament\Support\Enums\IconSize::Small" />
+            <span>{{ __('panel-app::profile.hints.username_rule_consecutive') }}</span>
+        </li>
+        <li class="flex items-start gap-2">
+            <x-filament::icon icon="heroicon-m-clock" class="mt-0.5 size-4 shrink-0 text-purple-600 dark:text-purple-400" :size="\Filament\Support\Enums\IconSize::Small" />
+            <span>{{ __('panel-app::profile.hints.username_rule_cooldown') }}</span>
+        </li>
+    </ul>
+</div>

--- a/app-modules/panel-app/src/Pages/ProfilePage.php
+++ b/app-modules/panel-app/src/Pages/ProfilePage.php
@@ -7,9 +7,11 @@ namespace He4rt\PanelApp\Pages;
 use App\Geo\Support\GeoLocation;
 use App\Support\UploadLimit;
 use BackedEnum;
+use Closure;
 use Filament\Actions\Action;
 use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\FileUpload;
+use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
@@ -28,8 +30,11 @@ use Filament\Schemas\JsContent;
 use Filament\Schemas\Schema;
 use Filament\Support\Enums\Width;
 use He4rt\Gamification\Character\Models\Character;
+use He4rt\Identity\User\Actions\UpdateUsername;
 use He4rt\Identity\User\Enums\ProfileImage;
+use He4rt\Identity\User\Exceptions\UsernameException;
 use He4rt\Identity\User\Models\User;
+use He4rt\Identity\User\ValueObjects\UsernameValidator;
 use He4rt\PanelApp\Rules\UnconvertedImageSize;
 use He4rt\Profile\Actions\SyncProfileSkills;
 use He4rt\Profile\Actions\ToggleAvailability;
@@ -44,6 +49,7 @@ use He4rt\Profile\Enums\StartAvailability;
 use He4rt\Profile\Models\Profile;
 use He4rt\Profile\Models\Skill;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
 use Livewire\Attributes\Computed;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
@@ -503,6 +509,79 @@ class ProfilePage extends Page
     public function adjustCoverAction(): Action
     {
         return $this->imageFramingAction('adjustCover', ProfileImage::Cover);
+    }
+
+    public function editUsernameAction(): Action
+    {
+        return Action::make('editUsername')
+            ->label(__('panel-app::profile.actions.change_username'))
+            ->modalHeading(__('panel-app::profile.actions.change_username'))
+            ->modalDescription(__('panel-app::profile.hints.username_modal_description'))
+            ->modalSubmitActionLabel(__('panel-app::profile.actions.save_username'))
+            ->modalSubmitAction(fn (Action $action) => $action->color('primary'))
+            ->modalWidth(Width::Medium)
+            ->schema([
+                Placeholder::make('admin_warning')
+                    ->hiddenLabel()
+                    ->visible(fn (): bool => auth()->user()?->isAdmin() ?? false)
+                    ->content(new HtmlString(view('panel-app::components.username-admin-warning')->render())),
+                TextInput::make('username')
+                    ->label(__('panel-app::profile.fields.username'))
+                    ->prefix('@')
+                    ->default(fn (): string => auth()->user()->username)
+                    ->required()
+                    ->rules([
+                        fn (): Closure => function (string $attribute, mixed $value, Closure $fail): void {
+                            if (!is_string($value)) {
+                                $fail(__('panel-app::profile.hints.username_rules_title'));
+
+                                return;
+                            }
+
+                            /** @var User|null $user */
+                            $user = auth()->user();
+
+                            try {
+                                UsernameValidator::validate($value, $user);
+                            } catch (UsernameException $usernameException) {
+                                $fail($usernameException->getMessage());
+                            }
+                        },
+                    ]),
+                Placeholder::make('username_rules')
+                    ->hiddenLabel()
+                    ->content(new HtmlString(view('panel-app::components.username-rules')->render())),
+            ])
+            ->action(function (array $data, Action $action): void {
+                /** @var User $user */
+                $user = auth()->user();
+
+                $rawUsername = $data['username'] ?? '';
+                $newUsername = is_string($rawUsername) ? $rawUsername : '';
+
+                try {
+                    $updated = resolve(UpdateUsername::class)->handle($user, $newUsername);
+                    auth()->setUser($updated);
+                    filament()->auth()->setUser($updated);
+                } catch (UsernameException $usernameException) {
+                    Notification::make()
+                        ->danger()
+                        ->title(__('panel-app::profile.notifications.username_error'))
+                        ->body($usernameException->getMessage())
+                        ->send();
+
+                    $this->addError('mountedActionsData.0.username', $usernameException->getMessage());
+                    $this->addError('data.username', $usernameException->getMessage());
+                    $this->addError('username', $usernameException->getMessage());
+
+                    $action->halt();
+                }
+
+                Notification::make()
+                    ->success()
+                    ->title(__('panel-app::profile.notifications.username_updated'))
+                    ->send();
+            });
     }
 
     public function getRecord(): Profile

--- a/app-modules/panel-app/src/Pages/ProfilePage.php
+++ b/app-modules/panel-app/src/Pages/ProfilePage.php
@@ -544,7 +544,7 @@ class ProfilePage extends Page
                             try {
                                 UsernameValidator::validate($value, $user);
                             } catch (UsernameException $usernameException) {
-                                $fail($usernameException->getMessage());
+                                $fail($usernameException->getLocalizedMessage());
                             }
                         },
                     ]),
@@ -564,15 +564,17 @@ class ProfilePage extends Page
                     auth()->setUser($updated);
                     filament()->auth()->setUser($updated);
                 } catch (UsernameException $usernameException) {
+                    $errorMessage = $usernameException->getLocalizedMessage();
+
                     Notification::make()
                         ->danger()
                         ->title(__('panel-app::profile.notifications.username_error'))
-                        ->body($usernameException->getMessage())
+                        ->body($errorMessage)
                         ->send();
 
-                    $this->addError('mountedActionsData.0.username', $usernameException->getMessage());
-                    $this->addError('data.username', $usernameException->getMessage());
-                    $this->addError('username', $usernameException->getMessage());
+                    $this->addError('mountedActionsData.0.username', $errorMessage);
+                    $this->addError('data.username', $errorMessage);
+                    $this->addError('username', $errorMessage);
 
                     $action->halt();
                 }

--- a/app-modules/panel-app/tests/Feature/ProfilePageTest.php
+++ b/app-modules/panel-app/tests/Feature/ProfilePageTest.php
@@ -382,3 +382,19 @@ test('profile page shows validation error when username has invalid format', fun
     'too short' => 'a',
     'reserved word' => 'admin',
 ]);
+
+test('profile page localizes username error in english', function (): void {
+    app()->setLocale('en');
+
+    $component = livewire(ProfilePage::class)
+        ->callAction('editUsername', [
+            'username' => 'invalid!',
+        ])
+        ->assertHasActionErrors(['username']);
+
+    expect($component->errors()->all())->toContain(
+        __('panel-app::profile.validation.username_invalid_format', [
+            'reason' => __('panel-app::profile.validation.username_reason_characters'),
+        ])
+    );
+});

--- a/app-modules/panel-app/tests/Feature/ProfilePageTest.php
+++ b/app-modules/panel-app/tests/Feature/ProfilePageTest.php
@@ -345,3 +345,40 @@ test('profile page uploads cover through action modal', function (): void {
     expect($media)->not->toBeNull()
         ->and($media?->collection_name)->toBe('cover');
 });
+
+test('profile page allows updating username through editUsername action modal', function (): void {
+    livewire(ProfilePage::class)
+        ->callAction('editUsername', [
+            'username' => 'new_cool_handle',
+        ])
+        ->assertHasNoActionErrors()
+        ->assertNotified(__('panel-app::profile.notifications.username_updated'))
+        ->assertSee('@new_cool_handle');
+
+    expect($this->user->fresh()->username)->toBe('new_cool_handle');
+});
+
+test('profile page halts action and sends danger notification on username error', function (): void {
+    livewire(ProfilePage::class)
+        ->callAction('editUsername', [
+            'username' => $this->user->username,
+        ])
+        ->assertActionHalted('editUsername')
+        ->assertNotified()
+        ->assertHasErrors(['mountedActionsData.0.username']);
+});
+
+test('profile page shows validation error when username has invalid format', function (string $invalidUsername): void {
+    livewire(ProfilePage::class)
+        ->callAction('editUsername', [
+            'username' => $invalidUsername,
+        ])
+        ->assertHasActionErrors(['username']);
+})->with([
+    'contains special characters' => 'teste!',
+    'starts with special character' => '_teste',
+    'ends with special character' => 'teste-',
+    'consecutive special characters' => 'teste..teste',
+    'too short' => 'a',
+    'reserved word' => 'admin',
+]);

--- a/config/he4rt.php
+++ b/config/he4rt.php
@@ -10,6 +10,8 @@ return [
         'minimum_level_for_retro' => env('HE4RT_SEASON_MIN_LEVEL', 3),
     ],
     'server_key' => env('HE4RT_BOT_SECRET', 'he4rt'),
+    'admins' => env('HE4RT_ADMINS_USERNAMES', ''),
+    'username_cooldown_days' => (int) env('HE4RT_USERNAME_COOLDOWN_DAYS', 7),
 
     /*
      * Quando a He4rt começou. Data única para qualquer lugar que precise contar a


### PR DESCRIPTION
## Contexto

- **Qual é o problema ou necessidade?**
  Atualmente, o `@` (username) do usuário é definido e vinculado automaticamente no momento do primeiro login via provedor social (ex.: Discord). O usuário não tinha autonomia para alterar seu identificador dentro do painel caso desejasse personalizá-lo. Além disso, logins sociais subsequentes ou processos de ETL/sincronização do Discord podiam sobrescrever o username caso não houvesse marcação explícita de definição manual.

- **Como esta alteração resolve o problema?**
  Implementa o fluxo completo de alteração de `@` (username) no painel do usuário (`panel-app`) apoiado por regras de domínio robustas no módulo `identity`:
  1. Criação dos campos de controle `username_manually_set_at` e `username_updated_at` na tabela `users`.
  2. Implementação da action `UpdateUsername` com aplicação de cooldown de 7 dias (com isenção para administradores).
  3. Validador estrito `UsernameValidator` com **regras de formatação baseadas no padrão de usernames do Discord**:
     - De 2 a 32 caracteres;
     - Apenas letras minúsculas (`a-z`), números (`0-9`), ponto (`.`), hífen (`-`) e sublinhado (`_`);
     - Início e fim obrigatórios com caractere alfanumérico (proibidos símbolos nas extremidades);
     - Proibição de caracteres especiais consecutivos (`..`, `--`, `__`);
     - Bloqueio de palavras reservadas do sistema e usernames de administradores.
  4. Proteção nas actions de login social (`EnrichUserOnFirstLogin`, `MergeAccountsAction`) e pipelines do Discord (`ImportDiscordProfileAction`, `MergeDuplicateDiscordUserAction`) para não sobrescrever `@` definidos manualmente.
  5. Modal interativo no Filament com prefixo fixo `@`, card explicativo de regras (destacando o padrão compatível com o Discord), aviso para administradores, validação inline imediata com destaque e mensagens de erro amigáveis em português.

- **Qual é o impacto esperado para o usuário ou sistema?**
  Os usuários ganham total autonomia para personalizar sua identidade pública na plataforma seguindo as mesmas convenções familiares do Discord, com feedback visual imediato e orientações claras sobre as regras. A integridade e segurança do sistema são preservadas via unicidade *case-insensitive*, proteção de palavras reservadas e respeito às regras de acesso administrativo.

### Alterações

#### `app-modules/identity`
- **Migration** `2026_09_02_195006_add_username_fields_to_users_table.php`: adiciona colunas `username_manually_set_at` e `username_updated_at` (`timestampTz`).
- **Model `User`**: adiciona casts `datetime`, anotações PHPDoc `@property` e método `isAdmin()` com suporte à role `super-admin` e checagem de administradores do sistema via config (`he4rt.admins`).
- **Exceptions & Validators**:
  - `UsernameException`: exceções com mensagens amigáveis em português para cada cenário (formato inválido, indisponível, cooldown ativo com data/hora em timezone local, mesmo `@` atual e palavras reservadas).
  - `UsernameValidator`: regras baseadas nas diretrizes de username do Discord (2–32 caracteres, regex `^[a-zA-Z0-9._-]+$`, proibição de símbolos nas pontas e consecutivos) e normalização para minúsculo (`mb_strtolower`).
- **Actions**:
  - `UpdateUsername`: validação, verificação de unicidade, salvamento atômico e cooldown de 7 dias com isenção para admins.
  - `EnrichUserOnFirstLogin` & `MergeAccountsAction`: respeitam `username_manually_set_at` para evitar substituições automáticas.
- **Testes**:
  - `UpdateUsernameTest`: 30 testes unitários/feature cobrindo validações (regras do Discord), unicidade, cooldown, isenção para admins e palavras reservadas.
  - Atualização dos testes de enriquecimento e mescla de contas.

#### `app-modules/integration-discord`
- `ImportDiscordProfileAction` & `MergeDuplicateDiscordUserAction`: adicionada checagem para nunca sobrescrever usernames onde `username_manually_set_at !== null`.
- `MergeDuplicateDiscordProfilesCommand` & testes do ETL atualizados para garantir compatibilidade.

#### `app-modules/panel-app`
- **Page `ProfilePage`**:
  - Implementada a action `editUsernameAction()` com modal Filament contendo prefixo fixo `@`.
  - Validação inline via `UsernameValidator` exibindo erros instantâneos no formulário com destaque visual em vermelho.
  - Captura de exceções de domínio no salvamento repassando erros para o Livewire ErrorBag (`$this->addError(...)`).
  - Sincronização dos guards de autenticação (`auth()->setUser()` e `filament()->auth()->setUser()`).
- **Componentes Blade**:
  - `username-rules.blade.php`: card de diretrizes com ícones e checklist de formato (especificando as regras baseadas no Discord) e cooldown.
  - `username-admin-warning.blade.php`: aviso visual com badge e bordas sutis alertando administradores sobre a vinculação de privilégios ao `@`.
  - `profile-media-header.blade.php` & `profile-preview-card.blade.php`: botões e inputs atualizados para acionar o modal de edição de `@`.
- **Traduções**: chaves adicionadas em `lang/pt_BR/profile.php` e `lang/en/profile.php`.
- **Testes**: `ProfilePageTest` com testes cobrindo todo o fluxo da action, datasets de validação de formato e renderização de componentes.

---

## Plano de Testes

- [x] Executar testes do módulo Identity: `vendor/bin/pest app-modules/identity/tests/Feature/User/UpdateUsernameTest.php`
- [x] Executar testes do módulo Panel: `vendor/bin/pest app-modules/panel-app/tests/Feature/ProfilePageTest.php --filter="username"`
- [x] Executar testes de integração/ETL: `vendor/bin/pest app-modules/integration-discord/tests/Feature/ETL/`
- [x] Executar análise estática do PHPStan: `vendor/bin/phpstan analyse app-modules/identity/src/User app-modules/panel-app/src/Pages/ProfilePage.php --memory-limit=2G`
- [x] Executar validação de formatação de código: `vendor/bin/pint --test`
- [x] Executar validação do Rector: `vendor/bin/rector process --dry-run`
- [x] Validar no navegador:
  - [x] Abertura do modal de alteração de username ao clicar no botão de edição de `@`.
  - [x] Exibição das regras do Discord e aviso de administrador (quando aplicável).
  - [x] Feedback inline em vermelho ao digitar caracteres especiais inválidos, símbolos nas pontas ou repetições consecutivas.
  - [x] Alteração com sucesso de um `@` válido e reflexo imediato no preview card e header.
  - [x] Bloqueio por cooldown de 7 dias para usuários regulares após alteração.
  - [x] Permissão contínua de alteração para usuários com permissão de administrador.

## Evidência
<img width="390" height="134" alt="image" src="https://github.com/user-attachments/assets/246fc13c-6716-4965-a6cc-93f364b45a6f" />

<img width="468" height="527" alt="image" src="https://github.com/user-attachments/assets/518102e5-c0df-43ab-8a66-1f7e504f39da" />

<img width="468" height="582" alt="image" src="https://github.com/user-attachments/assets/372ff302-8885-42dd-926e-2482c4af4e46" />

---
## Issues Relacionadas

Closes #502
