### PR TITLE
feat(activity): model UserReaction + factory e relação no Timeline (#542)

### DIFF
--- a/app-modules/activity/database/factories/ReactionFactory.php
+++ b/app-modules/activity/database/factories/ReactionFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Activity\Database\Factories;
+
+use He4rt\Activity\Reaction\Enums\TimelineReaction;
+use He4rt\Activity\Reaction\Models\UserReaction;
+use He4rt\Activity\Timeline\Timeline;
+use He4rt\Identity\User\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/** @extends Factory<UserReaction> */
+final class ReactionFactory extends Factory
+{
+    protected $model = UserReaction::class;
+
+    /** @return array<string, mixed> */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'timeline_id' => Timeline::factory(),
+            'reaction' => fake()->randomElement(TimelineReaction::cases()),
+        ];
+    }
+}

--- a/app-modules/activity/src/Reaction/Models/UserReaction.php
+++ b/app-modules/activity/src/Reaction/Models/UserReaction.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Activity\Reaction\Models;
+
+use Carbon\CarbonInterface;
+use He4rt\Activity\Database\Factories\ReactionFactory;
+use He4rt\Activity\Reaction\Enums\TimelineReaction;
+use He4rt\Activity\Timeline\Timeline;
+use He4rt\Identity\User\Models\User;
+use Illuminate\Database\Eloquent\Attributes\Table;
+use Illuminate\Database\Eloquent\Attributes\UseFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property string $id
+ * @property string $user_id
+ * @property string $timeline_id
+ * @property TimelineReaction $reaction
+ * @property CarbonInterface|null $created_at
+ * @property CarbonInterface|null $updated_at
+ * @property-read User $user
+ * @property-read Timeline $timeline
+ */
+#[UseFactory(factoryClass: ReactionFactory::class)]
+#[Table(name: 'activity_user_reactions')]
+final class UserReaction extends Model
+{
+    /** @use HasFactory<ReactionFactory> */
+    use HasFactory;
+    use HasUuids;
+
+    /** @return BelongsTo<User, $this> */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /** @return BelongsTo<Timeline, $this> */
+    public function timeline(): BelongsTo
+    {
+        return $this->belongsTo(Timeline::class);
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'reaction' => TimelineReaction::class,
+        ];
+    }
+}

--- a/app-modules/activity/src/Timeline/Timeline.php
+++ b/app-modules/activity/src/Timeline/Timeline.php
@@ -7,6 +7,7 @@ namespace He4rt\Activity\Timeline;
 use Carbon\CarbonInterface;
 use He4rt\Activity\Database\Factories\TimelineFactory;
 use He4rt\Activity\Reaction\Concerns\HasReactions;
+use He4rt\Activity\Reaction\Models\UserReaction;
 use He4rt\Identity\User\Models\User;
 use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
@@ -65,6 +66,12 @@ final class Timeline extends Model
     public function children(): HasMany
     {
         return $this->hasMany(self::class, 'parent_id');
+    }
+
+    /** @return HasMany<UserReaction, $this> */
+    public function userReactions(): HasMany
+    {
+        return $this->hasMany(UserReaction::class);
     }
 
     protected static function newFactory(): TimelineFactory

--- a/app-modules/activity/tests/Unit/Reaction/UserReactionTest.php
+++ b/app-modules/activity/tests/Unit/Reaction/UserReactionTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Activity\Reaction\Enums\TimelineReaction;
+use He4rt\Activity\Reaction\Models\UserReaction;
+use He4rt\Activity\Timeline\Timeline;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('cria uma linha válida via factory com reaction como enum', function (): void {
+    UserReaction::factory()->create();
+
+    $reaction = UserReaction::query()->first();
+
+    expect($reaction)->not->toBeNull()
+        ->and($reaction->reaction)->toBeInstanceOf(TimelineReaction::class);
+
+    $this->assertDatabaseCount('activity_user_reactions', 1);
+});
+
+it('devolve as reações do post pela relação userReactions', function (): void {
+    $timeline = Timeline::factory()->create();
+
+    UserReaction::factory()
+        ->count(3)
+        ->for($timeline)
+        ->create();
+
+    expect($timeline->userReactions)->toHaveCount(3);
+});


### PR DESCRIPTION
## Contexto

A timeline web precisa de acesso Eloquent à tabela `activity_user_reactions`, separado do agregado `Reaction` do Discord.

Este PR adiciona o model `UserReaction`, a factory e a relação `userReactions()` no `Timeline`, para as fatias seguintes (Action `ReactWith`, summary, UI) terem uma entidade persistível.

### Alterações

- Model `UserReaction` com `HasUuids`, `#[Table('activity_user_reactions')]`, `@property` alinhado ao schema, cast `reaction => TimelineReaction` e relações `user()` / `timeline()`
- Factory `ReactionFactory` (`user_id`, `timeline_id`, `reaction` aleatória do enum)
- Relação `userReactions(): HasMany` em `Timeline` (único ponto tocado nesse arquivo)
- Testes unitários: create via factory + 3 reações de usuários diferentes num post

---

## Plano de Testes

- [ ] Executar `make check` (ou `composer check`)
- [ ] Executar `php vendor/bin/pest --compact app-modules/activity/tests/Unit/Reaction/UserReactionTest.php`
- [ ] Confirmar que `UserReaction::factory()->create()` grava em `activity_user_reactions`
- [ ] Confirmar que `UserReaction::first()->reaction` é um caso de `TimelineReaction`
- [ ] Confirmar que `$timeline->userReactions` devolve as 3 linhas do post

---

## Evidências

Sem impacto visual (só domínio / persistência).

---

## Issues Relacionadas

Closes #542
Related to #539